### PR TITLE
MistDemo: bump withTimeout test budget for iOS-sim CI flake

### DIFF
--- a/Examples/MistDemo/Tests/MistDemoTests/Utilities/AsyncHelpersTests.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Utilities/AsyncHelpersTests.swift
@@ -69,7 +69,11 @@ struct AsyncHelpersTests {
     )
   )
   func returnsAsyncValue() async throws {
-    let result = try await withTimeout(seconds: 5.0) {
+    // The 30 s budget (vs. the operation's 50 ms inner sleep) is intentionally
+    // generous: under iOS-simulator CI load the operation task's single long
+    // Task.sleep can be scheduled behind the polling timeout task's many short
+    // sleeps, so a tighter budget produced flaky timeouts (#283).
+    let result = try await withTimeout(seconds: 30.0) {
       try await Task.sleep(nanoseconds: 50_000_000)  // 50ms
       return 42
     }


### PR DESCRIPTION
## Summary

`Test "withTimeout returns value from async operation"` flakes on the iOS-simulator CI runner (Xcode 26.4 / iPhone 17 Pro). Passes consistently on the macOS host (0.050 s); times out on the simulator inside the 5 s budget.

## Root cause

`withTimeout` (Examples/MistDemo/Sources/MistDemoKit/Utilities/AsyncHelpers.swift:49) schedules two racing tasks:

- Operation: a single `Task.sleep(50ms)` then return.
- Timeout: a loop of `Task.sleep(10ms)` until a 5 s `ContinuousClock` deadline.

On the iOS simulator under CI load the cooperative scheduler can starve the operation's single long sleep behind the timeout task's many short wake-ups, flipping the race so the timeout fires first.

## Fix

Test-only change: bump the budget from 5 s to 30 s for the "returns value from async operation" case. Operation's inner sleep is still 50 ms; assertion is unchanged. No production code touched.

If we want a sturdier fix later, the helper could replace the polling loop with a single `Task.sleep(seconds)` — that's a separate optimisation.

## Test plan

- [x] \`swift test --filter AsyncHelpersTests\` (macOS host) — all 17 tests pass
- [ ] iOS-simulator CI matrix re-run on this PR is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/brightdigit/MistKit/284)
<!-- GitContextEnd -->