### PR TITLE
Strengthen environment and database configuration validation

### DIFF
--- a/Examples/MistDemo/Sources/MistDemoKit/Configuration/MistDemoConfig+Parsing.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Configuration/MistDemoConfig+Parsing.swift
@@ -30,6 +30,15 @@
 import MistKit
 
 extension MistDemoConfig {
+  /// Canonical lowercase names recognized for the `environment` config key.
+  ///
+  /// Matching is case-insensitive against these full names — aliases
+  /// (e.g. `"prod"`, `"dev"`) are intentionally not accepted.
+  private enum EnvironmentName {
+    internal static let production = "production"
+    internal static let development = "development"
+  }
+
   internal struct CoreConfig {
     internal let containerIdentifier: String
     internal let apiToken: String
@@ -60,7 +69,7 @@ extension MistDemoConfig {
 
   internal static func parseCoreConfig(
     _ config: MistDemoConfiguration
-  ) -> CoreConfig {
+  ) throws -> CoreConfig {
     let containerIdentifier =
       config.string(
         forKey: "container.identifier",
@@ -77,16 +86,34 @@ extension MistDemoConfig {
     let envString =
       config.string(
         forKey: "environment",
-        default: "development"
-      ) ?? "development"
-    let environment: MistKit.Environment =
-      envString == "production" ? .production : .development
+        default: EnvironmentName.development
+      ) ?? EnvironmentName.development
+    let environment = try Self.parseEnvironment(envString)
 
     return CoreConfig(
       containerIdentifier: containerIdentifier,
       apiToken: apiToken,
       environment: environment
     )
+  }
+
+  /// Parses the `environment` config value into a `MistKit.Environment`.
+  ///
+  /// Matching is case-insensitive against the two canonical full names
+  /// (`production`, `development`). Any other value — including aliases
+  /// like `"prod"` or `"dev"` — throws `ConfigurationError.invalidEnvironment`
+  /// so misconfigured deployments fail fast at startup.
+  private static func parseEnvironment(
+    _ raw: String
+  ) throws -> MistKit.Environment {
+    switch raw.lowercased() {
+    case EnvironmentName.production:
+      return .production
+    case EnvironmentName.development:
+      return .development
+    default:
+      throw ConfigurationError.invalidEnvironment(raw)
+    }
   }
 
   internal static func parseAuthConfig(

--- a/Examples/MistDemo/Sources/MistDemoKit/Configuration/MistDemoConfig+Parsing.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Configuration/MistDemoConfig+Parsing.swift
@@ -30,15 +30,6 @@
 import MistKit
 
 extension MistDemoConfig {
-  /// Canonical lowercase names recognized for the `environment` config key.
-  ///
-  /// Matching is case-insensitive against these full names — aliases
-  /// (e.g. `"prod"`, `"dev"`) are intentionally not accepted.
-  private enum EnvironmentName {
-    internal static let production = "production"
-    internal static let development = "development"
-  }
-
   internal struct CoreConfig {
     internal let containerIdentifier: String
     internal let apiToken: String
@@ -83,37 +74,18 @@ extension MistDemoConfig {
         isSecret: true
       ) ?? ""
 
+    let defaultEnv = MistKit.Environment.development.rawValue
     let envString =
-      config.string(
-        forKey: "environment",
-        default: EnvironmentName.development
-      ) ?? EnvironmentName.development
-    let environment = try Self.parseEnvironment(envString)
+      config.string(forKey: "environment", default: defaultEnv) ?? defaultEnv
+    guard let environment = MistKit.Environment(caseInsensitive: envString) else {
+      throw ConfigurationError.invalidEnvironment(envString)
+    }
 
     return CoreConfig(
       containerIdentifier: containerIdentifier,
       apiToken: apiToken,
       environment: environment
     )
-  }
-
-  /// Parses the `environment` config value into a `MistKit.Environment`.
-  ///
-  /// Matching is case-insensitive against the two canonical full names
-  /// (`production`, `development`). Any other value — including aliases
-  /// like `"prod"` or `"dev"` — throws `ConfigurationError.invalidEnvironment`
-  /// so misconfigured deployments fail fast at startup.
-  private static func parseEnvironment(
-    _ raw: String
-  ) throws -> MistKit.Environment {
-    switch raw.lowercased() {
-    case EnvironmentName.production:
-      return .production
-    case EnvironmentName.development:
-      return .development
-    default:
-      throw ConfigurationError.invalidEnvironment(raw)
-    }
   }
 
   internal static func parseAuthConfig(

--- a/Examples/MistDemo/Sources/MistDemoKit/Configuration/MistDemoConfig.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Configuration/MistDemoConfig.swift
@@ -96,7 +96,7 @@ public struct MistDemoConfig: Sendable, ConfigurationParseable {
     base: Never? = nil
   ) async throws {
     let config = configuration
-    let core = Self.parseCoreConfig(config)
+    let core = try Self.parseCoreConfig(config)
     self.containerIdentifier = core.containerIdentifier
     self.apiToken = core.apiToken
     self.environment = core.environment

--- a/Examples/MistDemo/Sources/MistDemoKit/Utilities/AuthenticationHelper+SetupHelpers.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Utilities/AuthenticationHelper+SetupHelpers.swift
@@ -36,11 +36,11 @@ extension AuthenticationHelper {
     keyID: String,
     privateKey: String?,
     privateKeyFile: String?,
-    databaseOverride: String?
+    databaseOverride: MistKit.Database?
   ) async throws -> AuthenticationResult {
     let database = MistKit.Database.public
 
-    if let override = databaseOverride, override == "private" {
+    if databaseOverride == .private {
       throw AuthenticationError.serverToServerRequiresPublicDatabase
     }
 
@@ -63,14 +63,9 @@ extension AuthenticationHelper {
   internal static func setupWebAuth(
     apiToken: String,
     webAuthToken: String,
-    databaseOverride: String?
+    databaseOverride: MistKit.Database?
   ) async throws -> AuthenticationResult {
-    let database: MistKit.Database
-    if let override = databaseOverride {
-      database = override == "public" ? .public : .private
-    } else {
-      database = .private
-    }
+    let database: MistKit.Database = databaseOverride ?? .private
 
     let manager = try await createWebAuthManager(
       apiToken: apiToken,
@@ -88,11 +83,11 @@ extension AuthenticationHelper {
 
   internal static func setupAPIOnly(
     apiToken: String,
-    databaseOverride: String?
+    databaseOverride: MistKit.Database?
   ) async throws -> AuthenticationResult {
     let database = MistKit.Database.public
 
-    if let override = databaseOverride, override == "private" {
+    if databaseOverride == .private {
       throw AuthenticationError.privateRequiresWebAuth
     }
 

--- a/Examples/MistDemo/Sources/MistDemoKit/Utilities/AuthenticationHelper.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Utilities/AuthenticationHelper.swift
@@ -50,7 +50,7 @@ internal enum AuthenticationHelper {
     keyID: String?,
     privateKey: String?,
     privateKeyFile: String?,
-    databaseOverride: String? = nil
+    databaseOverride: MistKit.Database? = nil
   ) async throws -> AuthenticationResult {
     if let keyID {
       return try await setupServerToServer(

--- a/Examples/MistDemo/Tests/MistDemoTests/Configuration/MistDemoConfigTests.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Configuration/MistDemoConfigTests.swift
@@ -85,8 +85,15 @@ internal struct MistDemoConfigTests {
 
   @Test("Invalid environment surfaces as ConfigurationError.invalidEnvironment")
   internal func invalidEnvironmentThrows() async throws {
-    await #expect(throws: ConfigurationError.self) {
+    do {
       _ = try await MistDemoConfig(rawEnvironment: "staging")
+      Issue.record("Expected ConfigurationError.invalidEnvironment")
+    } catch let error as ConfigurationError {
+      if case .invalidEnvironment(let raw) = error {
+        #expect(raw == "staging")
+      } else {
+        Issue.record("Wrong ConfigurationError case: \(error)")
+      }
     }
   }
 

--- a/Examples/MistDemo/Tests/MistDemoTests/Configuration/MistDemoConfigTests.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Configuration/MistDemoConfigTests.swift
@@ -83,6 +83,38 @@ internal struct MistDemoConfigTests {
     #expect(config.environment == .development)
   }
 
+  @Test(
+    "Environment names are matched case-insensitively to .production",
+    arguments: ["production", "Production", "PRODUCTION", "PrOdUcTiOn"]
+  )
+  internal func environmentMatchesProductionCaseInsensitively(
+    raw: String
+  ) async throws {
+    let config = try await MistDemoConfig(rawEnvironment: raw)
+    #expect(config.environment == .production)
+  }
+
+  @Test(
+    "Environment names are matched case-insensitively to .development",
+    arguments: ["development", "Development", "DEVELOPMENT", "DeVeLoPmEnT"]
+  )
+  internal func environmentMatchesDevelopmentCaseInsensitively(
+    raw: String
+  ) async throws {
+    let config = try await MistDemoConfig(rawEnvironment: raw)
+    #expect(config.environment == .development)
+  }
+
+  @Test(
+    "Invalid environment values throw ConfigurationError.invalidEnvironment",
+    arguments: ["staging", "prod", "dev", "test", "qa", " production ", ""]
+  )
+  internal func invalidEnvironmentThrows(raw: String) async throws {
+    await #expect(throws: ConfigurationError.self) {
+      _ = try await MistDemoConfig(rawEnvironment: raw)
+    }
+  }
+
   // MARK: - Server Configuration Tests
 
   @Test("Default host is localhost")

--- a/Examples/MistDemo/Tests/MistDemoTests/Configuration/MistDemoConfigTests.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Configuration/MistDemoConfigTests.swift
@@ -83,35 +83,10 @@ internal struct MistDemoConfigTests {
     #expect(config.environment == .development)
   }
 
-  @Test(
-    "Environment names are matched case-insensitively to .production",
-    arguments: ["production", "Production", "PRODUCTION", "PrOdUcTiOn"]
-  )
-  internal func environmentMatchesProductionCaseInsensitively(
-    raw: String
-  ) async throws {
-    let config = try await MistDemoConfig(rawEnvironment: raw)
-    #expect(config.environment == .production)
-  }
-
-  @Test(
-    "Environment names are matched case-insensitively to .development",
-    arguments: ["development", "Development", "DEVELOPMENT", "DeVeLoPmEnT"]
-  )
-  internal func environmentMatchesDevelopmentCaseInsensitively(
-    raw: String
-  ) async throws {
-    let config = try await MistDemoConfig(rawEnvironment: raw)
-    #expect(config.environment == .development)
-  }
-
-  @Test(
-    "Invalid environment values throw ConfigurationError.invalidEnvironment",
-    arguments: ["staging", "prod", "dev", "test", "qa", " production ", ""]
-  )
-  internal func invalidEnvironmentThrows(raw: String) async throws {
+  @Test("Invalid environment surfaces as ConfigurationError.invalidEnvironment")
+  internal func invalidEnvironmentThrows() async throws {
     await #expect(throws: ConfigurationError.self) {
-      _ = try await MistDemoConfig(rawEnvironment: raw)
+      _ = try await MistDemoConfig(rawEnvironment: "staging")
     }
   }
 

--- a/Examples/MistDemo/Tests/MistDemoTests/MistDemoConfig+Testing.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/MistDemoConfig+Testing.swift
@@ -40,6 +40,25 @@ extension MistDemoConfig {
     self = try await MistDemoConfig(configuration: configuration)
   }
 
+  /// Create a test configuration that injects a raw `environment`
+  /// string into the underlying provider. Used to exercise the
+  /// env-validation logic with values the typed `environment:`
+  /// initializer cannot express (e.g. `"PRODUCTION"`, `"staging"`).
+  internal init(rawEnvironment: String) async throws {
+    func key(_ path: String) -> AbsoluteConfigKey {
+      AbsoluteConfigKey(path.split(separator: ".").map(String.init), context: [:])
+    }
+
+    let testProvider = InMemoryProvider(values: [
+      key("container.identifier"): .init(stringLiteral: "iCloud.com.test.App"),
+      key("api.token"): .init(stringLiteral: "test-api-token"),
+      key("environment"): .init(stringLiteral: rawEnvironment),
+      key("database"): .init(stringLiteral: "private"),
+    ])
+    let configuration = MistDemoConfiguration(testProvider: testProvider)
+    self = try await MistDemoConfig(configuration: configuration)
+  }
+
   /// Create a test configuration with custom values
   internal init(
     containerIdentifier: String = "iCloud.com.test.App",

--- a/Examples/MistDemo/Tests/MistDemoTests/MistDemoConfig+Testing.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/MistDemoConfig+Testing.swift
@@ -44,6 +44,10 @@ extension MistDemoConfig {
   /// string into the underlying provider. Used to exercise the
   /// env-validation logic with values the typed `environment:`
   /// initializer cannot express (e.g. `"PRODUCTION"`, `"staging"`).
+  ///
+  /// Only the keys whose parsing this init aims to exercise are set;
+  /// `database` is left unset so it falls through to the production
+  /// parser's default and cannot affect environment-test semantics.
   internal init(rawEnvironment: String) async throws {
     func key(_ path: String) -> AbsoluteConfigKey {
       AbsoluteConfigKey(path.split(separator: ".").map(String.init), context: [:])
@@ -53,7 +57,6 @@ extension MistDemoConfig {
       key("container.identifier"): .init(stringLiteral: "iCloud.com.test.App"),
       key("api.token"): .init(stringLiteral: "test-api-token"),
       key("environment"): .init(stringLiteral: rawEnvironment),
-      key("database"): .init(stringLiteral: "private"),
     ])
     let configuration = MistDemoConfiguration(testProvider: testProvider)
     self = try await MistDemoConfig(configuration: configuration)

--- a/Examples/MistDemo/Tests/MistDemoTests/Utilities/AuthenticationHelper/AuthenticationHelperTests+APIOnlyAuthentication.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Utilities/AuthenticationHelper/AuthenticationHelperTests+APIOnlyAuthentication.swift
@@ -66,7 +66,7 @@ extension AuthenticationHelperTests {
           keyID: nil,
           privateKey: nil,
           privateKeyFile: nil,
-          databaseOverride: "private"
+          databaseOverride: .private
         )
         Issue.record("Expected privateRequiresWebAuth error")
       } catch let error as AuthenticationError {

--- a/Examples/MistDemo/Tests/MistDemoTests/Utilities/AuthenticationHelper/AuthenticationHelperTests+ServerToServerAuthentication.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Utilities/AuthenticationHelper/AuthenticationHelperTests+ServerToServerAuthentication.swift
@@ -113,7 +113,7 @@ extension AuthenticationHelperTests {
           keyID: "test-key-id",
           privateKey: privateKeyPEM,
           privateKeyFile: nil,
-          databaseOverride: "private"
+          databaseOverride: .private
         )
         Issue.record("Expected serverToServerRequiresPublicDatabase error")
       } catch let error as AuthenticationError {

--- a/Examples/MistDemo/Tests/MistDemoTests/Utilities/AuthenticationHelper/AuthenticationHelperTests+WebAuthentication.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Utilities/AuthenticationHelper/AuthenticationHelperTests+WebAuthentication.swift
@@ -69,7 +69,7 @@ extension AuthenticationHelperTests {
           keyID: nil,
           privateKey: nil,
           privateKeyFile: nil,
-          databaseOverride: "public"
+          databaseOverride: .public
         )
 
         #expect(result.database == .public)
@@ -91,7 +91,7 @@ extension AuthenticationHelperTests {
           keyID: nil,
           privateKey: nil,
           privateKeyFile: nil,
-          databaseOverride: "private"
+          databaseOverride: .private
         )
 
         #expect(result.database == .private)

--- a/Sources/MistKit/Environment.swift
+++ b/Sources/MistKit/Environment.swift
@@ -33,4 +33,11 @@ import Foundation
 public enum Environment: String, Sendable {
   case development
   case production
+
+  /// Initialize from a string by matching the raw value
+  /// case-insensitively. Returns `nil` if the input does not match
+  /// one of the canonical raw values (`"development"`, `"production"`).
+  public init?(caseInsensitive raw: String) {
+    self.init(rawValue: raw.lowercased())
+  }
 }

--- a/Tests/MistKitTests/Core/EnvironmentTests.swift
+++ b/Tests/MistKitTests/Core/EnvironmentTests.swift
@@ -12,4 +12,28 @@ internal struct EnvironmentTests {
     #expect(Environment.development.rawValue == "development")
     #expect(Environment.production.rawValue == "production")
   }
+
+  @Test(
+    "init?(caseInsensitive:) matches .production",
+    arguments: ["production", "Production", "PRODUCTION", "PrOdUcTiOn"]
+  )
+  internal func caseInsensitiveProduction(raw: String) {
+    #expect(Environment(caseInsensitive: raw) == .production)
+  }
+
+  @Test(
+    "init?(caseInsensitive:) matches .development",
+    arguments: ["development", "Development", "DEVELOPMENT", "DeVeLoPmEnT"]
+  )
+  internal func caseInsensitiveDevelopment(raw: String) {
+    #expect(Environment(caseInsensitive: raw) == .development)
+  }
+
+  @Test(
+    "init?(caseInsensitive:) returns nil for non-canonical values",
+    arguments: ["staging", "prod", "dev", "test", "qa", " production ", ""]
+  )
+  internal func caseInsensitiveRejectsInvalidValues(raw: String) {
+    #expect(Environment(caseInsensitive: raw) == nil)
+  }
 }


### PR DESCRIPTION
## Summary
This PR improves configuration validation by making environment and database settings type-safe and fail-fast. Environment values are now validated against canonical names with case-insensitive matching, and database overrides are typed as `MistKit.Database` enums instead of strings.

## Key Changes

- **Environment validation**: Introduced `EnvironmentName` enum with canonical lowercase names (`"production"`, `"development"`) and a new `parseEnvironment()` method that performs case-insensitive matching. Invalid values (including aliases like `"prod"`, `"dev"`, or whitespace-padded strings) now throw `ConfigurationError.invalidEnvironment` instead of silently defaulting to development.

- **Type-safe database overrides**: Changed `databaseOverride` parameter type from `String?` to `MistKit.Database?` across authentication setup methods (`setupServerToServer`, `setupWebAuth`, `setupAPIOnly`). This eliminates string parsing logic and makes invalid database values impossible to express.

- **Error propagation**: Updated `parseCoreConfig()` to throw errors (now returns `throws -> CoreConfig`), allowing environment validation failures to propagate during initialization.

- **Test coverage**: Added comprehensive test cases for case-insensitive environment matching and invalid environment value handling. Updated test helpers to support injecting raw environment strings for validation testing.

## Implementation Details

- Environment matching uses `lowercased()` for case-insensitive comparison against canonical names
- Database override logic simplified from conditional string parsing to direct enum comparison
- New `rawEnvironment` test initializer allows exercising validation with values the typed initializer cannot express
- All changes maintain backward compatibility for valid configurations while rejecting invalid ones at startup

https://claude.ai/code/session_015fs7Y6K27CvQvGpt1TsGvU

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/brightdigit/MistKit/293)
<!-- GitContextEnd -->