### PR TITLE
Resolve #329: CloudKit JS alternate backend + browser-flag defaults

### DIFF
--- a/Examples/MistDemo/README.md
+++ b/Examples/MistDemo/README.md
@@ -68,9 +68,12 @@ Or via env var:
 CLOUDKIT_API_TOKEN=… swift run mistdemo web
 ```
 
-The CLI prints the server URL and opens your browser automatically.
-Sign in with your Apple ID; the server captures the web-auth token and
-the CRUD UI on the page becomes live.
+The CLI prints the server URL. The `web` command does **not** open the
+browser by default (the server is long-running and often driven from a
+different machine); pass `--browser` to opt in. The `auth-token` command
+**does** open the browser by default — the captured token is the whole
+point of running it. Sign in with your Apple ID; the server captures the
+web-auth token and the CRUD UI on the page becomes live.
 
 ### Options
 
@@ -81,11 +84,12 @@ the CRUD UI on the page becomes live.
 | `--environment <env>` | `development` | `development` or `production` |
 | `--host <host>` | `127.0.0.1` | Bind address |
 | `--port <port>` | `8080` | Server port |
-| `--no-browser` | off | Don't auto-open the browser |
+| `--browser` | on for `auth-token`, off for `web` | Open browser on startup |
+| `--no-browser` | — | Suppress the open (wins if both flags set) |
 
 Configuration is read via `MistDemoConfiguration`, so the same keys
 (`api.token`, `container.identifier`, `environment`, `port`, `host`,
-`no.browser`) can be supplied through `--config-file ~/.mistdemo/config.json`
+`browser`, `no.browser`) can be supplied through `--config-file ~/.mistdemo/config.json`
 or environment variables.
 
 ### What the server exposes

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/AuthTokenCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/AuthTokenCommand.swift
@@ -54,7 +54,8 @@
         --environment <env>      development (default) | production
         --port <port>            Server port (default: 8080)
         --host <host>            Server host (default: 127.0.0.1)
-        --no-browser             Don't open browser automatically
+        --browser                Open browser on startup (default for auth-token)
+        --no-browser             Don't open browser on startup (overrides --browser)
       """
 
     internal let config: AuthTokenConfig
@@ -69,7 +70,7 @@
       tokenStore: WebAuthTokenStore,
       host: String,
       port: Int,
-      noBrowser: Bool
+      openBrowser: Bool
     ) async throws -> String {
       do {
         return try await withTimeoutAndSignals(seconds: 300) {
@@ -79,7 +80,7 @@
               return nil
             }
             group.addTask {
-              if !noBrowser {
+              if openBrowser {
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
                 BrowserOpener.openBrowser(url: "http://\(host):\(port)")
               }
@@ -135,7 +136,7 @@
         tokenStore: tokenStore,
         host: config.host,
         port: config.port,
-        noBrowser: config.noBrowser
+        openBrowser: config.openBrowser
       )
 
       // Let the 205 response reach the browser before the process exits.

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/WebCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/WebCommand.swift
@@ -60,7 +60,8 @@
         --environment <env>      development (default) | production
         --port <port>            Server port (default: 8080)
         --host <host>            Server host (default: 127.0.0.1)
-        --no-browser             Don't open browser automatically
+        --browser                Open browser on startup (overrides default)
+        --no-browser             Don't open browser on startup (default for web)
 
       The page authenticates against CloudKit via the browser, then
       exposes a CRUD UI that calls MistKit on the server. Ctrl+C to exit.
@@ -114,7 +115,7 @@
     }
 
     private func openBrowserIfNeeded() async {
-      guard !config.noBrowser else {
+      guard config.openBrowser else {
         return
       }
       try? await Task.sleep(nanoseconds: 1_000_000_000)

--- a/Examples/MistDemo/Sources/MistDemoKit/Configuration/AuthTokenConfig.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Configuration/AuthTokenConfig.swift
@@ -48,8 +48,11 @@ public struct AuthTokenConfig: Sendable, ConfigurationParseable {
   public let port: Int
   /// The server host for authentication.
   public let host: String
-  /// Whether to skip opening the browser.
-  public let noBrowser: Bool
+  /// Whether to open the browser to the demo URL on startup.
+  /// Defaults to `true` for `auth-token` — the captured token is the
+  /// command's whole reason for existing, so a hands-off flow is the
+  /// expected UX.
+  public let openBrowser: Bool
 
   /// Creates a new instance.
   public init(
@@ -59,14 +62,14 @@ public struct AuthTokenConfig: Sendable, ConfigurationParseable {
     environment: MistKit.Environment = .development,
     port: Int = 8_080,
     host: String = "127.0.0.1",
-    noBrowser: Bool = false
+    openBrowser: Bool = true
   ) {
     self.apiToken = apiToken
     self.containerIdentifier = containerIdentifier
     self.environment = environment
     self.port = port
     self.host = host
-    self.noBrowser = noBrowser
+    self.openBrowser = openBrowser
   }
 
   /// Parse configuration from command line arguments.
@@ -107,8 +110,10 @@ public struct AuthTokenConfig: Sendable, ConfigurationParseable {
     let host =
       configReader.string(forKey: "host", default: "127.0.0.1")
       ?? "127.0.0.1"
-    let noBrowser =
-      configReader.bool(forKey: "no.browser", default: false)
+    let openBrowser = BrowserFlagResolver.resolve(
+      configReader: configReader,
+      default: true
+    )
 
     self.init(
       apiToken: apiToken,
@@ -116,7 +121,7 @@ public struct AuthTokenConfig: Sendable, ConfigurationParseable {
       environment: environment,
       port: port,
       host: host,
-      noBrowser: noBrowser
+      openBrowser: openBrowser
     )
   }
 }

--- a/Examples/MistDemo/Sources/MistDemoKit/Configuration/BrowserFlagResolver.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Configuration/BrowserFlagResolver.swift
@@ -1,6 +1,6 @@
 //
-//  AuthTokenCommandTests+Configuration.swift
-//  MistDemoTests
+//  BrowserFlagResolver.swift
+//  MistDemo
 //
 //  Created by Leo Dion.
 //  Copyright © 2026 BrightDigit.
@@ -27,39 +27,27 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if canImport(Hummingbird)
-  import Foundation
-  import Testing
+import Foundation
 
-  @testable import MistDemoKit
-
-  extension AuthTokenCommandTests {
-    @Suite("Configuration")
-    internal struct Configuration {
-      @Test("AuthTokenConfig initializes with default values")
-      internal func authTokenConfigInitializesWithDefaults() {
-        let config = AuthTokenConfig(apiToken: "test-token")
-
-        #expect(config.apiToken == "test-token")
-        #expect(config.port == 8_080)
-        #expect(config.host == "127.0.0.1")
-        #expect(config.openBrowser == true)
-      }
-
-      @Test("AuthTokenConfig accepts custom values")
-      internal func authTokenConfigAcceptsCustomValues() {
-        let config = AuthTokenConfig(
-          apiToken: "custom-token",
-          port: 3_000,
-          host: "localhost",
-          openBrowser: false
-        )
-
-        #expect(config.apiToken == "custom-token")
-        #expect(config.port == 3_000)
-        #expect(config.host == "localhost")
-        #expect(config.openBrowser == false)
-      }
+/// Resolves the "should we open the browser on startup?" decision from
+/// the two mutually-exclusive CLI flags into a single boolean.
+///
+/// - `--no-browser` sets `no.browser=true` → resolves to `false` (wins).
+/// - `--browser` sets `browser=true` → resolves to `true`.
+/// - Neither set → falls back to the per-command default.
+internal enum BrowserFlagResolver {
+  internal static func resolve(
+    configReader: MistDemoConfiguration,
+    default defaultValue: Bool
+  ) -> Bool {
+    let noBrowser = configReader.bool(forKey: "no.browser", default: false)
+    if noBrowser {
+      return false
     }
+    let browser = configReader.bool(forKey: "browser", default: false)
+    if browser {
+      return true
+    }
+    return defaultValue
   }
-#endif
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Configuration/WebConfig.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Configuration/WebConfig.swift
@@ -52,8 +52,11 @@ public struct WebConfig: Sendable, ConfigurationParseable {
   public let port: Int
   /// The server host.
   public let host: String
-  /// Whether to skip opening the browser.
-  public let noBrowser: Bool
+  /// Whether to open the browser to the demo URL on startup.
+  /// Defaults to `false` for `web` — the long-running server is often
+  /// driven from another machine (or a non-default browser), so silent
+  /// startup is the safer UX. Override with `--browser`.
+  public let openBrowser: Bool
 
   /// Creates a new instance.
   public init(
@@ -62,14 +65,14 @@ public struct WebConfig: Sendable, ConfigurationParseable {
     environment: MistKit.Environment = .development,
     port: Int = 8_080,
     host: String = "127.0.0.1",
-    noBrowser: Bool = false
+    openBrowser: Bool = false
   ) {
     self.apiToken = apiToken
     self.containerIdentifier = containerIdentifier
     self.environment = environment
     self.port = port
     self.host = host
-    self.noBrowser = noBrowser
+    self.openBrowser = openBrowser
   }
 
   /// Parse configuration from command line arguments.
@@ -107,8 +110,10 @@ public struct WebConfig: Sendable, ConfigurationParseable {
     let host =
       configReader.string(forKey: "host", default: "127.0.0.1")
       ?? "127.0.0.1"
-    let noBrowser =
-      configReader.bool(forKey: "no.browser", default: false)
+    let openBrowser = BrowserFlagResolver.resolve(
+      configReader: configReader,
+      default: false
+    )
 
     self.init(
       apiToken: apiToken,
@@ -116,7 +121,7 @@ public struct WebConfig: Sendable, ConfigurationParseable {
       environment: environment,
       port: port,
       host: host,
-      noBrowser: noBrowser
+      openBrowser: openBrowser
     )
   }
 }

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/index.html
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/index.html
@@ -130,11 +130,13 @@
             <h2>Backend</h2>
             <div class="mode-toggle">
                 <button id="mode-mistkit" class="active" type="button">MistKit (server)</button>
-                <button id="mode-cloudkitjs" type="button" disabled>CloudKit JS (browser)</button>
+                <button id="mode-cloudkitjs" type="button">CloudKit JS (browser)</button>
             </div>
             <div class="mode-hint" id="mode-hint">
-                MistKit mode routes through Hummingbird → CloudKit Web Services. CloudKit JS
-                mode (browser → CloudKit Web Services) is wired in by #329.
+                MistKit mode routes browser → Hummingbird → CloudKit Web Services.
+                CloudKit JS mode routes browser → CloudKit Web Services directly.
+                Both share the same Apple ID session token, hit the same container,
+                and exercise the same REST surface — only the SDK shape differs.
             </div>
 
             <h2 style="margin-top: 24px;">Auth</h2>
@@ -302,8 +304,52 @@
             }
         }
 
-        function cloudKitJsNotWired(label, statusEl) {
-            setStatus(statusEl, `${label} via CloudKit JS is not wired yet — see #329.`, 'error');
+        function ckJsDatabase() {
+            return container.privateCloudDatabase;
+        }
+
+        // CloudKit JS expects field values as { key: { value: ... } } while the
+        // MistKit-mode endpoints accept the flat { key: "value" } shape this
+        // demo's textareas already produce — wrap before saveRecords.
+        function fieldsToCKJS(fields) {
+            const wrapped = {};
+            for (const [k, v] of Object.entries(fields)) {
+                wrapped[k] = { value: v };
+            }
+            return wrapped;
+        }
+
+        async function runCloudKitJsOperation(label, work, statusEl, resultEl) {
+            clearStatus(statusEl);
+            resultEl.style.display = 'none';
+            try {
+                const data = await work();
+                if (data && data.hasErrors && data.errors && data.errors.length) {
+                    const first = data.errors[0];
+                    const message = (first && (first.reason || first.serverErrorCode))
+                        || 'CloudKit JS reported an error';
+                    setStatus(statusEl, `${label} failed: ${message}`, 'error');
+                    showResult(resultEl, data);
+                    return;
+                }
+                setStatus(statusEl, `${label} succeeded.`, 'success');
+                showResult(resultEl, data);
+            } catch (error) {
+                const message = (error && error.message) || String(error);
+                setStatus(statusEl, `${label} failed: ${message}`, 'error');
+                if (error && typeof error === 'object') showResult(resultEl, error);
+            }
+        }
+
+        async function fetchRecordChangeTag(recordName) {
+            const result = await ckJsDatabase().fetchRecords([{ recordName }]);
+            if (result.hasErrors && result.errors.length) {
+                const first = result.errors[0];
+                throw new Error((first && first.reason) || 'fetchRecords failed');
+            }
+            const record = result.records && result.records[0];
+            if (!record) throw new Error(`Record "${recordName}" not found`);
+            return record.recordChangeTag;
         }
 
         document.getElementById('query-btn').addEventListener('click', async () => {
@@ -311,20 +357,33 @@
             const limit = parseInt(document.getElementById('query-limit').value, 10);
             const statusEl = document.getElementById('query-status');
             const resultEl = document.getElementById('query-result');
-            if (currentMode !== 'mistkit') return cloudKitJsNotWired('Query', statusEl);
-            await runMistKitOperation('Query', '/api/records/query', {
-                recordType, limit: isFinite(limit) ? limit : undefined,
-            }, statusEl, resultEl);
+            if (currentMode === 'mistkit') {
+                await runMistKitOperation('Query', '/api/records/query', {
+                    recordType, limit: isFinite(limit) ? limit : undefined,
+                }, statusEl, resultEl);
+                return;
+            }
+            await runCloudKitJsOperation('Query', () =>
+                ckJsDatabase().performQuery({ recordType }, {
+                    resultsLimit: isFinite(limit) ? limit : undefined,
+                }),
+                statusEl, resultEl);
         });
 
         document.getElementById('create-btn').addEventListener('click', async () => {
             const recordType = document.getElementById('create-record-type').value.trim();
             const statusEl = document.getElementById('create-status');
             const resultEl = document.getElementById('create-result');
-            if (currentMode !== 'mistkit') return cloudKitJsNotWired('Create', statusEl);
             const fields = parseFieldsJSON(document.getElementById('create-fields').value, statusEl);
             if (!fields) return;
-            await runMistKitOperation('Create', '/api/records/create', { recordType, fields }, statusEl, resultEl);
+            if (currentMode === 'mistkit') {
+                await runMistKitOperation('Create', '/api/records/create',
+                    { recordType, fields }, statusEl, resultEl);
+                return;
+            }
+            await runCloudKitJsOperation('Create', () =>
+                ckJsDatabase().saveRecords([{ recordType, fields: fieldsToCKJS(fields) }]),
+                statusEl, resultEl);
         });
 
         document.getElementById('update-btn').addEventListener('click', async () => {
@@ -332,15 +391,24 @@
             const recordName = document.getElementById('update-record-name').value.trim();
             const statusEl = document.getElementById('update-status');
             const resultEl = document.getElementById('update-result');
-            if (currentMode !== 'mistkit') return cloudKitJsNotWired('Update', statusEl);
             if (!recordName) {
                 setStatus(statusEl, 'Record name is required.', 'error');
                 return;
             }
             const fields = parseFieldsJSON(document.getElementById('update-fields').value, statusEl);
             if (!fields) return;
-            await runMistKitOperation('Update', '/api/records/update', {
-                recordType, recordName, fields,
+            if (currentMode === 'mistkit') {
+                await runMistKitOperation('Update', '/api/records/update', {
+                    recordType, recordName, fields,
+                }, statusEl, resultEl);
+                return;
+            }
+            await runCloudKitJsOperation('Update', async () => {
+                const recordChangeTag = await fetchRecordChangeTag(recordName);
+                return ckJsDatabase().saveRecords([{
+                    recordType, recordName, recordChangeTag,
+                    fields: fieldsToCKJS(fields),
+                }]);
             }, statusEl, resultEl);
         });
 
@@ -349,12 +417,18 @@
             const recordName = document.getElementById('delete-record-name').value.trim();
             const statusEl = document.getElementById('delete-status');
             const resultEl = document.getElementById('delete-result');
-            if (currentMode !== 'mistkit') return cloudKitJsNotWired('Delete', statusEl);
             if (!recordName) {
                 setStatus(statusEl, 'Record name is required.', 'error');
                 return;
             }
-            await runMistKitOperation('Delete', '/api/records/delete', { recordType, recordName }, statusEl, resultEl);
+            if (currentMode === 'mistkit') {
+                await runMistKitOperation('Delete', '/api/records/delete',
+                    { recordType, recordName }, statusEl, resultEl);
+                return;
+            }
+            await runCloudKitJsOperation('Delete', () =>
+                ckJsDatabase().deleteRecords([{ recordName }]),
+                statusEl, resultEl);
         });
 
         // ---- auth flow ----

--- a/Examples/MistDemo/Tests/MistDemoTests/Commands/CommandIntegration/CommandIntegrationTests+AuthTokenCommandIntegration.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Commands/CommandIntegration/CommandIntegrationTests+AuthTokenCommandIntegration.swift
@@ -43,7 +43,7 @@
           apiToken: "test-api-token-123",
           port: 8_080,
           host: "127.0.0.1",
-          noBrowser: true
+          openBrowser: false
         )
 
         _ = AuthTokenCommand(config: config)

--- a/Examples/MistDemo/Tests/MistDemoTests/Commands/CommandIntegration/CommandIntegrationTests+RealWorldUsageSimulation.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Commands/CommandIntegration/CommandIntegrationTests+RealWorldUsageSimulation.swift
@@ -46,7 +46,7 @@ extension CommandIntegrationTests {
       #if canImport(Hummingbird)
         let authConfig = AuthTokenConfig(
           apiToken: "mock-api-token-for-test",
-          noBrowser: true
+          openBrowser: false
         )
         _ = AuthTokenCommand(config: authConfig)
       #endif

--- a/Examples/MistDemo/Tests/MistDemoTests/Configuration/AuthTokenConfigTests.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Configuration/AuthTokenConfigTests.swift
@@ -50,7 +50,7 @@ internal struct AuthTokenConfigTests {
     return MistDemoConfiguration(testProvider: InMemoryProvider(values: mapped))
   }
 
-  @Test("Memberwise init applies defaults for port, host, noBrowser, container")
+  @Test("Memberwise init applies defaults for port, host, openBrowser, container")
   internal func memberwiseDefaults() {
     let config = AuthTokenConfig(apiToken: "tok")
 
@@ -59,7 +59,8 @@ internal struct AuthTokenConfigTests {
     #expect(config.environment == .development)
     #expect(config.port == 8_080)
     #expect(config.host == "127.0.0.1")
-    #expect(config.noBrowser == false)
+    // auth-token defaults to opening the browser.
+    #expect(config.openBrowser == true)
   }
 
   @Test("Memberwise init accepts custom values for every field")
@@ -70,7 +71,7 @@ internal struct AuthTokenConfigTests {
       environment: .production,
       port: 9_000,
       host: "0.0.0.0",
-      noBrowser: true
+      openBrowser: false
     )
 
     #expect(config.apiToken == "tok")
@@ -78,7 +79,7 @@ internal struct AuthTokenConfigTests {
     #expect(config.environment == .production)
     #expect(config.port == 9_000)
     #expect(config.host == "0.0.0.0")
-    #expect(config.noBrowser == true)
+    #expect(config.openBrowser == false)
   }
 
   @Test("Configuration init throws missingRequired when api.token is absent")
@@ -114,7 +115,7 @@ internal struct AuthTokenConfigTests {
     #expect(config.environment == .development)
     #expect(config.port == 8_080)
     #expect(config.host == "127.0.0.1")
-    #expect(config.noBrowser == false)
+    #expect(config.openBrowser == true)
   }
 
   @Test("Configuration init honors every override key")
@@ -135,7 +136,20 @@ internal struct AuthTokenConfigTests {
     #expect(config.environment == .production)
     #expect(config.port == 9_090)
     #expect(config.host == "192.168.1.10")
-    #expect(config.noBrowser == true)
+    #expect(config.openBrowser == false)
+  }
+
+  @Test("--no-browser wins when both browser flags are set")
+  internal func noBrowserWinsOverBrowser() async throws {
+    let configuration = Self.configuration(values: [
+      "api.token": .init(stringLiteral: "tok-xyz"),
+      "browser": .init(booleanLiteral: true),
+      "no.browser": .init(booleanLiteral: true),
+    ])
+
+    let config = try await AuthTokenConfig(configuration: configuration)
+
+    #expect(config.openBrowser == false)
   }
 
   @Test("Configuration init throws on invalid environment")

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+Index.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+Index.swift
@@ -1,0 +1,74 @@
+//
+//  WebServerTests+Index.swift
+//  MistDemoTests
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if canImport(Hummingbird)
+  import Foundation
+  import HTTPTypes
+  import Hummingbird
+  import HummingbirdTesting
+  import MistKit
+  import Testing
+
+  @testable import MistDemoKit
+
+  extension WebServerTests {
+    @Test("GET / returns the web demo HTML")
+    internal func indexReturnsHtml() async throws {
+      let fixture = Self.makeFixture()
+      let app = Application(router: try fixture.server.makeRouter())
+
+      try await app.test(.router) { client in
+        try await client.execute(uri: "/", method: .get) { response in
+          #expect(response.status == .ok)
+          let body = String(buffer: response.body)
+          #expect(body.contains("MistKit Web Demo"))
+        }
+      }
+    }
+
+    @Test("Index HTML wires CloudKit JS as an alternate backend")
+    internal func indexExposesCloudKitJsHandlers() async throws {
+      let fixture = Self.makeFixture()
+      let app = Application(router: try fixture.server.makeRouter())
+
+      try await app.test(.router) { client in
+        try await client.execute(uri: "/", method: .get) { response in
+          #expect(response.status == .ok)
+          let body = String(buffer: response.body)
+          #expect(body.contains("cdn.apple-cloudkit.com/ck/2/cloudkit.js"))
+          #expect(!body.contains("id=\"mode-cloudkitjs\" type=\"button\" disabled"))
+          #expect(body.contains("performQuery"))
+          #expect(body.contains("saveRecords"))
+          #expect(body.contains("deleteRecords"))
+          #expect(!body.contains("cloudKitJsNotWired"))
+        }
+      }
+    }
+  }
+#endif

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests.swift
@@ -71,20 +71,6 @@
       return Fixture(server: server, tokenStore: store, backend: backend)
     }
 
-    @Test("GET / returns the web demo HTML")
-    internal func indexReturnsHtml() async throws {
-      let fixture = Self.makeFixture()
-      let app = Application(router: try fixture.server.makeRouter())
-
-      try await app.test(.router) { client in
-        try await client.execute(uri: "/", method: .get) { response in
-          #expect(response.status == .ok)
-          let body = String(buffer: response.body)
-          #expect(body.contains("MistKit Web Demo"))
-        }
-      }
-    }
-
     @Test("GET /api/config returns container + environment")
     internal func configIncludesEnvironment() async throws {
       let fixture = Self.makeFixture()


### PR DESCRIPTION
## Summary

- **#329** — wire CloudKit JS as the alternate web backend behind the existing mode toggle. The toggle button is now enabled and each CRUD operation (query/create/update/delete) calls `container.privateCloudDatabase` directly when CloudKit JS mode is active. Same Apple ID session token, same container, same REST surface as MistKit mode — only the SDK shape differs.
- **Browser-flag UX** — `auth-token` keeps its default of auto-opening the browser; `web` flips to **not** auto-opening (long-running server, often driven from another machine). Both commands accept `--browser` and `--no-browser`; `--no-browser` wins if both are set.

## Test plan
- [x] `swift test` from `Examples/MistDemo` — 920 tests pass.
- [x] `swift test` from repo root — 483 tests pass.
- [x] `mise exec -- swift-format -i -r Sources/ Tests/` — clean.
- [x] `mise exec -- swiftlint` — 0 violations in 487 files.
- [ ] Manual: `swift run mistdemo web --api-token "$CLOUDKIT_API_TOKEN" --browser` opens browser, both mode toggle buttons work, CRUD operations succeed in both modes against the same container.
- [ ] Manual: `swift run mistdemo auth-token --api-token "$CLOUDKIT_API_TOKEN"` still opens the browser by default; `--no-browser` suppresses it.

## Out of scope

- Public-DB asymmetry teaching point in the UI — that lands with #275's DB picker.
- UI refinement — planned as a follow-up branch on top of `330-interactive-mistdemo` before #275 starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/brightdigit/MistKit/335)
<!-- GitContextEnd -->