### PR TITLE
WebUI: table+form rework, system-metadata timestamps, sortable Created/Modified

### DIFF
--- a/Examples/MistDemo/README.md
+++ b/Examples/MistDemo/README.md
@@ -176,7 +176,7 @@ A SwiftUI demo app that talks to the same CloudKit container, but uses
 - **iCloud Account view** — `CKContainer.accountStatus()`
 - **Zones list** — `CKDatabase.allRecordZones()` (parity with `mistdemo lookup-zones`)
 - **Notes query** — `CKDatabase.records(matching:)` for `Note` records, sorted by `index`
-- **Note detail** — typed view of `title`, `index`, `image`, `createdAt`, `modified`
+- **Note detail** — typed view of `title`, `index`, `image`; created/modified come from CloudKit system metadata
 - **Create / update / delete** — `CKDatabase.save(_:)` and `deleteRecord(withID:)`
 
 The `Note` model in `Sources/MistDemoApp/Models/CloudKitModels.swift`

--- a/Examples/MistDemo/Sources/MistDemoApp/Models/Note.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Models/Note.swift
@@ -34,20 +34,20 @@
   /// Note record, mirroring the `Note` type defined in `schema.ckdb`:
   ///
   ///     RECORD TYPE Note (
-  ///         "title"     STRING    QUERYABLE SORTABLE SEARCHABLE,
-  ///         "index"     INT64     QUERYABLE SORTABLE,
-  ///         "image"     ASSET,
-  ///         "createdAt" TIMESTAMP QUERYABLE SORTABLE,
-  ///         "modified"  INT64     QUERYABLE
+  ///         "title" STRING    QUERYABLE SORTABLE SEARCHABLE,
+  ///         "index" INT64     QUERYABLE SORTABLE,
+  ///         "image" ASSET
   ///     );
+  ///
+  /// Created / modified timestamps come from CloudKit's system metadata
+  /// (`CKRecord.creationDate` / `.modificationDate`), so there's no need
+  /// for custom `createdAt` / `modified` schema fields.
   internal struct Note: Identifiable, Hashable {
     /// Known field name constants for `Note` records.
     internal enum Fields {
       internal static let title = "title"
       internal static let index = "index"
       internal static let image = "image"
-      internal static let createdAt = "createdAt"
-      internal static let modified = "modified"
     }
 
     /// CloudKit record type identifier.
@@ -57,8 +57,6 @@
     internal let title: String?
     internal let index: Int64?
     internal let imageAssetURL: URL?
-    internal let createdAt: Date?
-    internal let modified: Int64?
 
     /// CloudKit-managed metadata
     internal let modificationDate: Date?
@@ -73,8 +71,6 @@
       self.title = record[Fields.title] as? String
       self.index = (record[Fields.index] as? NSNumber)?.int64Value
       self.imageAssetURL = (record[Fields.image] as? CKAsset)?.fileURL
-      self.createdAt = record[Fields.createdAt] as? Date
-      self.modified = (record[Fields.modified] as? NSNumber)?.int64Value
       self.modificationDate = record.modificationDate
       self.creationDate = record.creationDate
       self.recordChangeTag = record.recordChangeTag

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/NativeCloudKitService.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/NativeCloudKitService.swift
@@ -58,7 +58,9 @@
       self.container = CKContainer(identifier: containerIdentifier)
     }
 
-    /// Apply the editable fields onto a CKRecord. Always refreshes `modified`.
+    /// Apply the editable fields onto a CKRecord. CloudKit's system metadata
+    /// (`creationDate`, `modificationDate`) is refreshed by the server on save,
+    /// so no manual timestamping is needed.
     private static func apply(
       title: String, index: Int64, imageURL: URL?, to record: CKRecord
     ) {
@@ -67,9 +69,6 @@
       if let imageURL {
         record[Note.Fields.image] = CKAsset(fileURL: imageURL)
       }
-      record[Note.Fields.modified] = NSNumber(
-        value: Int64(Date().timeIntervalSince1970 * 1_000)
-      )
     }
 
     internal func refreshAccountStatus() async {
@@ -134,7 +133,6 @@
     internal func createNote(title: String, index: Int64, imageURL: URL?) async throws -> Note {
       let record = CKRecord(recordType: Note.recordType)
       Self.apply(title: title, index: index, imageURL: imageURL, to: record)
-      record[Note.Fields.createdAt] = Date() as NSDate
       let saved = try await database.save(record)
       guard let note = Note(saved) else {
         throw NativeCloudKitError.unexpectedSaveResult

--- a/Examples/MistDemo/Sources/MistDemoApp/Views/QueryView.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Views/QueryView.swift
@@ -76,9 +76,9 @@
                       .font(.caption)
                       .foregroundStyle(.secondary)
                   }
-                  if let createdAt = note.createdAt {
+                  if let creationDate = note.creationDate {
                     Label(
-                      createdAt.formatted(date: .abbreviated, time: .omitted),
+                      creationDate.formatted(date: .abbreviated, time: .omitted),
                       systemImage: "calendar"
                     )
                     .font(.caption)

--- a/Examples/MistDemo/Sources/MistDemoApp/Views/RecordDetailView.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Views/RecordDetailView.swift
@@ -125,13 +125,6 @@
         LabeledContent("title", value: note.title ?? "—")
         LabeledContent("index", value: note.index.map(String.init) ?? "—")
         LabeledContent(
-          "createdAt",
-          value: note.createdAt?.formatted(
-            date: .abbreviated, time: .standard
-          ) ?? "—"
-        )
-        LabeledContent("modified", value: note.modified.map(String.init) ?? "—")
-        LabeledContent(
           "image",
           value: note.imageAssetURL?.lastPathComponent ?? "—"
         )

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/WebCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/WebCommand.swift
@@ -101,16 +101,23 @@
         )
       )
 
-      try await withSignalHandling {
-        try await withThrowingTaskGroup(of: Void.self) { group in
-          group.addTask {
-            try await app.runService()
+      do {
+        try await withSignalHandling {
+          try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+              try await app.runService()
+            }
+            group.addTask {
+              await openBrowserIfNeeded()
+            }
+            try await group.waitForAll()
           }
-          group.addTask {
-            await openBrowserIfNeeded()
-          }
-          try await group.waitForAll()
         }
+      } catch AsyncTimeoutError.cancelled {
+        // Ctrl+C / SIGTERM is the intended exit path for the long-running
+        // web server — `withSignalHandling` throws cancelled to unwind the
+        // task group. Treat it as a clean shutdown.
+        print("Server stopped.")
       }
     }
 

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/CreateRecordsPhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/CreateRecordsPhase.swift
@@ -59,7 +59,6 @@ internal struct CreateRecordsPhase: IntegrationPhase {
           "title": .string("Test Record \(recordIndex)"),
           "index": .int64(recordIndex),
           "image": .asset(input.asset),
-          "createdAt": .date(Date()),
         ]
       )
       createdRecordNames.append(record.recordName)

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/index.html
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/index.html
@@ -456,6 +456,9 @@
                 delBtn.className = 'danger';
                 delBtn.type = 'button';
                 delBtn.textContent = 'Delete';
+                // No confirm() — the demo prioritizes hands-on iteration; the
+                // raw response panel below the form shows the wire payload of
+                // every operation so accidents stay visible.
                 delBtn.addEventListener('click', () => deleteNote(note));
                 actionsTd.appendChild(delBtn);
                 tr.appendChild(actionsTd);
@@ -678,13 +681,17 @@
             }
         }
 
-        async function deleteNote(note) {
-            clearStatus(formStatusEl);
+        // statusEl defaults to tableStatusEl: per-row Delete buttons live in
+        // the table, so feedback belongs above the table. The form panel's
+        // Delete button passes formStatusEl explicitly to keep its status
+        // alongside the form it acts on.
+        async function deleteNote(note, statusEl = tableStatusEl) {
+            clearStatus(statusEl);
             try {
                 let payload;
                 if (currentMode === 'mistkit') {
                     payload = await postJSON('/api/records/delete', {
-                        recordType: note.recordType || recordTypeInput.value.trim(),
+                        recordType: note.recordType,
                         recordName: note.recordName,
                         recordChangeTag: note.recordChangeTag,
                     });
@@ -695,11 +702,11 @@
                     }
                 }
                 showRaw(payload);
-                setStatus(formStatusEl, `Deleted ${note.recordName}.`, 'success');
+                setStatus(statusEl, `Deleted ${note.recordName}.`, 'success');
                 if (note.recordName === selectedRecordName) clearForm();
                 await queryNotes();
             } catch (error) {
-                setStatus(formStatusEl, `Delete failed: ${error.message}`, 'error');
+                setStatus(statusEl, `Delete failed: ${error.message}`, 'error');
                 showRaw(error.payload || { message: error.message });
             }
         }
@@ -726,7 +733,7 @@
         clearBtn.addEventListener('click', clearForm);
         deleteBtn.addEventListener('click', () => {
             const note = selectedNote();
-            if (note) deleteNote(note);
+            if (note) deleteNote(note, formStatusEl);
         });
         refreshBtn.addEventListener('click', queryNotes);
 

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/index.html
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/index.html
@@ -12,11 +12,13 @@
             --muted: #6e6e73;
             --accent: #0369a1;
             --accent-dark: #0c4a6e;
+            --danger: #c00;
+            --danger-bg: #fdd;
             --success-bg: #d1f5d3;
             --success-fg: #1d5e20;
-            --error-bg: #fdd;
-            --error-fg: #c00;
             --border: #d0d7de;
+            --row-hover: #f0f4f8;
+            --row-selected: #dbeafe;
         }
         * { box-sizing: border-box; }
         body {
@@ -27,7 +29,7 @@
             color: var(--ink);
         }
         .layout {
-            max-width: 920px;
+            max-width: 1100px;
             margin: 0 auto;
             display: flex;
             flex-direction: column;
@@ -44,7 +46,7 @@
         h3 { font-size: 15px; margin: 0 0 8px 0; }
         p { color: var(--muted); margin: 0 0 16px 0; line-height: 1.5; }
         label { display: block; font-size: 13px; font-weight: 600; margin: 12px 0 4px; }
-        input, textarea, select {
+        input {
             width: 100%;
             padding: 8px 10px;
             border: 1px solid var(--border);
@@ -52,7 +54,6 @@
             font-size: 14px;
             font-family: inherit;
         }
-        textarea { font-family: 'SF Mono', Menlo, monospace; min-height: 80px; }
         button {
             background: var(--accent);
             color: white;
@@ -65,15 +66,30 @@
         }
         button:hover:not(:disabled) { background: var(--accent-dark); }
         button:disabled { opacity: 0.45; cursor: not-allowed; }
+        button.secondary {
+            background: transparent;
+            color: var(--ink);
+            border: 1px solid var(--border);
+            font-weight: 500;
+        }
+        button.secondary:hover:not(:disabled) {
+            background: var(--row-hover);
+        }
+        button.danger {
+            background: var(--danger);
+        }
+        button.danger:hover:not(:disabled) {
+            background: #900;
+        }
         .status {
-            margin-top: 16px;
+            margin-top: 12px;
             padding: 10px 12px;
             border-radius: 8px;
             font-size: 13px;
             display: none;
         }
         .status.success { background: var(--success-bg); color: var(--success-fg); display: block; }
-        .status.error { background: var(--error-bg); color: var(--error-fg); display: block; }
+        .status.error { background: var(--danger-bg); color: var(--danger); display: block; }
         pre {
             background: #0d1117;
             color: #c9d1d9;
@@ -82,7 +98,7 @@
             font-size: 12px;
             overflow-x: auto;
             margin: 8px 0 0 0;
-            max-height: 320px;
+            max-height: 240px;
         }
         .mode-toggle {
             display: flex;
@@ -100,20 +116,92 @@
             color: white;
             border-color: var(--accent);
         }
-        .mode-toggle button[disabled] { opacity: 0.5; }
         .mode-hint { font-size: 12px; color: var(--muted); margin-top: 4px; }
-        .crud-grid {
+        .notes-grid {
             display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 16px;
+            grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+            gap: 24px;
+            align-items: start;
         }
-        @media (max-width: 720px) {
-            .crud-grid { grid-template-columns: 1fr; }
+        @media (max-width: 820px) {
+            .notes-grid { grid-template-columns: 1fr; }
+        }
+        .table-toolbar {
+            display: flex;
+            align-items: end;
+            gap: 12px;
+            flex-wrap: wrap;
+            margin-bottom: 12px;
+        }
+        .table-toolbar label { margin: 0 0 4px; }
+        .table-toolbar .limit-field { width: 100px; }
+        .table-wrap {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            overflow: auto;
+            max-height: 480px;
+        }
+        table { width: 100%; border-collapse: collapse; font-size: 13px; }
+        th, td {
+            text-align: left;
+            padding: 8px 10px;
+            border-bottom: 1px solid var(--border);
+        }
+        th {
+            position: sticky;
+            top: 0;
+            background: var(--row-hover);
+            font-weight: 600;
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            color: var(--muted);
+        }
+        th.sortable { cursor: pointer; user-select: none; white-space: nowrap; }
+        th.sortable:hover { color: var(--accent); }
+        th.sortable.active { color: var(--accent); }
+        .sort-indicator { display: inline-block; width: 12px; margin-left: 4px; }
+        td.timestamp {
+            font-size: 12px;
+            color: var(--muted);
+            white-space: nowrap;
+        }
+        tbody tr { cursor: pointer; }
+        tbody tr:hover { background: var(--row-hover); }
+        tbody tr.selected { background: var(--row-selected); }
+        td.record-name {
+            font-family: 'SF Mono', Menlo, monospace;
+            font-size: 12px;
+            color: var(--muted);
+            max-width: 180px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        td.actions { width: 1%; white-space: nowrap; }
+        td.actions button { padding: 4px 10px; font-size: 12px; }
+        .empty-state {
+            padding: 24px;
+            text-align: center;
+            color: var(--muted);
+            font-size: 13px;
+        }
+        .form-actions {
+            display: flex;
+            gap: 8px;
+            margin-top: 12px;
+            flex-wrap: wrap;
+        }
+        .form-mode-label {
+            font-size: 12px;
+            color: var(--muted);
+            font-weight: 500;
         }
         .pre-auth { opacity: 0.5; pointer-events: none; }
         #signin-area { margin-top: 8px; }
         .badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; background: #eef; color: var(--accent); }
-        .row { display: flex; align-items: center; gap: 8px; }
+        .raw-response summary { font-size: 12px; color: var(--muted); cursor: pointer; margin-top: 12px; }
+        .raw-response[open] summary { margin-bottom: 4px; }
     </style>
     <script src="https://cdn.apple-cloudkit.com/ck/2/cloudkit.js" onerror="console.log('Failed to load CloudKit.js')"></script>
 </head>
@@ -147,61 +235,65 @@
             <div id="auth-status" class="status"></div>
         </div>
 
-        <div class="card crud-card pre-auth" id="crud-card">
-            <h2>Records <span class="badge" id="crud-mode-badge">MistKit</span></h2>
-            <div class="crud-grid">
+        <div class="card pre-auth" id="notes-card">
+            <h2>Notes <span class="badge" id="mode-badge">MistKit</span></h2>
+            <div class="notes-grid">
                 <section>
-                    <h3>Query</h3>
-                    <label for="query-record-type">Record type</label>
-                    <input id="query-record-type" type="text" value="Note">
-                    <label for="query-limit">Limit (1–200)</label>
-                    <input id="query-limit" type="number" value="20" min="1" max="200">
-                    <div class="row" style="margin-top: 8px;">
-                        <button id="query-btn" type="button">Query</button>
+                    <div class="table-toolbar">
+                        <div>
+                            <label for="record-type">Record type</label>
+                            <input id="record-type" type="text" value="Note">
+                        </div>
+                        <div>
+                            <label for="query-limit">Limit</label>
+                            <input id="query-limit" class="limit-field" type="number" value="20" min="1" max="200">
+                        </div>
+                        <div style="flex: 1; display: flex; justify-content: flex-end;">
+                            <button id="refresh-btn" type="button">Refresh</button>
+                        </div>
                     </div>
-                    <div id="query-status" class="status"></div>
-                    <pre id="query-result" style="display: none;"></pre>
+                    <div class="table-wrap">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Title</th>
+                                    <th>Index</th>
+                                    <th class="sortable" data-sort-field="___createTime">
+                                        <span class="sort-label">Created</span><span class="sort-indicator"></span>
+                                    </th>
+                                    <th class="sortable" data-sort-field="___modTime">
+                                        <span class="sort-label">Modified</span><span class="sort-indicator"></span>
+                                    </th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody id="notes-tbody">
+                                <tr><td colspan="5" class="empty-state" id="notes-empty">No notes loaded — click Refresh.</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div id="table-status" class="status"></div>
                 </section>
 
                 <section>
-                    <h3>Create</h3>
-                    <label for="create-record-type">Record type</label>
-                    <input id="create-record-type" type="text" value="Note">
-                    <label for="create-fields">Fields (JSON object of string values)</label>
-                    <textarea id="create-fields">{"title": "Hello from MistKit"}</textarea>
-                    <div class="row" style="margin-top: 8px;">
-                        <button id="create-btn" type="button">Create</button>
+                    <h3>
+                        <span id="form-heading">New note</span>
+                        <span class="form-mode-label" id="form-record-name"></span>
+                    </h3>
+                    <label for="form-title">Title</label>
+                    <input id="form-title" type="text" placeholder="Hello from MistKit">
+                    <label for="form-index">Index</label>
+                    <input id="form-index" type="number" placeholder="0">
+                    <div class="form-actions">
+                        <button id="save-btn" type="button">Create</button>
+                        <button id="clear-btn" class="secondary" type="button">New</button>
+                        <button id="delete-btn" class="danger" type="button" disabled>Delete</button>
                     </div>
-                    <div id="create-status" class="status"></div>
-                    <pre id="create-result" style="display: none;"></pre>
-                </section>
-
-                <section>
-                    <h3>Update</h3>
-                    <label for="update-record-type">Record type</label>
-                    <input id="update-record-type" type="text" value="Note">
-                    <label for="update-record-name">Record name</label>
-                    <input id="update-record-name" type="text" placeholder="e.g. abc-123">
-                    <label for="update-fields">Fields (JSON object of string values)</label>
-                    <textarea id="update-fields">{"title": "Updated"}</textarea>
-                    <div class="row" style="margin-top: 8px;">
-                        <button id="update-btn" type="button">Update</button>
-                    </div>
-                    <div id="update-status" class="status"></div>
-                    <pre id="update-result" style="display: none;"></pre>
-                </section>
-
-                <section>
-                    <h3>Delete</h3>
-                    <label for="delete-record-type">Record type</label>
-                    <input id="delete-record-type" type="text" value="Note">
-                    <label for="delete-record-name">Record name</label>
-                    <input id="delete-record-name" type="text" placeholder="e.g. abc-123">
-                    <div class="row" style="margin-top: 8px;">
-                        <button id="delete-btn" type="button">Delete</button>
-                    </div>
-                    <div id="delete-status" class="status"></div>
-                    <pre id="delete-result" style="display: none;"></pre>
+                    <div id="form-status" class="status"></div>
+                    <details class="raw-response">
+                        <summary>Last raw response</summary>
+                        <pre id="raw-response" style="display: block;">(none yet)</pre>
+                    </details>
                 </section>
             </div>
         </div>
@@ -211,13 +303,33 @@
         let container = null;
         let webAuthToken = null;
         let authenticationInProgress = false;
-        let currentMode = 'mistkit'; // 'mistkit' | 'cloudkitjs'
+        let currentMode = 'mistkit';            // 'mistkit' | 'cloudkitjs'
+        let notes = [];                          // [{ recordName, title, index, created, modified, recordChangeTag, raw }]
+        let selectedRecordName = null;
+        let authComplete = false;
+        // null until the user clicks a sortable column header. Once set,
+        // both MistKit-mode and CloudKit-JS-mode queries forward it.
+        let currentSort = null;                  // { field, ascending } | null
 
         const authStatusDiv = document.getElementById('auth-status');
         const signinButton = document.getElementById('signin-button');
         const signoutButton = document.getElementById('signout-button');
-        const crudCard = document.getElementById('crud-card');
-        const modeBadge = document.getElementById('crud-mode-badge');
+        const notesCard = document.getElementById('notes-card');
+        const modeBadge = document.getElementById('mode-badge');
+        const tbody = document.getElementById('notes-tbody');
+        const tableStatusEl = document.getElementById('table-status');
+        const formStatusEl = document.getElementById('form-status');
+        const formHeading = document.getElementById('form-heading');
+        const formRecordName = document.getElementById('form-record-name');
+        const titleInput = document.getElementById('form-title');
+        const indexInput = document.getElementById('form-index');
+        const saveBtn = document.getElementById('save-btn');
+        const clearBtn = document.getElementById('clear-btn');
+        const deleteBtn = document.getElementById('delete-btn');
+        const refreshBtn = document.getElementById('refresh-btn');
+        const recordTypeInput = document.getElementById('record-type');
+        const queryLimitInput = document.getElementById('query-limit');
+        const rawResponseEl = document.getElementById('raw-response');
 
         // ---- shared helpers ----
 
@@ -233,9 +345,8 @@
             el.style.display = 'none';
         }
 
-        function showResult(el, value) {
-            el.style.display = 'block';
-            el.textContent = JSON.stringify(value, null, 2);
+        function showRaw(value) {
+            rawResponseEl.textContent = value == null ? '(none)' : JSON.stringify(value, null, 2);
         }
 
         async function postJSON(path, body) {
@@ -257,61 +368,210 @@
             return payload;
         }
 
-        // ---- mode toggle ----
+        // ---- form state ----
 
-        document.getElementById('mode-mistkit').addEventListener('click', () => setMode('mistkit'));
-        document.getElementById('mode-cloudkitjs').addEventListener('click', () => setMode('cloudkitjs'));
-
-        function setMode(mode) {
-            currentMode = mode;
-            const mistKitBtn = document.getElementById('mode-mistkit');
-            const cloudKitJsBtn = document.getElementById('mode-cloudkitjs');
-            mistKitBtn.classList.toggle('active', mode === 'mistkit');
-            cloudKitJsBtn.classList.toggle('active', mode === 'cloudkitjs');
-            modeBadge.textContent = mode === 'mistkit' ? 'MistKit' : 'CloudKit JS';
+        function selectedNote() {
+            return notes.find(n => n.recordName === selectedRecordName) || null;
         }
 
-        // ---- CRUD ----
+        function refreshFormState() {
+            const note = selectedNote();
+            if (note) {
+                formHeading.textContent = 'Edit note';
+                formRecordName.textContent = `· ${note.recordName}`;
+                saveBtn.textContent = 'Save';
+                deleteBtn.disabled = false;
+            } else {
+                formHeading.textContent = 'New note';
+                formRecordName.textContent = '';
+                saveBtn.textContent = 'Create';
+                deleteBtn.disabled = true;
+            }
+        }
 
-        function parseFieldsJSON(raw, statusEl) {
-            try {
-                const parsed = JSON.parse(raw);
-                if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-                    throw new Error('Fields must be a JSON object');
+        function clearForm() {
+            selectedRecordName = null;
+            titleInput.value = '';
+            indexInput.value = '';
+            clearStatus(formStatusEl);
+            refreshFormState();
+            renderRows();
+        }
+
+        function loadNoteIntoForm(note) {
+            selectedRecordName = note.recordName;
+            titleInput.value = note.title ?? '';
+            indexInput.value = note.index != null ? String(note.index) : '';
+            clearStatus(formStatusEl);
+            refreshFormState();
+            renderRows();
+        }
+
+        // ---- render ----
+
+        function renderRows() {
+            tbody.innerHTML = '';
+            if (notes.length === 0) {
+                const tr = document.createElement('tr');
+                const td = document.createElement('td');
+                td.colSpan = 5;
+                td.className = 'empty-state';
+                td.textContent = 'No notes — Refresh or Create one.';
+                tr.appendChild(td);
+                tbody.appendChild(tr);
+                return;
+            }
+            for (const note of notes) {
+                const tr = document.createElement('tr');
+                tr.title = note.recordName;
+                if (note.recordName === selectedRecordName) tr.classList.add('selected');
+                tr.addEventListener('click', (e) => {
+                    if (e.target.closest('button')) return;
+                    loadNoteIntoForm(note);
+                });
+
+                const titleTd = document.createElement('td');
+                titleTd.textContent = note.title ?? '';
+                tr.appendChild(titleTd);
+
+                const indexTd = document.createElement('td');
+                indexTd.textContent = note.index != null ? String(note.index) : '';
+                tr.appendChild(indexTd);
+
+                const createdTd = document.createElement('td');
+                createdTd.className = 'timestamp';
+                createdTd.textContent = formatTimestamp(note.created);
+                if (note.created) createdTd.title = note.created.toISOString();
+                tr.appendChild(createdTd);
+
+                const modifiedTd = document.createElement('td');
+                modifiedTd.className = 'timestamp';
+                modifiedTd.textContent = formatTimestamp(note.modified);
+                if (note.modified) modifiedTd.title = note.modified.toISOString();
+                tr.appendChild(modifiedTd);
+
+                const actionsTd = document.createElement('td');
+                actionsTd.className = 'actions';
+                const delBtn = document.createElement('button');
+                delBtn.className = 'danger';
+                delBtn.type = 'button';
+                delBtn.textContent = 'Delete';
+                delBtn.addEventListener('click', () => deleteNote(note));
+                actionsTd.appendChild(delBtn);
+                tr.appendChild(actionsTd);
+
+                tbody.appendChild(tr);
+            }
+        }
+
+        function refreshSortIndicators() {
+            document.querySelectorAll('th.sortable').forEach(th => {
+                const field = th.dataset.sortField;
+                const isActive = currentSort && currentSort.field === field;
+                th.classList.toggle('active', isActive);
+                const indicator = th.querySelector('.sort-indicator');
+                if (isActive) {
+                    indicator.textContent = currentSort.ascending ? '↑' : '↓';
+                } else {
+                    indicator.textContent = '';
                 }
-                for (const [k, v] of Object.entries(parsed)) {
-                    if (typeof v !== 'string') {
-                        throw new Error(`Field "${k}" must be a string (this demo only supports string fields)`);
+            });
+        }
+
+        document.querySelectorAll('th.sortable').forEach(th => {
+            th.addEventListener('click', () => {
+                const field = th.dataset.sortField;
+                if (currentSort && currentSort.field === field) {
+                    if (currentSort.ascending) {
+                        currentSort = { field, ascending: false };
+                    } else {
+                        currentSort = null;            // third click clears
                     }
+                } else {
+                    currentSort = { field, ascending: true };
                 }
-                return parsed;
-            } catch (error) {
-                setStatus(statusEl, error.message, 'error');
-                return null;
-            }
+                refreshSortIndicators();
+                if (authComplete) queryNotes();
+            });
+        });
+
+        // ---- backend normalization ----
+
+        // Project the MistKit-mode `/api/records/query` payload (which mirrors
+        // CloudKit Web Services on the wire) and the CloudKit JS response
+        // into the single shape the table renders from.
+        //
+        // Timestamps:
+        //   - MistKit-mode wire: `created.timestamp` / `modified.timestamp`
+        //     are epoch-millis numbers (encoded with WebJSON's
+        //     .millisecondsSince1970 strategy on the server).
+        //   - CloudKit JS: `created` / `modified` are typed Date objects.
+        // The browser normalizes both into a Date instance.
+        function normalizeRecords(payload) {
+            const list = (payload && payload.records) || [];
+            return list.map(record => {
+                const fields = record.fields || {};
+                const titleField = fields.title;
+                const indexField = fields.index;
+                return {
+                    recordName: record.recordName,
+                    recordType: record.recordType,
+                    recordChangeTag: record.recordChangeTag,
+                    title: titleField && (titleField.value ?? titleField),
+                    index: indexField && Number(indexField.value ?? indexField),
+                    created: toDate(record.created),
+                    modified: toDate(record.modified),
+                    raw: record,
+                };
+            });
         }
 
-        async function runMistKitOperation(label, path, body, statusEl, resultEl) {
-            clearStatus(statusEl);
-            resultEl.style.display = 'none';
-            try {
-                const data = await postJSON(path, body);
-                setStatus(statusEl, `${label} succeeded.`, 'success');
-                showResult(resultEl, data);
-            } catch (error) {
-                setStatus(statusEl, `${label} failed: ${error.message}`, 'error');
-                if (error.payload) showResult(resultEl, error.payload);
+        function toDate(value) {
+            if (value == null) return null;
+            // CloudKit JS shape: a Date object directly on record.created/modified,
+            // OR an envelope { timestamp: Date|number, userRecordName }.
+            if (value instanceof Date) return value;
+            if (typeof value === 'number') return new Date(value);
+            if (typeof value === 'object') {
+                const inner = value.timestamp;
+                if (inner == null) return null;
+                if (inner instanceof Date) return inner;
+                if (typeof inner === 'number') return new Date(inner);
+                if (typeof inner === 'string') {
+                    const parsed = Date.parse(inner);
+                    return isNaN(parsed) ? null : new Date(parsed);
+                }
             }
+            return null;
+        }
+
+        function formatTimestamp(date) {
+            if (!date) return '—';
+            return date.toLocaleString(undefined, {
+                dateStyle: 'short', timeStyle: 'short',
+            });
         }
 
         function ckJsDatabase() {
             return container.privateCloudDatabase;
         }
 
-        // CloudKit JS expects field values as { key: { value: ... } } while the
-        // MistKit-mode endpoints accept the flat { key: "value" } shape this
-        // demo's textareas already produce — wrap before saveRecords.
-        function fieldsToCKJS(fields) {
+        function buildFields() {
+            const out = {};
+            const title = titleInput.value.trim();
+            if (title.length > 0) out.title = title;
+            const indexRaw = indexInput.value.trim();
+            if (indexRaw.length > 0) {
+                const parsed = Number(indexRaw);
+                if (!isFinite(parsed)) {
+                    throw new Error('Index must be a number.');
+                }
+                out.index = parsed;
+            }
+            return out;
+        }
+
+        function ckJsFields(fields) {
             const wrapped = {};
             for (const [k, v] of Object.entries(fields)) {
                 wrapped[k] = { value: v };
@@ -319,122 +579,162 @@
             return wrapped;
         }
 
-        async function runCloudKitJsOperation(label, work, statusEl, resultEl) {
-            clearStatus(statusEl);
-            resultEl.style.display = 'none';
+        // ---- operations ----
+
+        async function queryNotes() {
+            const recordType = recordTypeInput.value.trim();
+            const limit = parseInt(queryLimitInput.value, 10);
+            clearStatus(tableStatusEl);
             try {
-                const data = await work();
-                if (data && data.hasErrors && data.errors && data.errors.length) {
-                    const first = data.errors[0];
-                    const message = (first && (first.reason || first.serverErrorCode))
-                        || 'CloudKit JS reported an error';
-                    setStatus(statusEl, `${label} failed: ${message}`, 'error');
-                    showResult(resultEl, data);
-                    return;
+                let payload;
+                if (currentMode === 'mistkit') {
+                    payload = await postJSON('/api/records/query', {
+                        recordType,
+                        limit: isFinite(limit) ? limit : undefined,
+                        sortBy: currentSort
+                            ? [{ field: currentSort.field, ascending: currentSort.ascending }]
+                            : undefined,
+                    });
+                } else {
+                    const query = { recordType };
+                    if (currentSort) {
+                        query.sortBy = [{
+                            fieldName: currentSort.field,
+                            ascending: currentSort.ascending,
+                        }];
+                    }
+                    payload = await ckJsDatabase().performQuery(query, {
+                        resultsLimit: isFinite(limit) ? limit : undefined,
+                    });
+                    if (payload && payload.hasErrors && payload.errors.length) {
+                        throw new Error(payload.errors[0].reason || 'CloudKit JS query failed');
+                    }
                 }
-                setStatus(statusEl, `${label} succeeded.`, 'success');
-                showResult(resultEl, data);
+                notes = normalizeRecords(payload);
+                if (selectedRecordName && !notes.some(n => n.recordName === selectedRecordName)) {
+                    clearForm();
+                } else {
+                    refreshFormState();
+                    renderRows();
+                }
+                showRaw(payload);
+                setStatus(tableStatusEl, `Loaded ${notes.length} record${notes.length === 1 ? '' : 's'}.`, 'success');
             } catch (error) {
-                const message = (error && error.message) || String(error);
-                setStatus(statusEl, `${label} failed: ${message}`, 'error');
-                if (error && typeof error === 'object') showResult(resultEl, error);
+                setStatus(tableStatusEl, `Query failed: ${error.message}`, 'error');
+                showRaw(error.payload || { message: error.message });
             }
         }
 
-        async function fetchRecordChangeTag(recordName) {
-            const result = await ckJsDatabase().fetchRecords([{ recordName }]);
-            if (result.hasErrors && result.errors.length) {
-                const first = result.errors[0];
-                throw new Error((first && first.reason) || 'fetchRecords failed');
+        async function saveNote() {
+            let fields;
+            try {
+                fields = buildFields();
+            } catch (error) {
+                setStatus(formStatusEl, error.message, 'error');
+                return;
             }
-            const record = result.records && result.records[0];
-            if (!record) throw new Error(`Record "${recordName}" not found`);
-            return record.recordChangeTag;
+            if (Object.keys(fields).length === 0) {
+                setStatus(formStatusEl, 'Provide a title or index.', 'error');
+                return;
+            }
+            const recordType = recordTypeInput.value.trim();
+            const note = selectedNote();
+            const isUpdate = note != null;
+            const label = isUpdate ? 'Update' : 'Create';
+            clearStatus(formStatusEl);
+            try {
+                let payload;
+                if (currentMode === 'mistkit') {
+                    if (isUpdate) {
+                        payload = await postJSON('/api/records/update', {
+                            recordType,
+                            recordName: note.recordName,
+                            fields,
+                            recordChangeTag: note.recordChangeTag,
+                        });
+                    } else {
+                        payload = await postJSON('/api/records/create', {
+                            recordType, fields,
+                        });
+                    }
+                } else {
+                    const record = { recordType, fields: ckJsFields(fields) };
+                    if (isUpdate) {
+                        record.recordName = note.recordName;
+                        record.recordChangeTag = note.recordChangeTag;
+                    }
+                    payload = await ckJsDatabase().saveRecords([record]);
+                    if (payload && payload.hasErrors && payload.errors.length) {
+                        throw new Error(payload.errors[0].reason || 'CloudKit JS save failed');
+                    }
+                }
+                showRaw(payload);
+                setStatus(formStatusEl, `${label} succeeded.`, 'success');
+                if (!isUpdate) clearForm();
+                await queryNotes();
+            } catch (error) {
+                setStatus(formStatusEl, `${label} failed: ${error.message}`, 'error');
+                showRaw(error.payload || { message: error.message });
+            }
         }
 
-        document.getElementById('query-btn').addEventListener('click', async () => {
-            const recordType = document.getElementById('query-record-type').value.trim();
-            const limit = parseInt(document.getElementById('query-limit').value, 10);
-            const statusEl = document.getElementById('query-status');
-            const resultEl = document.getElementById('query-result');
-            if (currentMode === 'mistkit') {
-                await runMistKitOperation('Query', '/api/records/query', {
-                    recordType, limit: isFinite(limit) ? limit : undefined,
-                }, statusEl, resultEl);
-                return;
+        async function deleteNote(note) {
+            clearStatus(formStatusEl);
+            try {
+                let payload;
+                if (currentMode === 'mistkit') {
+                    payload = await postJSON('/api/records/delete', {
+                        recordType: note.recordType || recordTypeInput.value.trim(),
+                        recordName: note.recordName,
+                        recordChangeTag: note.recordChangeTag,
+                    });
+                } else {
+                    payload = await ckJsDatabase().deleteRecords([{ recordName: note.recordName }]);
+                    if (payload && payload.hasErrors && payload.errors.length) {
+                        throw new Error(payload.errors[0].reason || 'CloudKit JS delete failed');
+                    }
+                }
+                showRaw(payload);
+                setStatus(formStatusEl, `Deleted ${note.recordName}.`, 'success');
+                if (note.recordName === selectedRecordName) clearForm();
+                await queryNotes();
+            } catch (error) {
+                setStatus(formStatusEl, `Delete failed: ${error.message}`, 'error');
+                showRaw(error.payload || { message: error.message });
             }
-            await runCloudKitJsOperation('Query', () =>
-                ckJsDatabase().performQuery({ recordType }, {
-                    resultsLimit: isFinite(limit) ? limit : undefined,
-                }),
-                statusEl, resultEl);
-        });
+        }
 
-        document.getElementById('create-btn').addEventListener('click', async () => {
-            const recordType = document.getElementById('create-record-type').value.trim();
-            const statusEl = document.getElementById('create-status');
-            const resultEl = document.getElementById('create-result');
-            const fields = parseFieldsJSON(document.getElementById('create-fields').value, statusEl);
-            if (!fields) return;
-            if (currentMode === 'mistkit') {
-                await runMistKitOperation('Create', '/api/records/create',
-                    { recordType, fields }, statusEl, resultEl);
-                return;
-            }
-            await runCloudKitJsOperation('Create', () =>
-                ckJsDatabase().saveRecords([{ recordType, fields: fieldsToCKJS(fields) }]),
-                statusEl, resultEl);
-        });
+        // ---- mode toggle ----
 
-        document.getElementById('update-btn').addEventListener('click', async () => {
-            const recordType = document.getElementById('update-record-type').value.trim();
-            const recordName = document.getElementById('update-record-name').value.trim();
-            const statusEl = document.getElementById('update-status');
-            const resultEl = document.getElementById('update-result');
-            if (!recordName) {
-                setStatus(statusEl, 'Record name is required.', 'error');
-                return;
-            }
-            const fields = parseFieldsJSON(document.getElementById('update-fields').value, statusEl);
-            if (!fields) return;
-            if (currentMode === 'mistkit') {
-                await runMistKitOperation('Update', '/api/records/update', {
-                    recordType, recordName, fields,
-                }, statusEl, resultEl);
-                return;
-            }
-            await runCloudKitJsOperation('Update', async () => {
-                const recordChangeTag = await fetchRecordChangeTag(recordName);
-                return ckJsDatabase().saveRecords([{
-                    recordType, recordName, recordChangeTag,
-                    fields: fieldsToCKJS(fields),
-                }]);
-            }, statusEl, resultEl);
-        });
+        document.getElementById('mode-mistkit').addEventListener('click', () => setMode('mistkit'));
+        document.getElementById('mode-cloudkitjs').addEventListener('click', () => setMode('cloudkitjs'));
 
-        document.getElementById('delete-btn').addEventListener('click', async () => {
-            const recordType = document.getElementById('delete-record-type').value.trim();
-            const recordName = document.getElementById('delete-record-name').value.trim();
-            const statusEl = document.getElementById('delete-status');
-            const resultEl = document.getElementById('delete-result');
-            if (!recordName) {
-                setStatus(statusEl, 'Record name is required.', 'error');
-                return;
-            }
-            if (currentMode === 'mistkit') {
-                await runMistKitOperation('Delete', '/api/records/delete',
-                    { recordType, recordName }, statusEl, resultEl);
-                return;
-            }
-            await runCloudKitJsOperation('Delete', () =>
-                ckJsDatabase().deleteRecords([{ recordName }]),
-                statusEl, resultEl);
+        function setMode(mode) {
+            if (mode === currentMode) return;
+            currentMode = mode;
+            const mistKitBtn = document.getElementById('mode-mistkit');
+            const cloudKitJsBtn = document.getElementById('mode-cloudkitjs');
+            mistKitBtn.classList.toggle('active', mode === 'mistkit');
+            cloudKitJsBtn.classList.toggle('active', mode === 'cloudkitjs');
+            modeBadge.textContent = mode === 'mistkit' ? 'MistKit' : 'CloudKit JS';
+            if (authComplete) queryNotes();
+        }
+
+        // ---- form wiring ----
+
+        saveBtn.addEventListener('click', saveNote);
+        clearBtn.addEventListener('click', clearForm);
+        deleteBtn.addEventListener('click', () => {
+            const note = selectedNote();
+            if (note) deleteNote(note);
         });
+        refreshBtn.addEventListener('click', queryNotes);
 
         // ---- auth flow ----
 
         function setAuthed(authed) {
-            crudCard.classList.toggle('pre-auth', !authed);
+            authComplete = authed;
+            notesCard.classList.toggle('pre-auth', !authed);
             signoutButton.style.display = authed ? 'inline-block' : 'none';
         }
 
@@ -480,7 +780,7 @@
         }
 
         function renderTokenDisplay(token) {
-            crudCard.style.display = 'none';
+            notesCard.style.display = 'none';
             document.getElementById('signin-area').style.display = 'none';
             const card = document.createElement('div');
             card.className = 'card';
@@ -507,6 +807,7 @@
                 } else {
                     setStatus(authStatusDiv, `Authenticated as ${userIdentity.userRecordName}.`, 'success');
                     setAuthed(true);
+                    queryNotes();
                 }
             } catch (error) {
                 setStatus(authStatusDiv, `Authentication failed: ${error.message}`, 'error');
@@ -520,6 +821,8 @@
                 await container.signOut();
                 webAuthToken = null;
                 setAuthed(false);
+                notes = [];
+                clearForm();
                 setStatus(authStatusDiv, 'Signed out.', 'success');
             } catch (error) {
                 setStatus(authStatusDiv, 'Sign out failed: ' + error.message, 'error');
@@ -555,6 +858,8 @@
                 container.whenUserSignsOut().then(() => {
                     webAuthToken = null;
                     setAuthed(false);
+                    notes = [];
+                    clearForm();
                     setStatus(authStatusDiv, 'Signed out.', 'success');
                 });
             } catch (error) {
@@ -562,6 +867,7 @@
             }
         }
 
+        refreshFormState();
         initializeCloudKit();
     </script>
 </body>

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebBackend.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebBackend.swift
@@ -40,7 +40,8 @@ internal import MistKit
 internal protocol WebBackend: Sendable {
   func webQuery(
     recordType: String,
-    limit: Int?
+    limit: Int?,
+    sortBy: [WebRequests.QuerySortField]?
   ) async throws -> [RecordInfo]
 
   func webCreate(
@@ -51,12 +52,14 @@ internal protocol WebBackend: Sendable {
   func webUpdate(
     recordType: String,
     recordName: String,
-    fields: [String: FieldValue]
+    fields: [String: FieldValue],
+    recordChangeTag: String?
   ) async throws -> RecordInfo
 
   func webDelete(
     recordType: String,
-    recordName: String
+    recordName: String,
+    recordChangeTag: String?
   ) async throws
 }
 
@@ -64,12 +67,16 @@ internal protocol WebBackend: Sendable {
 extension CloudKitService: WebBackend {
   internal func webQuery(
     recordType: String,
-    limit: Int?
+    limit: Int?,
+    sortBy: [WebRequests.QuerySortField]?
   ) async throws -> [RecordInfo] {
+    let querySorts = sortBy?.map { sort in
+      QuerySort.sort(sort.field, ascending: sort.ascending)
+    }
     let result = try await queryRecords(
       recordType: recordType,
       filters: nil,
-      sortBy: nil,
+      sortBy: querySorts,
       limit: limit,
       desiredKeys: nil,
       continuationMarker: nil,
@@ -92,23 +99,27 @@ extension CloudKitService: WebBackend {
   internal func webUpdate(
     recordType: String,
     recordName: String,
-    fields: [String: FieldValue]
+    fields: [String: FieldValue],
+    recordChangeTag: String?
   ) async throws -> RecordInfo {
     try await updateRecord(
       recordType: recordType,
       recordName: recordName,
       fields: fields,
+      recordChangeTag: recordChangeTag,
       database: .private
     )
   }
 
   internal func webDelete(
     recordType: String,
-    recordName: String
+    recordName: String,
+    recordChangeTag: String?
   ) async throws {
     try await deleteRecord(
       recordType: recordType,
       recordName: recordName,
+      recordChangeTag: recordChangeTag,
       database: .private
     )
   }

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebJSON.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebJSON.swift
@@ -1,5 +1,5 @@
 //
-//  ModifyRecordsPhase.swift
+//  WebJSON.swift
 //  MistDemo
 //
 //  Created by Leo Dion.
@@ -27,45 +27,24 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import Foundation
-import MistKit
+internal import Foundation
 
-internal struct ModifyRecordsPhase: IntegrationPhase {
-  internal typealias Input = CreatedRecordNames
-  internal typealias Output = NoState
+/// Shared JSON encoder/decoder for the web demo's CRUD endpoints.
+///
+/// Uses `.millisecondsSince1970` for both directions so timestamps in
+/// `RecordInfo.created` / `RecordInfo.modified` arrive in the browser as
+/// epoch-millis numbers that the JS side can pass to `new Date(ms)` —
+/// the same shape CloudKit Web Services returns to CloudKit JS.
+internal enum WebJSON {
+  internal static func encoder() -> JSONEncoder {
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .millisecondsSince1970
+    return encoder
+  }
 
-  internal static let title = "Modify some records"
-  internal static let emoji = "\u{270F}\u{FE0F} "
-  internal static let apiName = "updateRecord"
-
-  internal func run(
-    input: CreatedRecordNames, context: PhaseContext
-  ) async throws -> NoState {
-    print("\n\(Self.emoji) \(Self.title)")
-
-    let recordsToUpdate = Array(input.names.prefix(min(3, input.names.count)))
-
-    let operations = recordsToUpdate.enumerated().map { offset, recordName in
-      RecordOperation(
-        operationType: .forceReplace,
-        recordType: IntegrationTestData.recordType,
-        recordName: recordName,
-        fields: [
-          "title": .string("Updated Record \(offset + 1)")
-        ]
-      )
-    }
-
-    _ = try await context.service.modifyRecords(operations)
-
-    if context.verbose {
-      for recordName in recordsToUpdate {
-        print("   ✅ Updated: \(recordName)")
-      }
-    }
-
-    print("✅ Updated \(recordsToUpdate.count) records")
-
-    return NoState()
+  internal static func decoder() -> JSONDecoder {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .millisecondsSince1970
+    return decoder
   }
 }

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebRequests.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebRequests.swift
@@ -32,44 +32,54 @@ internal import MistKit
 
 /// Request payloads for the web command's CRUD endpoints.
 ///
-/// Field values are limited to string in the request body so the HTML form
-/// schema stays trivial. Wider FieldValue coverage (numbers, dates, refs)
-/// can land later once the demo UI exposes typed input controls.
+/// `fields` decodes directly into MistKit's `FieldValue`, which has a custom
+/// Codable that accepts raw JSON primitives (string → `.string`, integer →
+/// `.int64`, floating-point → `.double`) along with the complex CloudKit
+/// shapes (location, reference, asset, list). So the browser can send the
+/// natural `{"title":"Hi","index":5}` shape without a custom request type.
 internal enum WebRequests {
+  /// One sort descriptor: a field name plus a direction. Field names follow
+  /// CloudKit Web Services / CloudKit JS naming — including the implicit
+  /// system fields `___createTime` and `___modTime`, which must be marked
+  /// SORTABLE in the schema.
+  internal struct QuerySortField: Decodable, Sendable {
+    internal let field: String
+    internal let ascending: Bool
+  }
+
   /// `POST /api/records/query`
   internal struct Query: Decodable {
     internal let recordType: String
     internal let limit: Int?
+    internal let sortBy: [QuerySortField]?
   }
 
   /// `POST /api/records/create`
   internal struct Create: Decodable {
     internal let recordType: String
-    internal let fields: [String: String]
+    internal let fields: [String: FieldValue]
   }
 
   /// `POST /api/records/update`
+  ///
+  /// `recordChangeTag` carries the optimistic-locking token CloudKit returns
+  /// on every record. The browser already holds it from the last query, so
+  /// it forwards directly to MistKit without a server-side fetch round-trip.
   internal struct Update: Decodable {
     internal let recordType: String
     internal let recordName: String
-    internal let fields: [String: String]
+    internal let fields: [String: FieldValue]
+    internal let recordChangeTag: String?
   }
 
   /// `POST /api/records/delete`
+  ///
+  /// `recordChangeTag` is required by CloudKit Web Services to delete an
+  /// existing record. Omitting it produces `BadRequestException: missing
+  /// required field 'recordChangeTag'`.
   internal struct Delete: Decodable {
     internal let recordType: String
     internal let recordName: String
-  }
-
-  /// Convert a JSON `[String: String]` request payload into the
-  /// `FieldValue` map MistKit expects.
-  internal static func stringFields(
-    _ raw: [String: String]
-  ) -> [String: FieldValue] {
-    var result: [String: FieldValue] = [:]
-    for (name, value) in raw {
-      result[name] = .string(value)
-    }
-    return result
+    internal let recordChangeTag: String?
   }
 }

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebRequests.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebRequests.swift
@@ -43,6 +43,10 @@ internal enum WebRequests {
   /// system fields `___createTime` and `___modTime`, which must be marked
   /// SORTABLE in the schema.
   internal struct QuerySortField: Decodable, Sendable {
+    /// CloudKit Web Services field name. Note: CloudKit JS's
+    /// `performQuery({ sortBy })` uses `fieldName` for the same concept —
+    /// the browser-side code maps this property to `fieldName` when issuing
+    /// CloudKit-JS-mode queries (see `queryNotes` in `index.html`).
     internal let field: String
     internal let ascending: Bool
   }

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer+CRUD.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer+CRUD.swift
@@ -48,9 +48,11 @@
         return try await Self.runOperation { () -> Data in
           let backend = try backendFactory.make(token)
           let records = try await backend.webQuery(
-            recordType: body.recordType, limit: body.limit
+            recordType: body.recordType,
+            limit: body.limit,
+            sortBy: body.sortBy
           )
-          return try JSONEncoder().encode(
+          return try WebJSON.encoder().encode(
             WebResponse.Records(records: records)
           )
         }
@@ -73,9 +75,9 @@
           let backend = try backendFactory.make(token)
           let record = try await backend.webCreate(
             recordType: body.recordType,
-            fields: WebRequests.stringFields(body.fields)
+            fields: body.fields
           )
-          return try JSONEncoder().encode(
+          return try WebJSON.encoder().encode(
             WebResponse.Records(records: [record])
           )
         }
@@ -99,9 +101,10 @@
           let record = try await backend.webUpdate(
             recordType: body.recordType,
             recordName: body.recordName,
-            fields: WebRequests.stringFields(body.fields)
+            fields: body.fields,
+            recordChangeTag: body.recordChangeTag
           )
-          return try JSONEncoder().encode(
+          return try WebJSON.encoder().encode(
             WebResponse.Records(records: [record])
           )
         }
@@ -124,9 +127,10 @@
           let backend = try backendFactory.make(token)
           try await backend.webDelete(
             recordType: body.recordType,
-            recordName: body.recordName
+            recordName: body.recordName,
+            recordChangeTag: body.recordChangeTag
           )
-          return try JSONEncoder().encode(
+          return try WebJSON.encoder().encode(
             WebResponse.Delete(
               recordName: body.recordName, deleted: true
             )

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend.swift
@@ -39,6 +39,7 @@
     internal struct QueryCall: Sendable {
       internal let recordType: String
       internal let limit: Int?
+      internal let sortBy: [WebRequests.QuerySortField]?
     }
 
     internal struct CreateCall: Sendable {
@@ -50,11 +51,13 @@
       internal let recordType: String
       internal let recordName: String
       internal let fields: [String: String]
+      internal let recordChangeTag: String?
     }
 
     internal struct DeleteCall: Sendable {
       internal let recordType: String
       internal let recordName: String
+      internal let recordChangeTag: String?
     }
 
     internal private(set) var lastQuery: QueryCall?
@@ -85,15 +88,24 @@
       )
     }
 
-    /// Flatten FieldValue.string entries back to plain strings so tests
-    /// can `#expect(captured.fields["title"] == "Hi")` without unwrapping.
+    /// Flatten FieldValue entries into a printable form so tests can write
+    /// `#expect(captured.fields["title"] == "Hi")` for strings or
+    /// `#expect(captured.fields["index"] == "5")` for numbers without
+    /// pattern-matching on FieldValue in every assertion.
     private static func flatten(
       _ fields: [String: FieldValue]
     ) -> [String: String] {
       var result: [String: String] = [:]
       for (name, value) in fields {
-        if case .string(let string) = value {
+        switch value {
+        case .string(let string):
           result[name] = string
+        case .int64(let int):
+          result[name] = String(int)
+        case .double(let double):
+          result[name] = String(double)
+        default:
+          continue
         }
       }
       return result
@@ -104,9 +116,13 @@
     }
 
     internal func webQuery(
-      recordType: String, limit: Int?
+      recordType: String,
+      limit: Int?,
+      sortBy: [WebRequests.QuerySortField]?
     ) async throws -> [RecordInfo] {
-      lastQuery = QueryCall(recordType: recordType, limit: limit)
+      lastQuery = QueryCall(
+        recordType: recordType, limit: limit, sortBy: sortBy
+      )
       try consumePendingError()
       return [
         Self.stubRecord(recordType: recordType, recordName: "stub-1")
@@ -129,12 +145,14 @@
     internal func webUpdate(
       recordType: String,
       recordName: String,
-      fields: [String: FieldValue]
+      fields: [String: FieldValue],
+      recordChangeTag: String?
     ) async throws -> RecordInfo {
       lastUpdate = UpdateCall(
         recordType: recordType,
         recordName: recordName,
-        fields: Self.flatten(fields)
+        fields: Self.flatten(fields),
+        recordChangeTag: recordChangeTag
       )
       try consumePendingError()
       return Self.stubRecord(
@@ -143,10 +161,14 @@
     }
 
     internal func webDelete(
-      recordType: String, recordName: String
+      recordType: String,
+      recordName: String,
+      recordChangeTag: String?
     ) async throws {
       lastDelete = DeleteCall(
-        recordType: recordType, recordName: recordName
+        recordType: recordType,
+        recordName: recordName,
+        recordChangeTag: recordChangeTag
       )
       try consumePendingError()
     }

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend.swift
@@ -92,6 +92,11 @@
     /// `#expect(captured.fields["title"] == "Hi")` for strings or
     /// `#expect(captured.fields["index"] == "5")` for numbers without
     /// pattern-matching on FieldValue in every assertion.
+    ///
+    /// Non-primitive cases (asset, date, reference, location, list, bytes)
+    /// are intentionally dropped — they yield no useful String form for an
+    /// equality assertion. Tests that need to assert those types should
+    /// inspect the FieldValue directly rather than going through `flatten`.
     private static func flatten(
       _ fields: [String: FieldValue]
     ) -> [String: String] {

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/WebJSONTests.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/WebJSONTests.swift
@@ -1,6 +1,6 @@
 //
-//  WebJSON.swift
-//  MistDemo
+//  WebJSONTests.swift
+//  MistDemoTests
 //
 //  Created by Leo Dion.
 //  Copyright © 2026 BrightDigit.
@@ -27,18 +27,30 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-internal import Foundation
+#if canImport(Hummingbird)
+  import Foundation
+  import Testing
 
-/// Shared JSON encoder for the web demo's CRUD response bodies.
-///
-/// Uses `.millisecondsSince1970` so timestamps in `RecordInfo.created` /
-/// `RecordInfo.modified` arrive in the browser as epoch-millis numbers
-/// that JS can pass to `new Date(ms)` — the same shape CloudKit Web
-/// Services returns to CloudKit JS.
-internal enum WebJSON {
-  internal static func encoder() -> JSONEncoder {
-    let encoder = JSONEncoder()
-    encoder.dateEncodingStrategy = .millisecondsSince1970
-    return encoder
+  @testable import MistDemoKit
+
+  @Suite("WebJSON")
+  internal struct WebJSONTests {
+    private struct DateWrapper: Codable {
+      let date: Date
+    }
+
+    @Test("encoder writes Date as epoch-millis numbers")
+    internal func encoderEmitsEpochMillis() throws {
+      // 1500ms since 1970-01-01T00:00:00Z — chosen so the expected JSON
+      // value is a plain integer the browser's `new Date(1500)` can consume.
+      let date = Date(timeIntervalSince1970: 1.5)
+
+      let data = try WebJSON.encoder().encode(DateWrapper(date: date))
+
+      let json = try #require(
+        try JSONSerialization.jsonObject(with: data) as? [String: Any]
+      )
+      #expect(json["date"] as? Double == 1_500)
+    }
   }
-}
+#endif

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+CRUD.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+CRUD.swift
@@ -97,8 +97,58 @@
       #expect(captured?.fields["title"] == "Hi")
     }
 
-    @Test("POST /api/records/update forwards record name + fields")
+    @Test("POST /api/records/create accepts JSON-number fields (Int + Double)")
+    internal func createAcceptsNumericFields() async throws {
+      let fixture = Self.makeFixture(authenticated: true)
+      let app = Application(router: try fixture.server.makeRouter())
+      let jsonBody = """
+        {"recordType":"Note","fields":{"title":"Hi","index":5,"score":1.5}}
+        """
+      try await app.test(.router) { client in
+        try await client.execute(
+          uri: "/api/records/create",
+          method: .post,
+          headers: [.contentType: "application/json"],
+          body: ByteBuffer(string: jsonBody)
+        ) { response in
+          #expect(response.status == .ok)
+        }
+      }
+      let captured = await fixture.backend.lastCreate
+      #expect(captured?.fields["title"] == "Hi")
+      #expect(captured?.fields["index"] == "5")
+      #expect(captured?.fields["score"] == "1.5")
+    }
+
+    @Test("POST /api/records/update forwards recordName, fields, changeTag")
     internal func updateForwards() async throws {
+      let fixture = Self.makeFixture(authenticated: true)
+      let app = Application(router: try fixture.server.makeRouter())
+      let jsonBody = """
+        {"recordType":"Note","recordName":"abc","fields":{"title":"Up"},\
+        "recordChangeTag":"tag-1"}
+        """
+
+      try await app.test(.router) { client in
+        try await client.execute(
+          uri: "/api/records/update",
+          method: .post,
+          headers: [.contentType: "application/json"],
+          body: ByteBuffer(string: jsonBody)
+        ) { response in
+          #expect(response.status == .ok)
+        }
+      }
+
+      let captured = await fixture.backend.lastUpdate
+      #expect(captured?.recordType == "Note")
+      #expect(captured?.recordName == "abc")
+      #expect(captured?.fields["title"] == "Up")
+      #expect(captured?.recordChangeTag == "tag-1")
+    }
+
+    @Test("POST /api/records/update accepts a missing recordChangeTag")
+    internal func updateAcceptsAbsentChangeTag() async throws {
       let fixture = Self.makeFixture(authenticated: true)
       let app = Application(router: try fixture.server.makeRouter())
       let jsonBody = """
@@ -117,16 +167,16 @@
       }
 
       let captured = await fixture.backend.lastUpdate
-      #expect(captured?.recordType == "Note")
-      #expect(captured?.recordName == "abc")
-      #expect(captured?.fields["title"] == "Up")
+      #expect(captured?.recordChangeTag == nil)
     }
 
-    @Test("POST /api/records/delete forwards record name")
+    @Test("POST /api/records/delete forwards recordName + changeTag")
     internal func deleteForwards() async throws {
       let fixture = Self.makeFixture(authenticated: true)
       let app = Application(router: try fixture.server.makeRouter())
-      let jsonBody = #"{"recordType":"Note","recordName":"abc"}"#
+      let jsonBody = #"""
+        {"recordType":"Note","recordName":"abc","recordChangeTag":"tag-9"}
+        """#
 
       try await app.test(.router) { client in
         try await client.execute(
@@ -148,6 +198,7 @@
       let captured = await fixture.backend.lastDelete
       #expect(captured?.recordType == "Note")
       #expect(captured?.recordName == "abc")
+      #expect(captured?.recordChangeTag == "tag-9")
     }
 
     @Test("Backend errors surface as 500 with a JSON message body")

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+QuerySort.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+QuerySort.swift
@@ -1,0 +1,87 @@
+//
+//  WebServerTests+QuerySort.swift
+//  MistDemoTests
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if canImport(Hummingbird)
+  import Foundation
+  import HTTPTypes
+  import Hummingbird
+  import HummingbirdTesting
+  import MistKit
+  import Testing
+
+  @testable import MistDemoKit
+
+  extension WebServerTests {
+    @Test("POST /api/records/query forwards sortBy to the backend")
+    internal func queryForwardsSort() async throws {
+      let fixture = Self.makeFixture(authenticated: true)
+      let app = Application(router: try fixture.server.makeRouter())
+      let jsonBody = """
+        {"recordType":"Note","sortBy":[\
+        {"field":"___modTime","ascending":false}]}
+        """
+
+      try await app.test(.router) { client in
+        try await client.execute(
+          uri: "/api/records/query",
+          method: .post,
+          headers: [.contentType: "application/json"],
+          body: ByteBuffer(string: jsonBody)
+        ) { response in
+          #expect(response.status == .ok)
+        }
+      }
+
+      let captured = await fixture.backend.lastQuery
+      #expect(captured?.sortBy?.count == 1)
+      #expect(captured?.sortBy?.first?.field == "___modTime")
+      #expect(captured?.sortBy?.first?.ascending == false)
+    }
+
+    @Test("POST /api/records/query without sortBy passes nil")
+    internal func queryWithoutSortIsNil() async throws {
+      let fixture = Self.makeFixture(authenticated: true)
+      let app = Application(router: try fixture.server.makeRouter())
+
+      try await app.test(.router) { client in
+        try await client.execute(
+          uri: "/api/records/query",
+          method: .post,
+          headers: [.contentType: "application/json"],
+          body: ByteBuffer(string: #"{"recordType":"Note"}"#)
+        ) { response in
+          #expect(response.status == .ok)
+        }
+      }
+
+      let captured = await fixture.backend.lastQuery
+      #expect(captured?.sortBy == nil)
+    }
+  }
+#endif

--- a/Examples/MistDemo/examples/README.md
+++ b/Examples/MistDemo/examples/README.md
@@ -94,10 +94,10 @@ swift run mistdemo query --record-type Note --limit 10
 swift run mistdemo query --filter "title:contains:important" --filter "priority:gt:5"
 
 # With sorting
-swift run mistdemo query --sort "createdAt:desc" --limit 5
+swift run mistdemo query --sort "index:desc" --limit 5
 
 # Field selection
-swift run mistdemo query --fields "title,createdAt,priority"
+swift run mistdemo query --fields "title,index"
 ```
 
 ### 📤 upload-asset.sh

--- a/Examples/MistDemo/examples/query-records.sh
+++ b/Examples/MistDemo/examples/query-records.sh
@@ -63,18 +63,18 @@ swift run mistdemo query $COMMON_ARGS --record-type Note \
     --output-format table
 
 echo ""
-echo -e "${GREEN}Example 4: Query with sorting (newest first)${NC}"
-echo "Command: swift run mistdemo query $COMMON_ARGS --sort \"createdAt:desc\""
+echo -e "${GREEN}Example 4: Query with sorting (by index, descending)${NC}"
+echo "Command: swift run mistdemo query $COMMON_ARGS --sort \"index:desc\""
 swift run mistdemo query $COMMON_ARGS --record-type Note \
-    --sort "createdAt:desc" \
+    --sort "index:desc" \
     --limit 5 \
     --output-format table
 
 echo ""
 echo -e "${GREEN}Example 5: Query with field selection${NC}"
-echo "Command: swift run mistdemo query $COMMON_ARGS --fields \"title,createdAt,priority\""
+echo "Command: swift run mistdemo query $COMMON_ARGS --fields \"title,index\""
 swift run mistdemo query $COMMON_ARGS --record-type Note \
-    --fields "title,createdAt,priority" \
+    --fields "title,index" \
     --limit 5 \
     --output-format table
 

--- a/Examples/MistDemo/schema.ckdb
+++ b/Examples/MistDemo/schema.ckdb
@@ -2,11 +2,11 @@ DEFINE SCHEMA
 
 RECORD TYPE Note (
     "___recordID"            REFERENCE QUERYABLE,
+    "___createTime"          TIMESTAMP QUERYABLE SORTABLE,
+    "___modTime"             TIMESTAMP QUERYABLE SORTABLE,
     "title"                  STRING QUERYABLE SORTABLE SEARCHABLE,
     "index"                  INT64 QUERYABLE SORTABLE,
     "image"                  ASSET,
-    "createdAt"              TIMESTAMP QUERYABLE SORTABLE,
-    "modified"               INT64 QUERYABLE,
 
     GRANT READ, CREATE, WRITE TO "_creator",
     GRANT READ, CREATE, WRITE TO "_icloud",


### PR DESCRIPTION
## Summary

Iterates on top of #329's CloudKit JS mode toggle (PR #335). The single-mode JSON-textarea CRUD grid is replaced by a Notes table beside a Title/Index form; clicking a row loads it for edit, per-row Delete, "New" to clear. Auto-refreshes after every mutation and on mode switch.

- **UI** — two-column responsive layout (stacks below 820px). Created and Modified columns formatted with locale `dateStyle:short`/`timeStyle:short`; ISO in cell tooltip. Created/Modified column headers are clickable: unsorted → ↑ → ↓ → unsorted. Record name is now a row tooltip (no longer a column).
- **Note schema** — drop the redundant custom `createdAt` (TIMESTAMP) and `modified` (INT64) fields; the demo now reads CloudKit system metadata (`CKRecord.creationDate` / `.modificationDate`, Web Services `created.timestamp` / `modified.timestamp`). Native model, views, integration phases, README, and CLI examples follow.
- **Schema additions** — explicit `___createTime` and `___modTime` with `QUERYABLE SORTABLE`. System fields default to non-sortable; they must be opted in for the new sort feature to work end-to-end.
- **Server** — new `WebJSON.encoder()/.decoder()` with `.millisecondsSince1970` date strategy so the browser receives epoch millis. `WebRequests.Query` gains `sortBy`. `WebRequests.Update`/`.Delete` gain optional `recordChangeTag`. `WebRequests.Create`/`.Update.fields` are now `[String: FieldValue]` decoded through MistKit's existing custom Codable.
- **Bug fixes hit while testing the rework** — `BadRequestException: missing recordChangeTag` on delete/update (now threaded through from the loaded row); `HTTP 400` on create when sending `"index": 5` as a JSON number against the prior `[String: String]` decoder; `Error raised at top level` crash on Ctrl+C (WebCommand now catches `AsyncTimeoutError.cancelled` as a clean shutdown).

## Schema deployment

The new `___createTime` / `___modTime` SORTABLE entries and the dropped `createdAt` / `modified` fields need to be deployed to the live CloudKit container manually (`cktool` or the dashboard) before sort works end-to-end. Default sort is `nil`, so unsorted listings work against either schema version.

## Test plan
- [x] `swift test` from `Examples/MistDemo` — 924 tests pass.
- [x] `Scripts/lint.sh` — exits successfully (swift-format + swiftlint + build + header check all green; trailing periphery warnings are pre-existing on the MistKit core).
- [ ] Manual: create a Note with title + numeric index in MistKit mode → row appears, table auto-refreshes.
- [ ] Manual: click row, edit title, Save → row updates without `recordChangeTag` error.
- [ ] Manual: per-row Delete → row removed, no `BadRequestException`.
- [ ] Manual: click Modified column → notes resort, ↓ indicator shows; click again → ↑; click again → unsorted. Same flow in CloudKit JS mode after deploying the SORTABLE system fields.
- [ ] Manual: Ctrl+C the `mistdemo web` server → prints `Server stopped.` and exits 0.

## Out of scope

- Public/private DB picker — that's #275, next on the #330 roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)