### PR TITLE
Add query pagination support with continuation markers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,7 @@ MistKit/
 
 | File | Operations |
 |------|-----------|
-| `CloudKitService+Operations.swift` | `queryRecords`, `lookupRecords`, `modifyRecords` |
+| `CloudKitService+Operations.swift` | `queryRecords`, `queryAllRecords`, `lookupRecords`, `modifyRecords` |
 | `CloudKitService+ZoneOperations.swift` | `listZones`, `lookupZones(zoneIDs:)`, `fetchZoneChanges(syncToken:)` |
 | `CloudKitService+SyncOperations.swift` | `fetchRecordChanges(recordType:syncToken:)`, `fetchAllRecordChanges(recordType:syncToken:)` |
 | `CloudKitService+UserOperations.swift` | `fetchCurrentUser()`, `discoverUserIdentities(lookupInfos:)` |
@@ -173,6 +173,7 @@ MistKit/
 - `discoverUserIdentities(lookupInfos:)` → `/users/discover` — takes `[UserIdentityLookupInfo]`, returns `[UserIdentity]`
 
 **Result Types (Sources/MistKit/Service/):**
+- `QueryResult` — `records: [RecordInfo]`, `continuationMarker: String?`
 - `RecordChangesResult` — `records: [RecordInfo]`, `syncToken: String?`, `moreComing: Bool`
 - `ZoneChangesResult` — `zones: [ZoneInfo]`, `syncToken: String?`
 - `UserIdentity` — `userRecordName: String?`, `nameComponents: NameComponents?`

--- a/Examples/BushelCloud/Sources/BushelCloudKit/CloudKit/BushelCloudKitService.swift
+++ b/Examples/BushelCloud/Sources/BushelCloudKit/CloudKit/BushelCloudKitService.swift
@@ -148,9 +148,9 @@ public struct BushelCloudKitService: Sendable, RecordManaging, CloudKitRecordCol
 
   // MARK: - RecordManaging Protocol Requirements
 
-  /// Query all records of a given type
+  /// Query all records of a given type, automatically paginating
   public func queryRecords(recordType: String) async throws -> [RecordInfo] {
-    try await service.queryRecords(recordType: recordType, limit: 200)
+    try await service.queryAllRecords(recordType: recordType)
   }
 
   /// Fetch existing record names for create/update classification

--- a/Examples/CelestraCloud/Sources/CelestraCloudKit/Protocols/CloudKitRecordOperating.swift
+++ b/Examples/CelestraCloud/Sources/CelestraCloudKit/Protocols/CloudKitRecordOperating.swift
@@ -53,6 +53,23 @@ public protocol CloudKitRecordOperating: Sendable {
   /// - Returns: Array of modified record info
   /// - Throws: CloudKitError if the modification fails
   func modifyRecords(_ operations: [RecordOperation]) async throws(CloudKitError) -> [RecordInfo]
+
+  /// Query all records of a type, automatically paginating through continuation markers
+  /// - Parameters:
+  ///   - recordType: The type of record to query
+  ///   - filters: Optional query filters
+  ///   - sortBy: Optional sort descriptors
+  ///   - limit: Maximum number of records per page (optional)
+  ///   - desiredKeys: Optional list of field keys to fetch
+  /// - Returns: Array of all matching record info across all pages
+  /// - Throws: CloudKitError if the query fails
+  func queryAllRecords(
+    recordType: String,
+    filters: [QueryFilter]?,
+    sortBy: [QuerySort]?,
+    limit: Int?,
+    desiredKeys: [String]?
+  ) async throws(CloudKitError) -> [RecordInfo]
 }
 
 // MARK: - CloudKitService Conformance

--- a/Examples/CelestraCloud/Sources/CelestraCloudKit/Protocols/CloudKitRecordOperating.swift
+++ b/Examples/CelestraCloud/Sources/CelestraCloudKit/Protocols/CloudKitRecordOperating.swift
@@ -59,16 +59,18 @@ public protocol CloudKitRecordOperating: Sendable {
   ///   - recordType: The type of record to query
   ///   - filters: Optional query filters
   ///   - sortBy: Optional sort descriptors
-  ///   - limit: Maximum number of records per page (optional)
+  ///   - pageSize: Maximum number of records per page (optional)
   ///   - desiredKeys: Optional list of field keys to fetch
+  ///   - maxPages: Maximum number of pages to fetch before throwing
   /// - Returns: Array of all matching record info across all pages
   /// - Throws: CloudKitError if the query fails
   func queryAllRecords(
     recordType: String,
     filters: [QueryFilter]?,
     sortBy: [QuerySort]?,
-    limit: Int?,
-    desiredKeys: [String]?
+    pageSize: Int?,
+    desiredKeys: [String]?,
+    maxPages: Int
   ) async throws(CloudKitError) -> [RecordInfo]
 }
 

--- a/Examples/CelestraCloud/Tests/CelestraCloudTests/Mocks/MockCloudKitRecordOperator.swift
+++ b/Examples/CelestraCloud/Tests/CelestraCloudTests/Mocks/MockCloudKitRecordOperator.swift
@@ -95,15 +95,16 @@ internal final class MockCloudKitRecordOperator: CloudKitRecordOperating, Sendab
     recordType: String,
     filters: [QueryFilter]?,
     sortBy: [QuerySort]?,
-    limit: Int?,
-    desiredKeys: [String]?
+    pageSize: Int?,
+    desiredKeys: [String]?,
+    maxPages: Int
   ) async throws(CloudKitError) -> [RecordInfo] {
     queryCalls.append(
       QueryCall(
         recordType: recordType,
         filters: filters,
         sortBy: sortBy,
-        limit: limit,
+        limit: pageSize,
         desiredKeys: desiredKeys
       )
     )

--- a/Examples/CelestraCloud/Tests/CelestraCloudTests/Mocks/MockCloudKitRecordOperator.swift
+++ b/Examples/CelestraCloud/Tests/CelestraCloudTests/Mocks/MockCloudKitRecordOperator.swift
@@ -90,4 +90,23 @@ internal final class MockCloudKitRecordOperator: CloudKitRecordOperating, Sendab
     modifyCalls.append(ModifyCall(operations: operations))
     return try modifyRecordsResult.get()
   }
+
+  internal func queryAllRecords(
+    recordType: String,
+    filters: [QueryFilter]?,
+    sortBy: [QuerySort]?,
+    limit: Int?,
+    desiredKeys: [String]?
+  ) async throws(CloudKitError) -> [RecordInfo] {
+    queryCalls.append(
+      QueryCall(
+        recordType: recordType,
+        filters: filters,
+        sortBy: sortBy,
+        limit: limit,
+        desiredKeys: desiredKeys
+      )
+    )
+    return try queryRecordsResult.get()
+  }
 }

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/QueryRecordsPhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/QueryRecordsPhase.swift
@@ -52,7 +52,13 @@ internal struct QueryRecordsPhase: IntegrationPhase {
         let ours = records.filter { input.names.contains($0.recordName) }
         print("   Found \(ours.count) of our \(input.names.count) test records")
       }
-    } catch CloudKitError.httpErrorWithDetails(statusCode: 404, serverErrorCode: _, reason: _) {
+    } catch {
+      // Workaround for Swift 6.3 SIL miscompile (MandatoryAllocBoxToStack) —
+      // a literal in a destructured-enum `catch` pattern crashes the pass on
+      // this branch. See SWIFT_COMPILER_BUG.md. Match via `guard case` instead.
+      guard case CloudKitError.httpErrorWithDetails(statusCode: 404, _, _) = error else {
+        throw error
+      }
       // Schema propagation in development can lag behind the first write.
       // LookupRecordsPhase already verifies the records exist by name.
       print("⚠️  queryRecords returned NOT_FOUND — schema may not be indexed yet (non-fatal)")

--- a/SWIFT_COMPILER_BUG.md
+++ b/SWIFT_COMPILER_BUG.md
@@ -1,0 +1,212 @@
+# Swift 6.3 SIL miscompile: `MandatoryAllocBoxToStack` crashes on destructured-enum `catch` pattern with a literal
+
+## Summary
+
+Swift 6.3 (`swiftlang-6.3.0.123.5`) crashes in the `MandatoryAllocBoxToStack`
+SIL pass (`StackNesting::fixNesting`, signal 11) while compiling a module that
+contains a `catch` clause whose destructured-enum pattern matches **any
+literal value** in **any associated-value position**, in combination with a
+specific `RecordManaging` protocol shape that includes a default-argumented
+`async throws` extension method built on top of a primitive protocol
+requirement.
+
+The crash is deterministic. Plain `catch`, all-wildcard destructured catch,
+and the equivalent pattern moved into a `guard case` all build without issue —
+only a `catch` with at least one literal in the pattern triggers the
+miscompile.
+
+## Environment
+
+- **Compiler**: Apple Swift version 6.3 (`swiftlang-6.3.0.123.5 clang-2100.0.123.102`)
+- **swift-driver**: 1.148.6
+- **Target**: `arm64-apple-macosx26.0`
+- **Host**: macOS 26.0 (Darwin 25.4.0), Apple Silicon
+- **Tools-version (failing)**: any of 6.1 / 6.2 / 6.3 — independent of the package's `swift-tools-version`
+
+## Reproducer
+
+```bash
+git clone git@github.com:brightdigit/MistKit.git
+cd MistKit
+git checkout 302-redesign-recordmanaging-experiment
+# Commit: d2178f3ba69217ee59d887be011e71e6e3d9d79e
+cd Examples/MistDemo
+swift build
+```
+
+The crash occurs during compilation of the `MistDemoKit` module while the
+mandatory diagnostic SIL pipeline runs `MandatoryAllocBoxToStack`.
+
+## Crash output (abridged)
+
+```
+4. While evaluating request ExecuteSILPipelineRequest(Run pipelines
+   { Mandatory Diagnostic Passes + Enabling Optimization Passes } on SIL
+   for MistDemoKit)
+5. While running pass #54 SILModuleTransform "MandatoryAllocBoxToStack".
+
+Stack:
+4  swift-frontend  swift::StackNesting::fixNesting(swift::SILFunction*)        + 4508
+5  swift-frontend  BridgedPassContext::fixStackNesting(BridgedFunction) const  +   32
+6  swift-frontend  Optimizer.tryConvertBoxesToStack                            + 10940
+7  swift-frontend  Optimizer.mandatoryAllocBoxToStack closure                  +  388
+8  swift-frontend  swift::SILPassManager::executePassPipelinePlan              + 14624
+9  swift-frontend  swift::SimpleRequest<…ExecuteSILPipelineRequest…>            +   48
+…
+11 swift-frontend  swift::runSILDiagnosticPasses(swift::SILModule&)            +  432
+12 swift-frontend  swift::CompilerInstance::performSILProcessing               +  656
+```
+
+The crashing pass is the new Swift-implemented optimizer module's
+`mandatoryAllocBoxToStack` calling its `tryConvertBoxesToStack` helper, which
+calls back into C++ via `BridgedPassContext::fixStackNesting`, where
+`StackNesting::fixNesting` segfaults.
+
+## Trigger
+
+The crashing site is the `catch` clause at
+`Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/QueryRecordsPhase.swift:55`:
+
+```swift
+internal func run(
+  input: CreatedRecordNames, context: PhaseContext
+) async throws -> NoState {
+  do {
+    let records = try await context.service.queryRecords(
+      recordType: IntegrationTestData.recordType
+    )
+    // ... uses `records` ...
+  } catch CloudKitError.httpErrorWithDetails(statusCode: 404, serverErrorCode: _, reason: _) {
+    // <-- this catch crashes the SIL pass
+    print("…")
+  }
+  return NoState()
+}
+```
+
+`context.service` is typed as a `RecordManaging` existential / generic. The
+relevant protocol shape (introduced in commit `d2178f3` on this branch) is:
+
+```swift
+public protocol RecordManaging {
+  func executeBatchOperations(_ operations: [RecordOperation], recordType: String) async throws
+
+  @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+  func queryRecords(
+    recordType: String,
+    filters: [QueryFilter]?,
+    sortBy: [QuerySort]?,
+    limit: Int?,
+    desiredKeys: [String]?,
+    continuationMarker: String?
+  ) async throws -> QueryResult
+}
+
+extension RecordManaging {
+  @available(*, deprecated, message: "…")
+  @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+  public func queryRecords(recordType: String) async throws -> [RecordInfo] {
+    let result = try await queryRecords(
+      recordType: recordType,
+      filters: nil, sortBy: nil, limit: nil,
+      desiredKeys: nil, continuationMarker: nil
+    )
+    return result.records
+  }
+  // also: queryAllRecords with default-argumented overloads, see
+  // Sources/MistKit/Protocols/RecordManaging.swift
+}
+```
+
+`CloudKitError` is defined in MistKit and includes the
+`httpErrorWithDetails(statusCode: Int, serverErrorCode: String, reason: String?)`
+case.
+
+## Bisection ladder
+
+I narrowed the crash with successive edits to the body of
+`QueryRecordsPhase.run`, clean-rebuilding between each change:
+
+| `run` body content                                                                                       | Result    |
+| -------------------------------------------------------------------------------------------------------- | --------- |
+| empty (`return NoState()`)                                                                               | builds    |
+| + `queryRecords` call + plain `print`                                                                    | builds    |
+| + `if context.verbose { records.filter { input.names.contains($0.recordName) } }`                        | builds    |
+| + plain `} catch { print("error") }` (no pattern)                                                        | builds    |
+| + `} catch CloudKitError.httpErrorWithDetails(statusCode: _, serverErrorCode: _, reason: _) { … }`        | builds    |
+| + `} catch CloudKitError.httpErrorWithDetails(statusCode: 404, serverErrorCode: _, reason: _) { … }`      | **crash** |
+| + `} catch CloudKitError.httpErrorWithDetails(statusCode: _, serverErrorCode: "X", reason: _) { … }`      | **crash** |
+
+The minimum sufficient ingredient is a **non-wildcard literal at any
+associated-value position** in the destructured `catch` pattern. The literal's
+type (`Int` vs `String`) and its position do not matter; presence of any
+literal does.
+
+## What was ruled out
+
+These hypotheses were tested and falsified during bisection:
+
+- **Tools-version language mode**: crash reproduces with all four combinations
+  of `swift-tools-version` 6.1/6.2/6.3 across MistKit and MistDemo
+  `Package.swift`.
+- **Multi-arg overload ambiguity at call sites**: the deprecated
+  `CloudKitService.queryRecords(...) -> [RecordInfo]` overload was removed and
+  call sites updated; the SIL crash still reproduces with only one
+  `queryRecords` overload visible to overload resolution.
+- **Typed vs untyped throws on the protocol primitive**: per the original
+  branch experiment commit message, both forms reproduce.
+- **`Sendable` conformance on `QueryFilter`/`QuerySort`**: per the same
+  commit message, toggling did not affect the crash.
+- **The body of `queryAllRecords`**: per the same commit message, replacing
+  the body did not affect the crash.
+- **Direct calls to the new generic `queryAllRecords` extension method**:
+  MistDemo never calls it; bisection of `QueryRecordsPhase.run`'s body shows
+  the trigger is the `catch` clause itself, not anything traversing the
+  generic protocol extension.
+
+## Why MistDemo and not BushelCloud (the sibling example)
+
+`Examples/BushelCloud` builds cleanly against the same branch. It implements
+the new `RecordManaging` primitive but never uses a `catch` clause that
+destructures `CloudKitError` with a literal in the pattern. Removing or
+softening that single `catch` in MistDemo's `QueryRecordsPhase.run` makes
+MistDemo build cleanly as well.
+
+## Workaround
+
+Replace the typed-pattern `catch` with a plain `catch` followed by a
+`guard case`/`if case` that performs the same destructuring + literal match.
+Identical runtime behavior; the SIL the compiler emits is different enough to
+sidestep the bug.
+
+```swift
+} catch {
+  guard case CloudKitError.httpErrorWithDetails(statusCode: 404, _, _) = error else {
+    throw error
+  }
+  print("…")
+}
+```
+
+This workaround is applied in
+`Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/QueryRecordsPhase.swift`
+on this branch.
+
+## Suggested investigation in the compiler
+
+The crash is in the C++ `StackNesting::fixNesting` invoked from the
+Swift-implemented optimizer's `tryConvertBoxesToStack`. Likely areas to look:
+
+- SIL emitted for a `catch` clause that produces a `try_apply` whose
+  unwind/error block performs a `switch_enum_addr` (or equivalent) destructure
+  of an indirect enum case with at least one literal-pattern match,
+  particularly when one of the boxes the pass attempts to promote is the
+  caught error value.
+- The combination with the `RecordManaging` protocol witness call (an `async
+  throws` requirement satisfied by a typed-throws concrete witness) which
+  produces a witness-thunk in the same function body.
+
+A minimal isolated reproducer outside MistKit was not produced — the bug
+needs both the protocol shape and the typed-pattern catch in scope. The full
+project repro is small enough (one branch, ~10 second clean build to crash)
+to use directly.

--- a/Sources/MistKit/Extensions/RecordManaging+Generic.swift
+++ b/Sources/MistKit/Extensions/RecordManaging+Generic.swift
@@ -80,8 +80,9 @@ extension RecordManaging {
   ///
   /// - Parameter type: The CloudKitRecord type to list
   /// - Throws: CloudKit errors if the query fails
+  @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
   public func list<T: CloudKitRecord>(_ type: T.Type) async throws {
-    let records = try await queryRecords(recordType: T.cloudKitRecordType)
+    let records = try await queryAllRecords(recordType: T.cloudKitRecordType)
 
     print("\n\(T.cloudKitRecordType) (\(records.count) total)")
     print(String(repeating: "=", count: 80))
@@ -117,11 +118,12 @@ extension RecordManaging {
   ///   - filter: Optional closure to filter RecordInfo results before parsing
   /// - Returns: Array of parsed model instances (nil records are filtered out)
   /// - Throws: CloudKit errors if the query fails
+  @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
   public func query<T: CloudKitRecord>(
     _ type: T.Type,
     where filter: (RecordInfo) -> Bool = { _ in true }
   ) async throws -> [T] {
-    let records = try await queryRecords(recordType: T.cloudKitRecordType)
+    let records = try await queryAllRecords(recordType: T.cloudKitRecordType)
     return records.filter(filter).compactMap(T.from)
   }
 }

--- a/Sources/MistKit/Extensions/RecordManaging+RecordCollection.swift
+++ b/Sources/MistKit/Extensions/RecordManaging+RecordCollection.swift
@@ -101,7 +101,7 @@ extension RecordManaging where Self: CloudKitRecordCollection {
     try await Self.recordTypes.forEach { recordType in
       recordTypesList.append(recordType)
       let typeName = recordType.cloudKitRecordType
-      let records = try await queryRecords(recordType: typeName)
+      let records = try await queryAllRecords(recordType: typeName)
       countsByType[typeName] = records.count
       totalCount += records.count
 
@@ -148,7 +148,7 @@ extension RecordManaging where Self: CloudKitRecordCollection {
     // swift-format-ignore: ReplaceForEachWithForLoop
     try await Self.recordTypes.forEach { recordType in
       let typeName = recordType.cloudKitRecordType
-      let records = try await queryRecords(recordType: typeName)
+      let records = try await queryAllRecords(recordType: typeName)
 
       guard !records.isEmpty else {
         print("\n\(typeName): No records to delete")

--- a/Sources/MistKit/Protocols/RecordManaging.swift
+++ b/Sources/MistKit/Protocols/RecordManaging.swift
@@ -52,4 +52,18 @@ public protocol RecordManaging {
   ///   - recordType: The record type being operated on (for logging)
   /// - Throws: CloudKit errors if the batch operations fail
   func executeBatchOperations(_ operations: [RecordOperation], recordType: String) async throws
+
+  /// Query all records of a specific type, automatically paginating
+  ///
+  /// - Parameter recordType: The CloudKit record type to query
+  /// - Returns: Array of all matching records across all pages
+  /// - Throws: CloudKit errors if the query fails
+  func queryAllRecords(recordType: String) async throws -> [RecordInfo]
+}
+
+extension RecordManaging {
+  /// Default implementation delegates to queryRecords
+  public func queryAllRecords(recordType: String) async throws -> [RecordInfo] {
+    try await queryRecords(recordType: recordType)
+  }
 }

--- a/Sources/MistKit/Protocols/RecordManaging.swift
+++ b/Sources/MistKit/Protocols/RecordManaging.swift
@@ -40,6 +40,11 @@ public protocol RecordManaging {
   /// - Parameter recordType: The CloudKit record type to query
   /// - Returns: Array of record information for all matching records
   /// - Throws: CloudKit errors if the query fails
+  @available(
+    *, deprecated,
+    message:
+      "Returns at most one page (silently truncates at the server limit). Use queryAllRecords(recordType:) to fetch all pages, or call CloudKitService.queryRecords(...) -> QueryResult to handle pagination explicitly."
+  )
   func queryRecords(recordType: String) async throws -> [RecordInfo]
 
   /// Execute a batch of record operations
@@ -62,7 +67,14 @@ public protocol RecordManaging {
 }
 
 extension RecordManaging {
-  /// Default implementation delegates to queryRecords
+  /// Default implementation delegates to the deprecated `queryRecords(recordType:)`,
+  /// which only returns one page. Conformers should override this with a real
+  /// auto-paginating implementation (e.g. `CloudKitService.queryAllRecords`).
+  @available(
+    *, deprecated,
+    message:
+      "Default implementation only returns one page. Override queryAllRecords with a real auto-paginating implementation."
+  )
   public func queryAllRecords(recordType: String) async throws -> [RecordInfo] {
     try await queryRecords(recordType: recordType)
   }

--- a/Sources/MistKit/PublicTypes/QueryFilter.swift
+++ b/Sources/MistKit/PublicTypes/QueryFilter.swift
@@ -31,7 +31,7 @@ import Foundation
 
 /// Public wrapper for CloudKit query filters
 @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
-public struct QueryFilter {
+public struct QueryFilter: Sendable {
   // MARK: - Internal
 
   internal let filter: Components.Schemas.Filter

--- a/Sources/MistKit/PublicTypes/QuerySort.swift
+++ b/Sources/MistKit/PublicTypes/QuerySort.swift
@@ -31,7 +31,7 @@ import Foundation
 
 /// Public wrapper for CloudKit query sort descriptors
 @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
-public struct QuerySort {
+public struct QuerySort: Sendable {
   // MARK: - Internal
 
   internal let sort: Components.Schemas.Sort

--- a/Sources/MistKit/Service/CloudKitError.swift
+++ b/Sources/MistKit/Service/CloudKitError.swift
@@ -44,6 +44,7 @@ public enum CloudKitError: LocalizedError, Sendable {
   case decodingError(DecodingError)
   case networkError(URLError)
   case unsupportedOperationType(String)
+  case paginationLimitExceeded(maxPages: Int, recordsCollected: Int)
 
   /// HTTP status code if this error originated from an HTTP response, otherwise nil.
   public var httpStatusCode: Int? {
@@ -53,7 +54,7 @@ public enum CloudKitError: LocalizedError, Sendable {
       .httpErrorWithRawResponse(let statusCode, _):
       return statusCode
     case .invalidResponse, .underlyingError, .decodingError, .networkError,
-      .unsupportedOperationType:
+      .unsupportedOperationType, .paginationLimitExceeded:
       return nil
     }
   }
@@ -119,6 +120,10 @@ public enum CloudKitError: LocalizedError, Sendable {
       return message
     case .unsupportedOperationType(let type):
       return "Unsupported record operation type: \(type)"
+    case .paginationLimitExceeded(let maxPages, let recordsCollected):
+      return
+        "CloudKit query exceeded pagination limit of \(maxPages) pages "
+        + "(collected \(recordsCollected) records)"
     }
   }
 }

--- a/Sources/MistKit/Service/CloudKitService+Classification.swift
+++ b/Sources/MistKit/Service/CloudKitService+Classification.swift
@@ -66,14 +66,11 @@ extension CloudKitService {
     recordType: String,
     limit: Int? = nil
   ) async throws(CloudKitError) -> Set<String> {
-    // Pass `limit:` explicitly so overload resolution picks the typed-throws
-    // variant of `queryRecords` rather than the 1-param RecordManaging-
-    // conforming overload (which has untyped throws).
-    let records = try await queryRecords(
+    let result: QueryResult = try await queryRecords(
       recordType: recordType,
       limit: limit ?? Self.maxRecordsPerRequest
     )
-    return Set(records.map(\.recordName))
+    return Set(result.records.map(\.recordName))
   }
 
   /// Modify CloudKit records and partition the response into creates,

--- a/Sources/MistKit/Service/CloudKitService+Operations.swift
+++ b/Sources/MistKit/Service/CloudKitService+Operations.swift
@@ -85,6 +85,7 @@ extension CloudKitService {
   /// ```
   ///
   /// - Note: For large result sets, consider using pagination
+  ///   with `continuationMarker` or `queryAllRecords`
   public func queryRecords(
     recordType: String,
     filters: [QueryFilter]? = nil,
@@ -92,6 +93,57 @@ extension CloudKitService {
     limit: Int? = nil,
     desiredKeys: [String]? = nil
   ) async throws(CloudKitError) -> [RecordInfo] {
+    let result: QueryResult = try await queryRecords(
+      recordType: recordType,
+      filters: filters,
+      sortBy: sortBy,
+      limit: limit,
+      desiredKeys: desiredKeys,
+      continuationMarker: nil
+    )
+    return result.records
+  }
+
+  /// Query records from the default zone with pagination support
+  ///
+  /// Queries CloudKit records with optional filtering, sorting, and pagination.
+  /// Returns a `QueryResult` containing both the matching records and
+  /// a `continuationMarker` for fetching subsequent pages.
+  ///
+  /// - Parameters:
+  ///   - recordType: The type of records to query (must not be empty)
+  ///   - filters: Optional array of filters to apply to the query
+  ///   - sortBy: Optional array of sort descriptors
+  ///   - limit: Maximum number of records to return
+  ///     (1-200, defaults to `defaultQueryLimit`)
+  ///   - desiredKeys: Optional array of field names to fetch
+  ///   - continuationMarker: Marker from a previous `QueryResult`
+  ///     to fetch the next page of results
+  /// - Returns: A `QueryResult` with matching records and an optional
+  ///   continuation marker for the next page
+  /// - Throws: CloudKitError if validation fails or the request fails
+  ///
+  /// # Example: Paginated Query
+  /// ```swift
+  /// var marker: String? = nil
+  /// repeat {
+  ///   let result: QueryResult = try await service.queryRecords(
+  ///     recordType: "Article",
+  ///     limit: 50,
+  ///     continuationMarker: marker
+  ///   )
+  ///   process(result.records)
+  ///   marker = result.continuationMarker
+  /// } while marker != nil
+  /// ```
+  public func queryRecords(
+    recordType: String,
+    filters: [QueryFilter]? = nil,
+    sortBy: [QuerySort]? = nil,
+    limit: Int? = nil,
+    desiredKeys: [String]? = nil,
+    continuationMarker: String? = nil
+  ) async throws(CloudKitError) -> QueryResult {
     let effectiveLimit = limit ?? defaultQueryLimit
 
     guard !recordType.isEmpty else {
@@ -131,7 +183,8 @@ extension CloudKitService {
                 filterBy: componentsFilters,
                 sortBy: componentsSorts
               ),
-              desiredKeys: desiredKeys
+              desiredKeys: desiredKeys,
+              continuationMarker: continuationMarker
             )
           )
         )
@@ -139,10 +192,82 @@ extension CloudKitService {
 
       let recordsData: Components.Schemas.QueryResponse =
         try await responseProcessor.processQueryRecordsResponse(response)
-      return recordsData.records?.compactMap { RecordInfo(from: $0) } ?? []
+      return QueryResult(from: recordsData)
     } catch {
       throw mapToCloudKitError(error, context: "queryRecords")
     }
+  }
+
+  /// Query all records, handling pagination automatically
+  ///
+  /// Convenience method that automatically fetches all matching records
+  /// by following continuation markers and making multiple requests if needed.
+  ///
+  /// - Parameters:
+  ///   - recordType: The type of records to query (must not be empty)
+  ///   - filters: Optional array of filters to apply to the query
+  ///   - sortBy: Optional array of sort descriptors
+  ///   - limit: Maximum number of records per page
+  ///     (1-200, defaults to `defaultQueryLimit`)
+  ///   - desiredKeys: Optional array of field names to fetch
+  /// - Returns: Array of all matching records across all pages
+  /// - Throws: CloudKitError if any page request fails
+  ///
+  /// - Warning: For queries with many matching records, this may make
+  ///           multiple requests and return a large array. Consider using
+  ///           `queryRecords` with `continuationMarker` for better
+  ///           memory control.
+  /// - Warning: This method will stop early if the server repeatedly
+  ///           returns a continuation marker with no records and the same
+  ///           marker (stuck-marker scenario), or if the page count
+  ///           exceeds 1,000.
+  public func queryAllRecords(
+    recordType: String,
+    filters: [QueryFilter]? = nil,
+    sortBy: [QuerySort]? = nil,
+    limit: Int? = nil,
+    desiredKeys: [String]? = nil
+  ) async throws(CloudKitError) -> [RecordInfo] {
+    var allRecords: [RecordInfo] = []
+    var currentMarker: String? = nil
+    var hasMore = true
+    var pageCount = 0
+    let maxPages = 1_000
+
+    while hasMore {
+      guard pageCount < maxPages else {
+        throw CloudKitError.invalidResponse
+      }
+
+      do {
+        try Task.checkCancellation()
+      } catch {
+        throw mapToCloudKitError(error, context: "queryAllRecords")
+      }
+
+      let result: QueryResult = try await queryRecords(
+        recordType: recordType,
+        filters: filters,
+        sortBy: sortBy,
+        limit: limit,
+        desiredKeys: desiredKeys,
+        continuationMarker: currentMarker
+      )
+
+      // Stuck-marker detection
+      if result.records.isEmpty && result.continuationMarker != nil
+        && result.continuationMarker == currentMarker
+      {
+        break
+      }
+
+      allRecords.append(contentsOf: result.records)
+      currentMarker = result.continuationMarker
+      hasMore = currentMarker != nil
+      pageCount += 1
+    }
+
+    return allRecords
   }
 
   /// Modify (create, update, delete) records

--- a/Sources/MistKit/Service/CloudKitService+Operations.swift
+++ b/Sources/MistKit/Service/CloudKitService+Operations.swift
@@ -237,7 +237,10 @@ extension CloudKitService {
 
     repeat {
       guard pageCount < maxPages else {
-        throw CloudKitError.invalidResponse
+        throw CloudKitError.paginationLimitExceeded(
+          maxPages: maxPages,
+          recordsCollected: allRecords.count
+        )
       }
 
       do {

--- a/Sources/MistKit/Service/CloudKitService+Operations.swift
+++ b/Sources/MistKit/Service/CloudKitService+Operations.swift
@@ -86,6 +86,11 @@ extension CloudKitService {
   ///
   /// - Note: For large result sets, consider using pagination
   ///   with `continuationMarker` or `queryAllRecords`
+  @available(
+    *, deprecated,
+    message:
+      "Use queryRecords(...) -> QueryResult to handle pagination explicitly, or queryAllRecords(...) to auto-paginate."
+  )
   public func queryRecords(
     recordType: String,
     filters: [QueryFilter]? = nil,
@@ -207,34 +212,30 @@ extension CloudKitService {
   ///   - recordType: The type of records to query (must not be empty)
   ///   - filters: Optional array of filters to apply to the query
   ///   - sortBy: Optional array of sort descriptors
-  ///   - limit: Maximum number of records per page
+  ///   - pageSize: Maximum number of records per page
   ///     (1-200, defaults to `defaultQueryLimit`)
   ///   - desiredKeys: Optional array of field names to fetch
+  ///   - maxPages: Maximum number of pages to fetch before throwing
+  ///     `CloudKitError.invalidResponse` (defaults to 1,000)
   /// - Returns: Array of all matching records across all pages
   /// - Throws: CloudKitError if any page request fails
   ///
-  /// - Warning: For queries with many matching records, this may make
-  ///           multiple requests and return a large array. Consider using
-  ///           `queryRecords` with `continuationMarker` for better
-  ///           memory control.
-  /// - Warning: This method will stop early if the server repeatedly
-  ///           returns a continuation marker with no records and the same
-  ///           marker (stuck-marker scenario), or if the page count
-  ///           exceeds 1,000.
+  /// - Warning: Stops early if the server returns the same continuation
+  ///   marker with no new records (stuck-marker scenario), or if
+  ///   the page count exceeds `maxPages`.
   public func queryAllRecords(
     recordType: String,
     filters: [QueryFilter]? = nil,
     sortBy: [QuerySort]? = nil,
-    limit: Int? = nil,
-    desiredKeys: [String]? = nil
+    pageSize: Int? = nil,
+    desiredKeys: [String]? = nil,
+    maxPages: Int = 1_000
   ) async throws(CloudKitError) -> [RecordInfo] {
     var allRecords: [RecordInfo] = []
     var currentMarker: String? = nil
-    var hasMore = true
     var pageCount = 0
-    let maxPages = 1_000
 
-    while hasMore {
+    repeat {
       guard pageCount < maxPages else {
         throw CloudKitError.invalidResponse
       }
@@ -249,7 +250,7 @@ extension CloudKitService {
         recordType: recordType,
         filters: filters,
         sortBy: sortBy,
-        limit: limit,
+        limit: pageSize,
         desiredKeys: desiredKeys,
         continuationMarker: currentMarker
       )
@@ -263,9 +264,8 @@ extension CloudKitService {
 
       allRecords.append(contentsOf: result.records)
       currentMarker = result.continuationMarker
-      hasMore = currentMarker != nil
       pageCount += 1
-    }
+    } while currentMarker != nil
 
     return allRecords
   }

--- a/Sources/MistKit/Service/CloudKitService+RecordManaging.swift
+++ b/Sources/MistKit/Service/CloudKitService+RecordManaging.swift
@@ -73,4 +73,21 @@ extension CloudKitService: RecordManaging {
   ) async throws {
     _ = try await self.modifyRecords(operations)
   }
+
+  /// Query all records of a specific type, automatically paginating
+  ///
+  /// This implementation uses `queryAllRecords` which follows continuation markers
+  /// to fetch all matching records across multiple pages.
+  ///
+  /// - Parameter recordType: The CloudKit record type to query
+  /// - Returns: Array of all matching records
+  /// - Throws: CloudKit errors if any page request fails
+  public func queryAllRecords(recordType: String) async throws -> [RecordInfo] {
+    try await self.queryAllRecords(
+      recordType: recordType,
+      filters: nil,
+      sortBy: nil,
+      limit: nil
+    )
+  }
 }

--- a/Sources/MistKit/Service/CloudKitService+RecordManaging.swift
+++ b/Sources/MistKit/Service/CloudKitService+RecordManaging.swift
@@ -35,38 +35,24 @@ import Foundation
 /// operations, enabling protocol-oriented patterns for CloudKit operations.
 @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
 extension CloudKitService: RecordManaging {
-  /// Query records of a specific type from CloudKit
-  ///
-  /// This implementation uses a default limit of 200 records. For more control over
-  /// query parameters (filters, sorting, custom limits), use the full `queryRecords`
-  /// method directly on CloudKitService.
-  ///
-  /// - Parameter recordType: The CloudKit record type to query
-  /// - Returns: Array of record information for matching records (up to 200)
-  /// - Throws: CloudKit errors if the query fails
+  /// Query records of a specific type from CloudKit (deprecated single-page form)
+  @available(
+    *, deprecated,
+    message:
+      "Returns at most one page (silently truncates at the server limit). Use queryAllRecords(recordType:) to fetch all pages, or call queryRecords(...) -> QueryResult to handle pagination explicitly."
+  )
   public func queryRecords(recordType: String) async throws -> [RecordInfo] {
-    try await self.queryRecords(
+    let result: QueryResult = try await self.queryRecords(
       recordType: recordType,
       filters: nil,
       sortBy: nil,
-      limit: 200
+      limit: 200,
+      desiredKeys: nil,
+      continuationMarker: nil
     )
+    return result.records
   }
 
-  /// Execute a batch of record operations
-  ///
-  /// This implementation delegates to CloudKitService's `modifyRecords` method.
-  /// The recordType parameter is provided for logging purposes but is not required
-  /// by the underlying implementation (operation types are embedded in RecordOperation).
-  ///
-  /// Note: The caller is responsible for respecting CloudKit's 200 operations/request
-  /// limit by batching operations. The RecordManaging generic extensions handle this
-  /// automatically.
-  ///
-  /// - Parameters:
-  ///   - operations: Array of record operations to execute
-  ///   - recordType: The record type being operated on (for reference/logging)
-  /// - Throws: CloudKit errors if the batch operations fail
   public func executeBatchOperations(
     _ operations: [RecordOperation],
     recordType: String
@@ -75,19 +61,12 @@ extension CloudKitService: RecordManaging {
   }
 
   /// Query all records of a specific type, automatically paginating
-  ///
-  /// This implementation uses `queryAllRecords` which follows continuation markers
-  /// to fetch all matching records across multiple pages.
-  ///
-  /// - Parameter recordType: The CloudKit record type to query
-  /// - Returns: Array of all matching records
-  /// - Throws: CloudKit errors if any page request fails
   public func queryAllRecords(recordType: String) async throws -> [RecordInfo] {
     try await self.queryAllRecords(
       recordType: recordType,
       filters: nil,
       sortBy: nil,
-      limit: nil
+      pageSize: nil
     )
   }
 }

--- a/Sources/MistKit/Service/QueryResult.swift
+++ b/Sources/MistKit/Service/QueryResult.swift
@@ -1,0 +1,53 @@
+//
+//  QueryResult.swift
+//  MistKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+/// Result from querying records
+///
+/// Contains the matching records along with an optional continuation marker
+/// for fetching the next page of results.
+public struct QueryResult: Codable, Sendable {
+  /// Records matching the query
+  public let records: [RecordInfo]
+  /// Marker to pass into the next query request to fetch the next page
+  public let continuationMarker: String?
+
+  /// Initialize a query result
+  public init(
+    records: [RecordInfo],
+    continuationMarker: String?
+  ) {
+    self.records = records
+    self.continuationMarker = continuationMarker
+  }
+
+  internal init(from response: Components.Schemas.QueryResponse) {
+    self.records = response.records?.compactMap { RecordInfo(from: $0) } ?? []
+    self.continuationMarker = response.continuationMarker
+  }
+}

--- a/Tests/MistKitTests/Protocols/RecordManagingTests+List.swift
+++ b/Tests/MistKitTests/Protocols/RecordManagingTests+List.swift
@@ -37,6 +37,10 @@ extension RecordManagingTests {
   internal struct List {
     @Test("list() calls queryRecords and doesn't throw")
     internal func listCallsQueryRecords() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("RecordManaging.list is not available on this operating system.")
+        return
+      }
       let service = MockRecordManagingService()
 
       await service.reset()

--- a/Tests/MistKitTests/Protocols/RecordManagingTests+Query.swift
+++ b/Tests/MistKitTests/Protocols/RecordManagingTests+Query.swift
@@ -37,6 +37,10 @@ extension RecordManagingTests {
   internal struct Query {
     @Test("query() returns parsed records")
     internal func queryReturnsParsedRecords() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("RecordManaging.query is not available on this operating system.")
+        return
+      }
       let service = MockRecordManagingService()
 
       // Set up mock data
@@ -79,6 +83,10 @@ extension RecordManagingTests {
 
     @Test("query() with filter applies filtering")
     internal func queryWithFilter() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("RecordManaging.query is not available on this operating system.")
+        return
+      }
       let service = MockRecordManagingService()
 
       await service.reset()
@@ -123,6 +131,10 @@ extension RecordManagingTests {
 
     @Test("query() filters out nil parse results")
     internal func queryFiltersOutInvalidRecords() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("RecordManaging.query is not available on this operating system.")
+        return
+      }
       let service = MockRecordManagingService()
 
       await service.reset()
@@ -164,6 +176,10 @@ extension RecordManagingTests {
 
     @Test("query() with no results returns empty array")
     internal func queryWithNoResults() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("RecordManaging.query is not available on this operating system.")
+        return
+      }
       let service = MockRecordManagingService()
 
       await service.reset()

--- a/Tests/MistKitTests/Service/CloudKitServiceQueryPagination/CloudKitServiceQueryPaginationTests+Helpers.swift
+++ b/Tests/MistKitTests/Service/CloudKitServiceQueryPagination/CloudKitServiceQueryPaginationTests+Helpers.swift
@@ -1,0 +1,123 @@
+//
+//  CloudKitServiceQueryPaginationTests+Helpers.swift
+//  MistKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import MistKit
+
+extension CloudKitServiceTests.QueryPagination {
+  private static let testAPIToken =
+    TestConstants.apiToken
+
+  @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+  internal static func makeSuccessfulService(
+    recordCount: Int = 2,
+    continuationMarker: String? = nil
+  ) throws -> CloudKitService {
+    let responseProvider = ResponseProvider(
+      defaultResponse: .successfulQueryResponse(
+        recordCount: recordCount,
+        continuationMarker: continuationMarker
+      )
+    )
+    let transport = MockTransport(responseProvider: responseProvider)
+    return try CloudKitService(
+      containerIdentifier: TestConstants.serviceContainerIdentifier,
+      apiToken: testAPIToken,
+      transport: transport
+    )
+  }
+
+  @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+  internal static func makePaginatedService(
+    pages: [(recordCount: Int, continuationMarker: String?)]
+  ) async throws -> CloudKitService {
+    let provider = ResponseProvider(
+      defaultResponse: .successfulQueryResponse()
+    )
+    for page in pages {
+      await provider.enqueue(
+        .successfulQueryResponse(
+          recordCount: page.recordCount,
+          continuationMarker: page.continuationMarker
+        ),
+        for: "queryRecords"
+      )
+    }
+    let transport = MockTransport(responseProvider: provider)
+    return try CloudKitService(
+      containerIdentifier: TestConstants.serviceContainerIdentifier,
+      apiToken: testAPIToken,
+      transport: transport
+    )
+  }
+}
+
+// MARK: - Query Pagination Response Builders
+
+extension ResponseConfig {
+  internal static func successfulQueryResponse(
+    recordCount: Int = 0,
+    continuationMarker: String? = nil
+  ) -> ResponseConfig {
+    var records: [[String: Any]] = []
+    for index in 0..<recordCount {
+      records.append([
+        "recordName": "record-\(index)",
+        "recordType": "TestRecord",
+        "recordChangeTag": "tag-\(index)",
+        "fields": [String: Any](),
+      ])
+    }
+
+    let recordsString =
+      (try? JSONSerialization.data(withJSONObject: records))
+      .flatMap { String(data: $0, encoding: .utf8) } ?? "[]"
+
+    var jsonParts = [String]()
+    jsonParts.append("\"records\": \(recordsString)")
+    if let marker = continuationMarker {
+      jsonParts.append("\"continuationMarker\": \"\(marker)\"")
+    }
+
+    let responseJSON = "{ \(jsonParts.joined(separator: ", ")) }"
+
+    var headers = HTTPFields()
+    headers[.contentType] = "application/json"
+
+    return ResponseConfig(
+      statusCode: 200,
+      headers: headers,
+      body: responseJSON.data(using: .utf8),
+      error: nil
+    )
+  }
+}

--- a/Tests/MistKitTests/Service/CloudKitServiceQueryPagination/CloudKitServiceQueryPaginationTests+Helpers.swift
+++ b/Tests/MistKitTests/Service/CloudKitServiceQueryPagination/CloudKitServiceQueryPaginationTests+Helpers.swift
@@ -43,7 +43,7 @@ extension CloudKitServiceTests.QueryPagination {
     continuationMarker: String? = nil
   ) throws -> CloudKitService {
     let responseProvider = ResponseProvider(
-      defaultResponse: .successfulQueryResponse(
+      defaultResponse: try .successfulQueryResponse(
         recordCount: recordCount,
         continuationMarker: continuationMarker
       )
@@ -61,11 +61,11 @@ extension CloudKitServiceTests.QueryPagination {
     pages: [(recordCount: Int, continuationMarker: String?)]
   ) async throws -> CloudKitService {
     let provider = ResponseProvider(
-      defaultResponse: .successfulQueryResponse()
+      defaultResponse: try .successfulQueryResponse()
     )
     for page in pages {
       await provider.enqueue(
-        .successfulQueryResponse(
+        try .successfulQueryResponse(
           recordCount: page.recordCount,
           continuationMarker: page.continuationMarker
         ),
@@ -87,7 +87,7 @@ extension ResponseConfig {
   internal static func successfulQueryResponse(
     recordCount: Int = 0,
     continuationMarker: String? = nil
-  ) -> ResponseConfig {
+  ) throws -> ResponseConfig {
     var records: [[String: Any]] = []
     for index in 0..<recordCount {
       records.append([
@@ -98,17 +98,12 @@ extension ResponseConfig {
       ])
     }
 
-    let recordsString =
-      (try? JSONSerialization.data(withJSONObject: records))
-      .flatMap { String(data: $0, encoding: .utf8) } ?? "[]"
-
-    var jsonParts = [String]()
-    jsonParts.append("\"records\": \(recordsString)")
+    var responseDict: [String: Any] = ["records": records]
     if let marker = continuationMarker {
-      jsonParts.append("\"continuationMarker\": \"\(marker)\"")
+      responseDict["continuationMarker"] = marker
     }
 
-    let responseJSON = "{ \(jsonParts.joined(separator: ", ")) }"
+    let bodyData = try JSONSerialization.data(withJSONObject: responseDict)
 
     var headers = HTTPFields()
     headers[.contentType] = "application/json"
@@ -116,7 +111,7 @@ extension ResponseConfig {
     return ResponseConfig(
       statusCode: 200,
       headers: headers,
-      body: responseJSON.data(using: .utf8),
+      body: bodyData,
       error: nil
     )
   }

--- a/Tests/MistKitTests/Service/CloudKitServiceQueryPagination/CloudKitServiceQueryPaginationTests+SuccessCases.swift
+++ b/Tests/MistKitTests/Service/CloudKitServiceQueryPagination/CloudKitServiceQueryPaginationTests+SuccessCases.swift
@@ -1,0 +1,208 @@
+//
+//  CloudKitServiceQueryPaginationTests+SuccessCases.swift
+//  MistKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import Foundation
+import Testing
+
+@testable import MistKit
+
+extension CloudKitServiceTests.QueryPagination {
+  @Suite("Success Cases")
+  internal struct SuccessCases {
+
+    // MARK: - queryRecords returning QueryResult
+
+    @Test("queryRecords() returns QueryResult with records and nil continuationMarker")
+    internal func queryRecordsReturnsQueryResultNoContinuation() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let service = try CloudKitServiceTests.QueryPagination.makeSuccessfulService(
+        recordCount: 3,
+        continuationMarker: nil
+      )
+
+      let result: QueryResult = try await service.queryRecords(
+        recordType: "TestRecord",
+        continuationMarker: nil
+      )
+
+      #expect(result.records.count == 3)
+      #expect(result.continuationMarker == nil)
+    }
+
+    @Test("queryRecords() returns QueryResult with continuationMarker")
+    internal func queryRecordsReturnsQueryResultWithContinuation() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let service = try CloudKitServiceTests.QueryPagination.makeSuccessfulService(
+        recordCount: 2,
+        continuationMarker: "marker-abc"
+      )
+
+      let result: QueryResult = try await service.queryRecords(
+        recordType: "TestRecord"
+      )
+
+      #expect(result.records.count == 2)
+      #expect(result.continuationMarker == "marker-abc")
+    }
+
+    @Test("queryRecords() with continuationMarker parameter returns next page")
+    internal func queryRecordsWithContinuationMarkerReturnsNextPage() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let service = try CloudKitServiceTests.QueryPagination.makeSuccessfulService(
+        recordCount: 1,
+        continuationMarker: nil
+      )
+
+      let result: QueryResult = try await service.queryRecords(
+        recordType: "TestRecord",
+        continuationMarker: "previous-marker"
+      )
+
+      #expect(result.records.count == 1)
+      #expect(result.continuationMarker == nil)
+    }
+
+    // MARK: - queryAllRecords
+
+    @Test("queryAllRecords() returns records when no pagination needed")
+    internal func queryAllRecordsNoPagination() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let service = try await CloudKitServiceTests.QueryPagination.makePaginatedService(
+        pages: [
+          (recordCount: 3, continuationMarker: nil)
+        ]
+      )
+
+      let records = try await service.queryAllRecords(recordType: "TestRecord")
+
+      #expect(records.count == 3)
+    }
+
+    @Test("queryAllRecords() accumulates records across two pages")
+    internal func queryAllRecordsMultiPage() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let service = try await CloudKitServiceTests.QueryPagination.makePaginatedService(
+        pages: [
+          (recordCount: 3, continuationMarker: "marker-1"),
+          (recordCount: 2, continuationMarker: nil),
+        ]
+      )
+
+      let records = try await service.queryAllRecords(recordType: "TestRecord")
+
+      #expect(records.count == 5)
+    }
+
+    @Test("queryAllRecords() accumulates records across three pages")
+    internal func queryAllRecordsThreePages() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let service = try await CloudKitServiceTests.QueryPagination.makePaginatedService(
+        pages: [
+          (recordCount: 2, continuationMarker: "marker-1"),
+          (recordCount: 3, continuationMarker: "marker-2"),
+          (recordCount: 1, continuationMarker: nil),
+        ]
+      )
+
+      let records = try await service.queryAllRecords(recordType: "TestRecord")
+
+      #expect(records.count == 6)
+    }
+
+    @Test("queryAllRecords() breaks on stuck marker (empty records, same marker)")
+    internal func queryAllRecordsStuckMarkerDetection() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      // First page returns records with a marker, second page returns no records
+      // but same marker (stuck). The method should break out of the loop.
+      let provider = ResponseProvider(
+        defaultResponse: .successfulQueryResponse(
+          recordCount: 0,
+          continuationMarker: "stuck-marker"
+        )
+      )
+      await provider.enqueue(
+        .successfulQueryResponse(
+          recordCount: 2,
+          continuationMarker: "stuck-marker"
+        ),
+        for: "queryRecords"
+      )
+      let transport = MockTransport(responseProvider: provider)
+      let service = try CloudKitService(
+        containerIdentifier: TestConstants.serviceContainerIdentifier,
+        apiToken: TestConstants.apiToken,
+        transport: transport
+      )
+
+      let records = try await service.queryAllRecords(recordType: "TestRecord")
+
+      // Should get the 2 records from page 1, then break on page 2 (stuck marker)
+      #expect(records.count == 2)
+    }
+
+    @Test("queryAllRecords() handles empty first page with continuation")
+    internal func queryAllRecordsEmptyFirstPage() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let service = try await CloudKitServiceTests.QueryPagination.makePaginatedService(
+        pages: [
+          (recordCount: 0, continuationMarker: "marker-1"),
+          (recordCount: 3, continuationMarker: nil),
+        ]
+      )
+
+      let records = try await service.queryAllRecords(recordType: "TestRecord")
+
+      #expect(records.count == 3)
+    }
+  }
+}

--- a/Tests/MistKitTests/Service/CloudKitServiceQueryPagination/CloudKitServiceQueryPaginationTests+SuccessCases.swift
+++ b/Tests/MistKitTests/Service/CloudKitServiceQueryPagination/CloudKitServiceQueryPaginationTests+SuccessCases.swift
@@ -35,7 +35,6 @@ import Testing
 extension CloudKitServiceTests.QueryPagination {
   @Suite("Success Cases")
   internal struct SuccessCases {
-
     // MARK: - queryRecords returning QueryResult
 
     @Test("queryRecords() returns QueryResult with records and nil continuationMarker")

--- a/Tests/MistKitTests/Service/CloudKitServiceQueryPagination/CloudKitServiceQueryPaginationTests+SuccessCases.swift
+++ b/Tests/MistKitTests/Service/CloudKitServiceQueryPagination/CloudKitServiceQueryPaginationTests+SuccessCases.swift
@@ -161,13 +161,13 @@ extension CloudKitServiceTests.QueryPagination {
       // First page returns records with a marker, second page returns no records
       // but same marker (stuck). The method should break out of the loop.
       let provider = ResponseProvider(
-        defaultResponse: .successfulQueryResponse(
+        defaultResponse: try .successfulQueryResponse(
           recordCount: 0,
           continuationMarker: "stuck-marker"
         )
       )
       await provider.enqueue(
-        .successfulQueryResponse(
+        try .successfulQueryResponse(
           recordCount: 2,
           continuationMarker: "stuck-marker"
         ),

--- a/Tests/MistKitTests/Service/CloudKitServiceQueryPagination/CloudKitServiceQueryPaginationTests.swift
+++ b/Tests/MistKitTests/Service/CloudKitServiceQueryPagination/CloudKitServiceQueryPaginationTests.swift
@@ -1,0 +1,38 @@
+//
+//  CloudKitServiceQueryPaginationTests.swift
+//  MistKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import Foundation
+import Testing
+
+@testable import MistKit
+
+extension CloudKitServiceTests {
+  @Suite("CloudKitService Query Pagination", .enabled(if: Platform.isCryptoAvailable))
+  internal enum QueryPagination {}
+}


### PR DESCRIPTION
## Summary

- Add `QueryResult` type with `records` and `continuationMarker` fields
- Expose `continuationMarker` parameter in `queryRecords` for manual pagination
- Add `queryAllRecords` auto-paginating convenience method following the `fetchAllRecordChanges` pattern (stuck-marker detection, max pages safeguard, cancellation support)
- Add `queryAllRecords(recordType:)` to `RecordManaging` protocol
- Update Bushel example to use `queryAllRecords` instead of hard-coded 200 limit
- Update Celestra `CloudKitRecordOperating` protocol with pagination support

## Test plan

- [x] `swift build` compiles cleanly
- [x] `swift test` — all 458 tests pass (including 8 new pagination tests)
- [x] `Scripts/lint.sh` — no new violations
- [ ] Verify single-page queries still work identically to before
- [ ] Verify multi-page auto-pagination with `queryAllRecords`
- [ ] Verify stuck-marker detection breaks the loop

Closes #145, closes #166, resolves #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/brightdigit/MistKit/306)
<!-- GitContextEnd -->