### PR TITLE
Resolve #313: paginationLimitExceeded carries accumulated records

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -11,7 +11,6 @@
 ### Error Handling
 * Improve error handling: typed TokenManagerError and safe RecordOperation conversion by @leogdion in https://github.com/brightdigit/MistKit/pull/305
 * Move CloudKitResponseType default implementations to protocol extension by @leogdion in https://github.com/brightdigit/MistKit/pull/292
-* **Breaking:** `CloudKitError.paginationLimitExceeded` now carries `records: [RecordInfo]` instead of `recordsCollected: Int`. When `queryAllRecords` / `fetchAllRecordChanges` exceed `maxPages`, callers can pattern-match the error to recover every record collected before the cap. `fetchAllRecordChanges` gains an explicit `maxPages:` parameter and no longer throws the generic `.invalidResponse` on overflow. Resolves [#313](https://github.com/brightdigit/MistKit/issues/313).
 
 ### Concurrency
 * Replace custom AsyncChannel with swift-async-algorithms by @leogdion in https://github.com/brightdigit/MistKit/pull/280

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -11,6 +11,7 @@
 ### Error Handling
 * Improve error handling: typed TokenManagerError and safe RecordOperation conversion by @leogdion in https://github.com/brightdigit/MistKit/pull/305
 * Move CloudKitResponseType default implementations to protocol extension by @leogdion in https://github.com/brightdigit/MistKit/pull/292
+* **Breaking:** `CloudKitError.paginationLimitExceeded` now carries `records: [RecordInfo]` instead of `recordsCollected: Int`. When `queryAllRecords` / `fetchAllRecordChanges` exceed `maxPages`, callers can pattern-match the error to recover every record collected before the cap. `fetchAllRecordChanges` gains an explicit `maxPages:` parameter and no longer throws the generic `.invalidResponse` on overflow. Resolves [#313](https://github.com/brightdigit/MistKit/issues/313).
 
 ### Concurrency
 * Replace custom AsyncChannel with swift-async-algorithms by @leogdion in https://github.com/brightdigit/MistKit/pull/280

--- a/Sources/MistKit/Service/Extensions/CloudKitService+QueryPagination.swift
+++ b/Sources/MistKit/Service/Extensions/CloudKitService+QueryPagination.swift
@@ -45,13 +45,16 @@ extension CloudKitService {
   ///     (1-200, defaults to `defaultQueryLimit`)
   ///   - desiredKeys: Optional array of field names to fetch
   ///   - maxPages: Maximum number of pages to fetch before throwing
-  ///     `CloudKitError.invalidResponse` (defaults to 1,000)
+  ///     `CloudKitError.paginationLimitExceeded` (defaults to 1,000)
   /// - Returns: Array of all matching records across all pages
-  /// - Throws: CloudKitError if any page request fails
+  /// - Throws: `CloudKitError`. When `maxPages` is exceeded, throws
+  ///   `.paginationLimitExceeded(maxPages:records:)` whose `records`
+  ///   payload contains every record collected before the cap was hit,
+  ///   so callers can resume or surface partial results.
   ///
   /// - Warning: Stops early if the server returns the same
   ///   continuation marker with no new records (stuck-marker
-  ///   scenario), or if the page count exceeds `maxPages`.
+  ///   scenario).
   public func queryAllRecords(
     recordType: String,
     filters: [QueryFilter]? = nil,
@@ -69,7 +72,7 @@ extension CloudKitService {
       guard pageCount < maxPages else {
         throw CloudKitError.paginationLimitExceeded(
           maxPages: maxPages,
-          recordsCollected: allRecords.count
+          records: allRecords
         )
       }
 

--- a/Sources/MistKit/Service/Extensions/CloudKitService+SyncOperations.swift
+++ b/Sources/MistKit/Service/Extensions/CloudKitService+SyncOperations.swift
@@ -135,8 +135,12 @@ extension CloudKitService {
   ///     (defaults to _defaultZone)
   ///   - syncToken: Optional token from previous fetch (nil = initial fetch)
   ///   - resultsLimit: Optional maximum records per request (1-200)
+  ///   - maxPages: Maximum number of pages to fetch before throwing
+  ///     `CloudKitError.paginationLimitExceeded` (defaults to 1,000)
   /// - Returns: Array of all changed records and final sync token
-  /// - Throws: CloudKitError if any fetch fails
+  /// - Throws: `CloudKitError`. When `maxPages` is exceeded, throws
+  ///   `.paginationLimitExceeded(maxPages:records:)` whose `records`
+  ///   payload contains every record collected before the cap was hit.
   ///
   /// Example:
   /// ```swift
@@ -153,7 +157,7 @@ extension CloudKitService {
   ///           with manual pagination for better memory control.
   /// - Warning: This method will stop early if the server repeatedly returns
   ///           `moreComing: true` with no records and the same sync token
-  ///           (stuck-token scenario), or if the page count exceeds 1000.
+  ///           (stuck-token scenario).
   /// - Note: Makes sequential requests with no backoff or cooperative
   ///         cancellation between pages. For fine-grained control,
   ///         use `fetchRecordChanges(syncToken:)` directly.
@@ -161,17 +165,20 @@ extension CloudKitService {
     zoneID: ZoneID? = nil,
     syncToken: String? = nil,
     resultsLimit: Int? = nil,
+    maxPages: Int = 1_000,
     database: Database = .public
   ) async throws(CloudKitError) -> (records: [RecordInfo], syncToken: String?) {
     var allRecords: [RecordInfo] = []
     var currentToken = syncToken
     var moreComing = true
     var pageCount = 0
-    let maxPages = 1_000
 
     while moreComing {
       guard pageCount < maxPages else {
-        throw CloudKitError.invalidResponse
+        throw CloudKitError.paginationLimitExceeded(
+          maxPages: maxPages,
+          records: allRecords
+        )
       }
 
       do {

--- a/Sources/MistKit/Service/Extensions/CloudKitService+SyncOperations.swift
+++ b/Sources/MistKit/Service/Extensions/CloudKitService+SyncOperations.swift
@@ -170,10 +170,10 @@ extension CloudKitService {
   ) async throws(CloudKitError) -> (records: [RecordInfo], syncToken: String?) {
     var allRecords: [RecordInfo] = []
     var currentToken = syncToken
-    var moreComing = true
+    var moreComing = false
     var pageCount = 0
 
-    while moreComing {
+    repeat {
       guard pageCount < maxPages else {
         throw CloudKitError.paginationLimitExceeded(
           maxPages: maxPages,
@@ -194,6 +194,7 @@ extension CloudKitService {
         database: database
       )
 
+      // Stuck-token detection
       if result.records.isEmpty && result.moreComing && result.syncToken == currentToken {
         break
       }
@@ -206,7 +207,7 @@ extension CloudKitService {
       currentToken = result.syncToken
       moreComing = result.moreComing
       pageCount += 1
-    }
+    } while moreComing
 
     return (allRecords, currentToken)
   }

--- a/Sources/MistKit/Service/ResponseProcessing/CloudKitError.swift
+++ b/Sources/MistKit/Service/ResponseProcessing/CloudKitError.swift
@@ -44,7 +44,7 @@ public enum CloudKitError: LocalizedError, Sendable {
   case decodingError(DecodingError)
   case networkError(URLError)
   case unsupportedOperationType(String)
-  case paginationLimitExceeded(maxPages: Int, recordsCollected: Int)
+  case paginationLimitExceeded(maxPages: Int, records: [RecordInfo])
   case missingCredentials(database: Database, reason: String)
   case invalidPrivateKey(path: String?, underlying: any Error)
 
@@ -123,10 +123,10 @@ public enum CloudKitError: LocalizedError, Sendable {
       return message
     case .unsupportedOperationType(let type):
       return "Unsupported record operation type: \(type)"
-    case .paginationLimitExceeded(let maxPages, let recordsCollected):
+    case .paginationLimitExceeded(let maxPages, let records):
       return
         "CloudKit query exceeded pagination limit of \(maxPages) pages "
-        + "(collected \(recordsCollected) records)"
+        + "(collected \(records.count) records)"
     case .missingCredentials(let database, let reason):
       return
         "Missing credentials for database '\(database.rawValue)': \(reason)"

--- a/Tests/MistKitTests/Service/CloudKitServiceFetchChanges/CloudKitServiceTests.FetchChanges+ErrorHandling.swift
+++ b/Tests/MistKitTests/Service/CloudKitServiceFetchChanges/CloudKitServiceTests.FetchChanges+ErrorHandling.swift
@@ -73,6 +73,56 @@ extension CloudKitServiceTests.FetchChanges {
       }
     }
 
+    @Test("fetchAllRecordChanges() throws paginationLimitExceeded carrying collected records")
+    internal func fetchAllOverflowReturnsAccumulatedRecords() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      // Three pages, each still indicating moreComing:true, so the loop would
+      // keep going. With maxPages:2 the third page triggers the cap and we
+      // expect the records from pages 1 and 2 to come back inside the error.
+      let provider = ResponseProvider(
+        defaultResponse: try .successfulFetchChangesResponse(
+          recordCount: 0,
+          moreComing: true,
+          syncToken: "default-token"
+        )
+      )
+      await provider.enqueue(
+        try .successfulFetchChangesResponse(
+          recordCount: 3,
+          moreComing: true,
+          syncToken: "token-1"
+        ),
+        for: "fetchRecordChanges"
+      )
+      await provider.enqueue(
+        try .successfulFetchChangesResponse(
+          recordCount: 2,
+          moreComing: true,
+          syncToken: "token-2"
+        ),
+        for: "fetchRecordChanges"
+      )
+      let service = try CloudKitServiceTests.makeService(provider: provider)
+
+      do {
+        _ = try await service.fetchAllRecordChanges(maxPages: 2)
+        Issue.record("Expected paginationLimitExceeded to be thrown")
+      } catch CloudKitError.paginationLimitExceeded(let maxPages, let records) {
+        #expect(maxPages == 2)
+        #expect(records.count == 5)
+        #expect(
+          records.map(\.recordName) == [
+            "record-0", "record-1", "record-2",
+            "record-0", "record-1",
+          ])
+      } catch {
+        Issue.record("Expected paginationLimitExceeded, got \(error)")
+      }
+    }
+
     @Test("fetchAllRecordChanges() propagates a mid-pagination network failure")
     internal func fetchAllPropagatesMidPaginationFailure() async throws {
       guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {

--- a/Tests/MistKitTests/Service/CloudKitServiceQueryPagination/CloudKitServiceTests.QueryPagination+ErrorCases.swift
+++ b/Tests/MistKitTests/Service/CloudKitServiceQueryPagination/CloudKitServiceTests.QueryPagination+ErrorCases.swift
@@ -1,0 +1,71 @@
+//
+//  CloudKitServiceTests.QueryPagination+ErrorCases.swift
+//  MistKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import Foundation
+import Testing
+
+@testable import MistKit
+
+extension CloudKitServiceTests.QueryPagination {
+  @Suite("Error Cases")
+  internal struct ErrorCases {
+    @Test("queryAllRecords() throws paginationLimitExceeded carrying collected records")
+    internal func queryAllRecordsOverflowReturnsAccumulatedRecords() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let service = try await CloudKitServiceTests.QueryPagination.makePaginatedService(
+        pages: [
+          (recordCount: 3, continuationMarker: "marker-1"),
+          (recordCount: 2, continuationMarker: "marker-2"),
+          (recordCount: 5, continuationMarker: "marker-3"),
+        ]
+      )
+
+      do {
+        _ = try await service.queryAllRecords(
+          recordType: "TestRecord",
+          maxPages: 2
+        )
+        Issue.record("Expected paginationLimitExceeded to be thrown")
+      } catch CloudKitError.paginationLimitExceeded(let maxPages, let records) {
+        #expect(maxPages == 2)
+        #expect(records.count == 5)
+        #expect(
+          records.map(\.recordName) == [
+            "record-0", "record-1", "record-2",
+            "record-0", "record-1",
+          ])
+      } catch {
+        Issue.record("Expected paginationLimitExceeded, got \(error)")
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Resolves #313 ("MaxPage Error Should Return Results too."), which spun out of [review comment #r3210049916](https://github.com/brightdigit/MistKit/pull/309#discussion_r3210049916) on `queryAllRecords`. When MistKit's auto-paginating helpers hit their `maxPages` cap, they used to throw an error that dropped the partial result. Callers had to start over or accept silent data loss. Now the error carries every record collected before the cap so callers can resume or surface partial results.

- **Breaking — `CloudKitError.paginationLimitExceeded`**: case shape changes from `(maxPages: Int, recordsCollected: Int)` to `(maxPages: Int, records: [RecordInfo])`. `errorDescription` keeps the same wording via `records.count`.
- **`queryAllRecords`** throws with `records: allRecords`. Docstring corrected — it previously claimed the throw was `.invalidResponse`.
- **`fetchAllRecordChanges`** gains an explicit `maxPages:` parameter (default 1 000, was a hard-coded local) and now throws `.paginationLimitExceeded` on overflow instead of `.invalidResponse`. Existing callers continue to work — `maxPages` is defaulted.
- Tests in `CloudKitServiceQueryPagination/+ErrorCases.swift` and `CloudKitServiceFetchChanges/+ErrorHandling.swift` drive the overflow path with `maxPages: 2` and assert the carried records.
- `ReleaseNotes.md` flags this under v1.0.0-beta.1.

The PR #298 review (which inspired the work) was largely addressed in commit 7a5da7a already; verified by reading the current files. The one nit left was the `queryAllRecords` `maxPages` docstring claiming `.invalidResponse` — fixed here next to the code change.

## Test plan

- [x] `swift build` from repo root — clean (only pre-existing import warnings)
- [x] `swift test` — 483 MistKit tests pass (incl. two new overflow tests)
- [x] `cd Examples/MistDemo && swift test` — 901 tests pass
- [x] `cd Examples/CelestraCloud && swift build` — clean (its `.paginationLimitExceeded` switch case has no value bindings, so the shape change is invisible)
- [x] `cd Examples/BushelCloud && swift build` — clean
- [x] `./Scripts/lint.sh` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/brightdigit/MistKit/326)
<!-- GitContextEnd -->