### PR TITLE
fix: Correct Claude Code Review workflow plugin configuration

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,10 +36,17 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
+          plugin_marketplaces: 'anthropics/claude-code'
+          plugins: 'code-review'
           allowed_bots: 'codefactor-io[bot]'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: |
+            Please review this PR and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Security concerns
+            - CLAUDE.md compliance
+
+            Post your review as a comment on this pull request.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Problem Summary

The Claude Code Review workflow (`.github/workflows/claude-code-review.yml`) was failing with SDK crashes due to incorrect plugin configuration syntax introduced in commit `ebf913f3` on Feb 4, 2026.

### Current Broken Configuration (Before):
```yaml
plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
plugins: 'code-review@claude-code-plugins'
prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
```

### Root Cause:
1. Plugin marketplace format was incorrect: used full git URL instead of GitHub short format
2. Plugin reference format was wrong: `code-review@claude-code-plugins` instead of `code-review`
3. Prompt used CLI command syntax instead of natural language instructions

## Solution

### Fixed Configuration (After):
```yaml
plugin_marketplaces: 'anthropics/claude-code'
plugins: 'code-review'
prompt: |
  Please review this PR and provide feedback on:
  - Code quality and best practices
  - Potential bugs or issues
  - Security concerns
  - CLAUDE.md compliance

  Post your review as a comment on this pull request.
```

### Key Changes:
- ✅ Changed `plugin_marketplaces` to GitHub short format: `anthropics/claude-code`
- ✅ Changed `plugins` to simple plugin name: `code-review`
- ✅ Replaced CLI command syntax with descriptive natural language instructions
- ✅ Kept existing `allowed_bots: 'codefactor-io[bot]'` configuration

## Expected Behavior

After this fix:
- ✅ GitHub Actions workflow should complete without exit code 1
- ✅ No SDK crash errors in logs
- ✅ Claude successfully posts review comments on PRs
- ✅ All PR triggers work: `opened`, `synchronize`, `ready_for_review`, `reopened`

## Testing

This fix should be verified by:
1. Merging this PR
2. Creating a test PR to trigger the workflow
3. Confirming the Claude Code Review action runs successfully
4. Verifying review comments appear on the test PR

## References

- [Claude Code Plugins Documentation](https://code.claude.com/docs/en/plugins)
- [Discover and install prebuilt plugins](https://code.claude.com/docs/en/discover-plugins)
- [Code-Review Plugin README](https://github.com/anthropics/claude-code/blob/main/plugins/code-review/README.md)
- [Claude Code Action Usage](https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md)

## Files Modified

- `.github/workflows/claude-code-review.yml` (lines 39-42)

Fixes the SDK crash and restores functionality to the Claude Code Review workflow.

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/brightdigit/MistKit/236)
<!-- GitContextEnd -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the automated code review process with improved assessment criteria, now evaluating code quality, bugs, security, and compliance standards more thoroughly on pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->