### PR TITLE
Resolve #338: per-call PublicAuthPreference encoded in Database

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,12 +290,33 @@ A `ClientTransport` extension could provide a generic upload method, but would n
 ### CloudKit Web Services Integration
 - Base URL: `https://api.apple-cloudkit.com`
 - Authentication:
-  - **Public database**: `CLOUDKIT_KEY_ID` + `CLOUDKIT_PRIVATE_KEY` or `CLOUDKIT_PRIVATE_KEY_PATH` → server-to-server signing
-  - **Private database**: `CLOUDKIT_API_TOKEN` + `CLOUDKIT_WEB_AUTH_TOKEN` → web authentication
+  - **Public database**: caller picks per-call via `PublicAuthPreference` carried on `Database.public(_:)`. Either `.requires(.serverToServer)` (key-pair signing — needs `CLOUDKIT_KEY_ID` + `CLOUDKIT_PRIVATE_KEY` or `CLOUDKIT_PRIVATE_KEY_PATH`) or `.requires(.webAuth)` (user-attributed — needs `CLOUDKIT_API_TOKEN` + `CLOUDKIT_WEB_AUTH_TOKEN`). Use `.prefers(_:)` to fall back to whichever cred is configured.
+  - **Private / Shared database**: always `CLOUDKIT_API_TOKEN` + `CLOUDKIT_WEB_AUTH_TOKEN` → web-auth (CloudKit rejects S2S on these scopes).
 - All operations should reference the OpenAPI spec in `openapi.yaml`
 - URL Pattern: `/database/{version}/{container}/{environment}/{database}/{operation}`
-- Supported databases: `public`, `private`, `shared`
+- Supported databases: `Database.public(PublicAuthPreference)`, `Database.private`, `Database.shared`
 - Environments: `development`, `production`
+
+### Per-call attribution for `.public`
+
+`Database` carries the signing choice when targeting public:
+
+```swift
+public enum Database {
+  case `public`(PublicAuthPreference)
+  case `private`
+  case shared
+}
+```
+
+`PublicAuthPreference` is constructed via two factories — never via the (internal) memberwise init:
+
+- `.prefers(.serverToServer)` — try S2S, fall back to web-auth/API-token if S2S isn't configured.
+- `.prefers(.webAuth)` — try web-auth, fall back to S2S if web-auth isn't configured.
+- `.requires(.serverToServer)` — must use S2S; throw `missingCredentials(.preferenceRequired)` otherwise.
+- `.requires(.webAuth)` — must use web-auth; throw `missingCredentials(.preferenceRequired)` otherwise.
+
+There is **no default** on the operation `database:` parameter — every call must pick explicitly. The `requiresUserContext` flag on the dispatcher is gone; user-context routes (`users/*`) pass `.public(.requires(.webAuth))` directly. See `Sources/MistKit/Authentication/PublicAuthPreference.swift` and `Sources/MistKit/Authentication/Credentials/Credentials+TokenManager.swift`.
 
 ### Testing Strategy
 - Use Swift Testing framework (`@Test` macro) for all tests

--- a/Examples/MistDemo/Sources/MistDemoKit/CloudKit/MistKitClientFactory.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/CloudKit/MistKitClientFactory.swift
@@ -66,7 +66,7 @@ public struct MistKitClientFactory: Sendable {
       )
     #else
       if config.badCredentials {
-        guard config.database != .public else {
+        if case .public = config.database {
           throw ConfigurationError.badCredentialsOnPublicDB
         }
         return try create(from: config, tokenManager: makeBadCredentialsTokenManager())

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/CreateCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/CreateCommand.swift
@@ -84,8 +84,9 @@ public struct CreateCommand: MistDemoCommand, OutputFormatting {
       let recordInfo = try await client.createRecord(
         recordType: config.recordType,
         recordName: recordName,
-        fields: cloudKitFields
-          // Zone: config.zone - to be added when CloudKitService supports it
+        fields: cloudKitFields,
+        // Zone: config.zone - to be added when CloudKitService supports it
+        database: config.base.database
       )
 
       // Format and output result

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/DeleteCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/DeleteCommand.swift
@@ -90,7 +90,8 @@ public struct DeleteCommand: MistDemoCommand, OutputFormatting {
       try await client.deleteRecord(
         recordType: config.recordType,
         recordName: config.recordName,
-        recordChangeTag: effectiveChangeTag
+        recordChangeTag: effectiveChangeTag,
+        database: config.base.database
       )
 
       let result = DeleteResult(

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/DemoErrorsRunner+Output.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/DemoErrorsRunner+Output.swift
@@ -36,7 +36,7 @@ extension DemoErrorsRunner {
     print("🛑 CloudKit Error Demo — typed CloudKitError handling")
     print(String(repeating: "=", count: 80))
     print("Container: \(config.containerIdentifier)")
-    print("Database:  \(config.database.rawValue)")
+    print("Database:  \(config.database.pathSegment)")
     print(String(repeating: "=", count: 80))
   }
 

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/DemoErrorsRunner.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/DemoErrorsRunner.swift
@@ -145,7 +145,8 @@ internal struct DemoErrorsRunner {
       let created = try await service.createRecord(
         recordType: Self.conflictRecordType,
         recordName: recordName,
-        fields: ["title": .string("original")]
+        fields: ["title": .string("original")],
+        database: config.database
       )
       createdRecordName = created.recordName
       staleTag = created.recordChangeTag
@@ -160,7 +161,8 @@ internal struct DemoErrorsRunner {
         recordType: Self.conflictRecordType,
         recordName: recordName,
         fields: ["title": .string("first-update")],
-        recordChangeTag: staleTag
+        recordChangeTag: staleTag,
+        database: config.database
       )
     } catch {
       print("❌ Setup update failed: \(error)")
@@ -173,7 +175,8 @@ internal struct DemoErrorsRunner {
         recordType: Self.conflictRecordType,
         recordName: recordName,
         fields: ["title": .string("second-update-stale")],
-        recordChangeTag: staleTag
+        recordChangeTag: staleTag,
+        database: config.database
       )
       print("⚠️  Expected 409 but update was accepted.")
     } catch {
@@ -198,7 +201,8 @@ internal struct DemoErrorsRunner {
     do {
       try await service.deleteRecord(
         recordType: Self.conflictRecordType,
-        recordName: createdRecordName
+        recordName: createdRecordName,
+        database: config.database
       )
       print("   ✅ Deleted.")
     } catch {

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/DemoInFilterCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/DemoInFilterCommand.swift
@@ -106,7 +106,8 @@ public struct DemoInFilterCommand: MistDemoCommand {
         fields: [
           "title": .string("demo-in-filter-\(tag)-idx\(idx)"),
           "index": .int64(idx),
-        ]
+        ],
+        database: config.database
       )
       createdNames.append(record.recordName)
       print("  Created \(record.recordName) (index=\(idx))")
@@ -122,7 +123,9 @@ public struct DemoInFilterCommand: MistDemoCommand {
   ) async throws {
     print("\nVerifying records are queryable...")
     let allRecords = try await client.queryRecords(
-      recordType: recordType, limit: 200
+      recordType: recordType,
+      limit: 200,
+      database: config.database
     )
     let visible = allRecords.filter {
       createdNames.contains($0.recordName)
@@ -136,7 +139,8 @@ public struct DemoInFilterCommand: MistDemoCommand {
     let results = try await client.queryRecords(
       recordType: recordType,
       filters: [.in("index", [.int64(10), .int64(30)])],
-      limit: 200
+      limit: 200,
+      database: config.database
     )
 
     let matching = results.filter {
@@ -163,7 +167,10 @@ public struct DemoInFilterCommand: MistDemoCommand {
         recordType: recordType,
         recordName: name
       )
-      _ = try await client.modifyRecords([operation])
+      _ = try await client.modifyRecords(
+        [operation],
+        database: config.database
+      )
       print("  Deleted \(name)")
     }
     print("Done.")

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/FetchChangesCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/FetchChangesCommand.swift
@@ -108,7 +108,8 @@ public struct FetchChangesCommand: MistDemoCommand, OutputFormatting {
     print("\n📦 Fetching all changes (automatic pagination)...")
     let (records, newToken) = try await service.fetchAllRecordChanges(
       zoneID: zoneID,
-      syncToken: config.syncToken
+      syncToken: config.syncToken,
+      database: config.base.database
     )
     print("\n✅ Fetched \(records.count) record(s)")
     displayRecords(records, limit: 5)
@@ -125,7 +126,8 @@ public struct FetchChangesCommand: MistDemoCommand, OutputFormatting {
     let result = try await service.fetchRecordChanges(
       zoneID: zoneID,
       syncToken: config.syncToken,
-      resultsLimit: config.limit ?? 10
+      resultsLimit: config.limit ?? 10,
+      database: config.base.database
     )
     print("\n✅ Fetched \(result.records.count) record(s)")
     displayRecords(result.records, limit: 5)

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/LookupCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/LookupCommand.swift
@@ -78,7 +78,8 @@ public struct LookupCommand: MistDemoCommand, OutputFormatting {
 
       let records = try await client.lookupRecords(
         recordNames: config.recordNames,
-        desiredKeys: config.fields
+        desiredKeys: config.fields,
+        database: config.base.database
       )
 
       // Report missing names to stderr so a JSON/CSV/etc. stdout stream stays parseable

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/ModifyCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/ModifyCommand.swift
@@ -80,7 +80,9 @@ public struct ModifyCommand: MistDemoCommand, OutputFormatting {
         }
 
       let results = try await client.modifyRecords(
-        operations, atomic: config.atomic
+        operations,
+        atomic: config.atomic,
+        database: config.base.database
       )
 
       let rows = results.map { record in

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/QueryCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/QueryCommand.swift
@@ -81,14 +81,16 @@ public struct QueryCommand: MistDemoCommand, OutputFormatting {
           recordType: config.recordType,
           filters: filters,
           sortBy: nil,
-          limit: config.limit
+          limit: config.limit,
+          database: config.base.database
         )
       } else {
         recordInfos = try await client.queryRecords(
           recordType: config.recordType,
           filters: nil,
           sortBy: nil,
-          limit: config.limit
+          limit: config.limit,
+          database: config.base.database
         )
       }
 

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/UpdateCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/UpdateCommand.swift
@@ -106,7 +106,8 @@ public struct UpdateCommand: MistDemoCommand, OutputFormatting {
         recordType: config.recordType,
         recordName: config.recordName,
         fields: cloudKitFields,
-        recordChangeTag: effectiveChangeTag
+        recordChangeTag: effectiveChangeTag,
+        database: config.base.database
       )
 
       try await outputResult(recordInfo, format: config.output)

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/UploadAssetCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/UploadAssetCommand.swift
@@ -137,7 +137,8 @@ public struct UploadAssetCommand: MistDemoCommand, OutputFormatting {
       data: data,
       recordType: config.recordType,
       fieldName: config.fieldName,
-      recordName: config.recordName
+      recordName: config.recordName,
+      database: config.base.database
     )
     print("\n✅ Asset uploaded!")
     print("   Record Name: \(result.recordName)")
@@ -186,7 +187,8 @@ public struct UploadAssetCommand: MistDemoCommand, OutputFormatting {
       return try await service.createRecord(
         recordType: config.recordType,
         recordName: newRecordName,
-        fields: fields
+        fields: fields,
+        database: config.base.database
       )
     }
   }
@@ -197,7 +199,8 @@ public struct UploadAssetCommand: MistDemoCommand, OutputFormatting {
     service: CloudKitService
   ) async throws -> RecordInfo {
     let existingRecords = try await service.lookupRecords(
-      recordNames: [recordName]
+      recordNames: [recordName],
+      database: config.base.database
     )
     guard let existingRecord = existingRecords.first else {
       throw UploadAssetError.operationFailed(
@@ -208,7 +211,8 @@ public struct UploadAssetCommand: MistDemoCommand, OutputFormatting {
       recordType: config.recordType,
       recordName: recordName,
       fields: fields,
-      recordChangeTag: existingRecord.recordChangeTag
+      recordChangeTag: existingRecord.recordChangeTag,
+      database: config.base.database
     )
   }
 }

--- a/Examples/MistDemo/Sources/MistDemoKit/Configuration/MistDemoConfig.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Configuration/MistDemoConfig.swift
@@ -103,7 +103,7 @@ public struct MistDemoConfig: Sendable, ConfigurationParseable {
 
     let databaseString =
       config.string(forKey: "database", default: "public") ?? "public"
-    guard let database = MistKit.Database(rawValue: databaseString) else {
+    guard let database = MistDemoConfig.parseDatabase(databaseString) else {
       throw ConfigurationError.invalidDatabase(databaseString)
     }
     self.database = database
@@ -165,6 +165,27 @@ public struct MistDemoConfig: Sendable, ConfigurationParseable {
     self.testAdaptive = testAdaptive
     self.testServerToServer = testServerToServer
     self.badCredentials = badCredentials
+  }
+
+  /// Map a `"public" | "private" | "shared"` string to a `MistKit.Database`.
+  ///
+  /// `"public"` resolves to `.public(.prefers(.serverToServer))` to match
+  /// `toPrimaryCredentials()`'s "S2S-preferred, web-auth augments" policy.
+  /// Returns `nil` for unrecognized strings so callers can raise a
+  /// configuration error.
+  internal static func parseDatabase(
+    _ raw: String
+  ) -> MistKit.Database? {
+    switch raw {
+    case "public":
+      return .public(.prefers(.serverToServer))
+    case "private":
+      return .private
+    case "shared":
+      return .shared
+    default:
+      return nil
+    }
   }
 
   /// Returns a copy with the given database override.

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/PhasedIntegrationTest.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/PhasedIntegrationTest.swift
@@ -97,7 +97,7 @@ extension PhasedIntegrationTest {
     print("\u{1F9EA} Integration Test Suite: \(name)")
     print(String(repeating: "=", count: 80))
     print("Container: \(context.containerIdentifier)")
-    let dbLabel = database == .public ? "public" : "private"
+    let dbLabel = database.pathSegment == "public" ? "public" : "private"
     print("Database: \(dbLabel)")
     print("Record Count: \(context.recordCount)")
     print("Asset Size: \(context.assetSizeKB) KB")
@@ -118,7 +118,7 @@ extension PhasedIntegrationTest {
     )
     let cid = context.containerIdentifier
     print("   2. Select your container: \(cid)")
-    let dbName = database == .public ? "Public" : "Private"
+    let dbName = database.pathSegment == "public" ? "Public" : "Private"
     print(
       "   3. Navigate to \(dbName) Database \u{2192} Records"
     )

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/CleanupPhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/CleanupPhase.swift
@@ -59,7 +59,10 @@ internal struct CleanupPhase: IntegrationPhase, CleanupPhaseMarker {
     }
 
     do {
-      _ = try await context.service.modifyRecords(deleteOps)
+      _ = try await context.service.modifyRecords(
+        deleteOps,
+        database: context.database
+      )
       deletedCount = input.names.count
       if context.verbose {
         for name in input.names { print("   ✅ Deleted: \(name)") }

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/CreateRecordsPhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/CreateRecordsPhase.swift
@@ -59,7 +59,8 @@ internal struct CreateRecordsPhase: IntegrationPhase {
           "title": .string("Test Record \(recordIndex)"),
           "index": .int64(recordIndex),
           "image": .asset(input.asset),
-        ]
+        ],
+        database: context.database
       )
       createdRecordNames.append(record.recordName)
       if context.verbose {

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/IncrementalSyncPhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/IncrementalSyncPhase.swift
@@ -56,7 +56,10 @@ internal struct IncrementalSyncPhase: IntegrationPhase {
     }
 
     do {
-      let incrementalResult = try await context.service.fetchRecordChanges(syncToken: token)
+      let incrementalResult = try await context.service.fetchRecordChanges(
+        syncToken: token,
+        database: context.database
+      )
 
       print("✅ Fetched \(incrementalResult.records.count) changed records")
 

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/InitialSyncPhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/InitialSyncPhase.swift
@@ -44,7 +44,9 @@ internal struct InitialSyncPhase: IntegrationPhase {
     print("\n\(Self.emoji) \(Self.title)")
 
     do {
-      let initialResult = try await context.service.fetchRecordChanges()
+      let initialResult = try await context.service.fetchRecordChanges(
+        database: context.database
+      )
 
       print("✅ Fetched \(initialResult.records.count) records")
 

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/LookupRecordsPhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/LookupRecordsPhase.swift
@@ -48,7 +48,10 @@ internal struct LookupRecordsPhase: IntegrationPhase {
       print("   Looking up \(lookupNames.count) of \(input.names.count) record(s) by name")
     }
 
-    let records = try await context.service.lookupRecords(recordNames: lookupNames)
+    let records = try await context.service.lookupRecords(
+      recordNames: lookupNames,
+      database: context.database
+    )
 
     print("✅ Looked up \(records.count) record(s)")
 

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/ModifyRecordsPhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/ModifyRecordsPhase.swift
@@ -56,7 +56,10 @@ internal struct ModifyRecordsPhase: IntegrationPhase {
       )
     }
 
-    _ = try await context.service.modifyRecords(operations)
+    _ = try await context.service.modifyRecords(
+      operations,
+      database: context.database
+    )
 
     if context.verbose {
       for recordName in recordsToUpdate {

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/UploadAssetPhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/UploadAssetPhase.swift
@@ -53,7 +53,8 @@ internal struct UploadAssetPhase: IntegrationPhase {
     let receipt = try await context.service.uploadAssets(
       data: testData,
       recordType: IntegrationTestData.recordType,
-      fieldName: "image"
+      fieldName: "image",
+      database: context.database
     )
 
     print("✅ Uploaded asset: \(testData.count) bytes")

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Tests/PublicDatabaseTest.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Tests/PublicDatabaseTest.swift
@@ -43,13 +43,13 @@ internal struct PublicDatabaseTest: PhasedIntegrationTest {
   ///     call from the service's `Credentials`. The runner sets this based on
   ///     whether web-auth credentials are configured.
   internal init(
-    database: MistKit.Database = .public,
+    database: MistKit.Database = .public(.prefers(.serverToServer)),
     includeUserContextPhases: Bool = false
   ) {
-    precondition(
-      database == .public,
-      "PublicDatabaseTest only supports the public database"
-    )
+    if case .public = database {
+    } else {
+      preconditionFailure("PublicDatabaseTest only supports the public database")
+    }
     self.database = database
 
     var phases: [any IntegrationPhase] = [

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebRequests.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebRequests.swift
@@ -185,7 +185,7 @@ internal enum WebRequests {
     else {
       return defaultDatabase
     }
-    guard let database = MistKit.Database(rawValue: raw) else {
+    guard let database = MistDemoConfig.parseDatabase(raw) else {
       throw DecodingError.dataCorruptedError(
         forKey: key,
         in: container,

--- a/Examples/MistDemo/Sources/MistDemoKit/Utilities/AuthenticationHelper+SetupHelpers.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Utilities/AuthenticationHelper+SetupHelpers.swift
@@ -38,7 +38,7 @@ extension AuthenticationHelper {
     privateKeyFile: String?,
     databaseOverride: MistKit.Database?
   ) async throws -> AuthenticationResult {
-    let database = MistKit.Database.public
+    let database: MistKit.Database = .public(.prefers(.serverToServer))
 
     if databaseOverride == .private {
       throw AuthenticationError.serverToServerRequiresPublicDatabase
@@ -85,7 +85,7 @@ extension AuthenticationHelper {
     apiToken: String,
     databaseOverride: MistKit.Database?
   ) async throws -> AuthenticationResult {
-    let database = MistKit.Database.public
+    let database: MistKit.Database = .public(.prefers(.serverToServer))
 
     if databaseOverride == .private {
       throw AuthenticationError.privateRequiresWebAuth

--- a/Examples/MistDemo/Tests/MistDemoTests/CloudKit/MistKitClientFactory/MistKitClientFactoryTests+BadCredentials.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/CloudKit/MistKitClientFactory/MistKitClientFactoryTests+BadCredentials.swift
@@ -66,7 +66,7 @@ extension MistKitClientFactoryTests {
     internal func badCredentialsOnPublicDatabaseThrows() async throws {
       let config = try await MistKitClientFactoryTests.makeConfig(
         apiToken: "real-config-token",
-        database: .public,
+        database: .public(.prefers(.serverToServer)),
         keyID: "real-key-id",
         privateKey: MistKitClientFactoryTests.validPrivateKey,
         badCredentials: true

--- a/Examples/MistDemo/Tests/MistDemoTests/CloudKit/MistKitClientFactory/MistKitClientFactoryTests+CustomTokenManager.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/CloudKit/MistKitClientFactory/MistKitClientFactoryTests+CustomTokenManager.swift
@@ -52,7 +52,7 @@ extension MistKitClientFactoryTests {
     @Test("Create client with custom token manager for public database")
     internal func createWithCustomTokenManagerPublicDB() async throws {
       let config = try await MistKitClientFactoryTests.makeConfig(
-        apiToken: "api-token", database: .public
+        apiToken: "api-token", database: .public(.prefers(.serverToServer))
       )
       let tokenManager = APITokenManager(apiToken: "custom-token")
 

--- a/Examples/MistDemo/Tests/MistDemoTests/CloudKit/MistKitClientFactory/MistKitClientFactoryTests+PublicDatabase.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/CloudKit/MistKitClientFactory/MistKitClientFactoryTests+PublicDatabase.swift
@@ -39,7 +39,7 @@ extension MistKitClientFactoryTests {
     @Test("Create client for public database")
     internal func createForPublicDatabaseTest() async throws {
       let config = try await MistKitClientFactoryTests.makeConfig(
-        apiToken: "api-token", database: .public
+        apiToken: "api-token", database: .public(.prefers(.serverToServer))
       )
       let tokenManager = APITokenManager(apiToken: "api-token")
 
@@ -53,7 +53,9 @@ extension MistKitClientFactoryTests {
 
     @Test("Public database creation requires API token")
     internal func publicDatabaseRequiresAPIToken() async throws {
-      let config = try await MistKitClientFactoryTests.makeConfig(apiToken: "", database: .public)
+      let config = try await MistKitClientFactoryTests.makeConfig(
+        apiToken: "", database: .public(.prefers(.serverToServer))
+      )
 
       #expect(throws: ConfigurationError.self) {
         try MistKitClientFactory.create(for: config)

--- a/Examples/MistDemo/Tests/MistDemoTests/Configuration/AuthenticationCredentialsTests+ToConfiguration.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Configuration/AuthenticationCredentialsTests+ToConfiguration.swift
@@ -45,7 +45,7 @@ extension AuthenticationCredentialsTests {
     @Test("public with raw private key produces serverToServer with .raw material")
     internal func publicWithRawKey() async throws {
       let config = try await MistKitClientFactoryTests.makeConfig(
-        database: .public,
+        database: .public(.prefers(.serverToServer)),
         keyID: "test-key-id",
         privateKey: MistKitClientFactoryTests.validPrivateKey
       )
@@ -69,7 +69,7 @@ extension AuthenticationCredentialsTests {
         containerIdentifier: "iCloud.com.test.App",
         apiToken: "test-api-token",
         environment: .development,
-        database: .public,
+        database: .public(.prefers(.serverToServer)),
         webAuthToken: nil,
         keyID: "test-key-id",
         privateKey: nil,
@@ -100,7 +100,7 @@ extension AuthenticationCredentialsTests {
     @Test("public missing keyID throws missingRequired(\"key.id\")")
     internal func publicMissingKeyIDThrows() async throws {
       let config = try await MistKitClientFactoryTests.makeConfig(
-        database: .public,
+        database: .public(.prefers(.serverToServer)),
         keyID: "",
         privateKey: MistKitClientFactoryTests.validPrivateKey
       )
@@ -120,7 +120,7 @@ extension AuthenticationCredentialsTests {
     @Test("public missing private key material throws missingRequired(\"private.key\")")
     internal func publicMissingPrivateKeyThrows() async throws {
       let config = try await MistKitClientFactoryTests.makeConfig(
-        database: .public,
+        database: .public(.prefers(.serverToServer)),
         keyID: "test-key-id"
       )
 
@@ -177,7 +177,7 @@ extension AuthenticationCredentialsTests {
     internal func publicEmbedsAPIAuthWhenAvailable() async throws {
       let config = try await MistKitClientFactoryTests.makeConfig(
         apiToken: "api",
-        database: .public,
+        database: .public(.prefers(.serverToServer)),
         webAuthToken: "web",
         keyID: "k",
         privateKey: MistKitClientFactoryTests.validPrivateKey
@@ -194,7 +194,7 @@ extension AuthenticationCredentialsTests {
     internal func publicOmitsAPIAuthWhenWebAuthMissing() async throws {
       let config = try await MistKitClientFactoryTests.makeConfig(
         apiToken: "",
-        database: .public,
+        database: .public(.prefers(.serverToServer)),
         webAuthToken: nil,
         keyID: "k",
         privateKey: MistKitClientFactoryTests.validPrivateKey

--- a/Examples/MistDemo/Tests/MistDemoTests/Configuration/TestPrivateConfigTests.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Configuration/TestPrivateConfigTests.swift
@@ -71,12 +71,12 @@ internal struct TestPrivateConfigTests {
     // Even though we configure the base for the public DB, TestPrivateConfig
     // must override to `.private`. The init also requires web-auth credentials.
     let baseConfig = try await MistDemoConfig(
-      database: .public,
+      database: .public(.prefers(.serverToServer)),
       webAuthToken: "wat-xyz"
     )
     let config = TestPrivateConfig(base: baseConfig.with(database: .private))
 
-    #expect(config.base.database == .private)
+    #expect(config.base.database == MistKit.Database.private)
   }
 
   @Test("Memberwise init preserves base configuration values")

--- a/Examples/MistDemo/Tests/MistDemoTests/MistDemoConfig+Testing.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/MistDemoConfig+Testing.swift
@@ -92,7 +92,7 @@ extension MistDemoConfig {
       key("container.identifier"): .init(stringLiteral: containerIdentifier),
       key("api.token"): .init(stringLiteral: apiToken),
       key("environment"): .init(stringLiteral: envString),
-      key("database"): .init(stringLiteral: database.rawValue),
+      key("database"): .init(stringLiteral: database.pathSegment),
       key("host"): .init(stringLiteral: host),
       key("port"): .init(integerLiteral: port),
       key("auth.timeout"): .init(integerLiteral: Int(authTimeout)),

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+Database.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+Database.swift
@@ -110,7 +110,7 @@
       default:
         captured = nil
       }
-      #expect(captured == .public)
+      #expect(captured == .public(.prefers(.serverToServer)))
     }
 
     @Test("CRUD requests with an unknown `database` value return 400")

--- a/Examples/MistDemo/Tests/MistDemoTests/Utilities/AuthenticationHelper/AuthenticationHelperTests+APIOnlyAuthentication.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Utilities/AuthenticationHelper/AuthenticationHelperTests+APIOnlyAuthentication.swift
@@ -48,7 +48,7 @@ extension AuthenticationHelperTests {
           databaseOverride: nil
         )
 
-        #expect(result.database == .public)
+        #expect(result.database == .public(.prefers(.serverToServer)))
         #expect(result.authMethod.contains("API-only"))
       } catch AuthenticationError.invalidAPIToken {
         // Expected with test token

--- a/Examples/MistDemo/Tests/MistDemoTests/Utilities/AuthenticationHelper/AuthenticationHelperTests+AuthenticationMethodPriority.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Utilities/AuthenticationHelper/AuthenticationHelperTests+AuthenticationMethodPriority.swift
@@ -51,7 +51,7 @@ extension AuthenticationHelperTests {
           databaseOverride: nil
         )
 
-        #expect(result.database == .public)
+        #expect(result.database == .public(.prefers(.serverToServer)))
         #expect(result.authMethod.contains("Server-to-server"))
       } catch AuthenticationError.invalidServerToServerCredentials {
         // Expected with test credentials

--- a/Examples/MistDemo/Tests/MistDemoTests/Utilities/AuthenticationHelper/AuthenticationHelperTests+ServerToServerAuthentication.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Utilities/AuthenticationHelper/AuthenticationHelperTests+ServerToServerAuthentication.swift
@@ -70,7 +70,7 @@ extension AuthenticationHelperTests {
         )
 
         // If we get here, validation succeeded (unlikely with test key)
-        #expect(result.database == .public)
+        #expect(result.database == .public(.prefers(.serverToServer)))
         #expect(result.authMethod.contains("Server-to-server"))
       } catch AuthenticationError.invalidServerToServerCredentials {
         // Expected - test key won't validate
@@ -93,7 +93,7 @@ extension AuthenticationHelperTests {
           databaseOverride: nil
         )
 
-        #expect(result.database == .public)
+        #expect(result.database == .public(.prefers(.serverToServer)))
         #expect(result.authMethod.contains("Server-to-server"))
       } catch AuthenticationError.invalidServerToServerCredentials {
         // Expected with test key

--- a/Examples/MistDemo/Tests/MistDemoTests/Utilities/AuthenticationHelper/AuthenticationHelperTests+WebAuthentication.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Utilities/AuthenticationHelper/AuthenticationHelperTests+WebAuthentication.swift
@@ -69,10 +69,10 @@ extension AuthenticationHelperTests {
           keyID: nil,
           privateKey: nil,
           privateKeyFile: nil,
-          databaseOverride: .public
+          databaseOverride: .public(.prefers(.serverToServer))
         )
 
-        #expect(result.database == .public)
+        #expect(result.database == .public(.prefers(.serverToServer)))
         #expect(result.authMethod.contains("Web authentication"))
         #expect(result.authMethod.contains("public"))
       } catch AuthenticationError.invalidWebAuthCredentials {

--- a/Sources/MistKit/Authentication/Credentials/Credentials+TokenManager.swift
+++ b/Sources/MistKit/Authentication/Credentials/Credentials+TokenManager.swift
@@ -31,20 +31,19 @@
 extension Credentials {
   /// Resolve the appropriate token manager for an outgoing request.
   ///
-  /// Picks among the populated `serverToServer` and `apiAuth` credentials
-  /// based on the target `database` and whether the route requires
-  /// user-context authentication:
+  /// The signing choice is encoded in `database`:
+  /// - `.public(let auth)` consults `auth` and the populated credential sets
+  ///   per the table below.
+  /// - `.private` / `.shared` always use web-auth — CloudKit rejects
+  ///   server-to-server signing on those scopes — and require
+  ///   `apiAuth.webAuthToken`.
   ///
-  /// - `requiresUserContext == true`: web-auth is mandatory regardless of
-  ///   database. CloudKit's user-identity routes (`fetchCaller`,
-  ///   `lookupUsersByEmail`, `lookupUsersByRecordName`,
-  ///   `discoverAllUserIdentities`) live on `.public` but still need
-  ///   web-auth to identify the caller.
-  /// - `.public` + no user context: prefers server-to-server signing, falls
-  ///   back to web-auth, then bare API-token.
-  /// - `.private` / `.shared`: requires `apiAuth.webAuthToken`. CloudKit
-  ///   rejects server-to-server signing for these databases, so any
-  ///   `serverToServer` material is ignored on this path.
+  /// Resolution for `.public(let auth)`:
+  /// - `auth.required` + mode's creds present → use `auth.mode`.
+  /// - `auth.required` + mode's creds absent → throw `.preferenceRequired`.
+  /// - `auth.prefers` + mode's creds present → use `auth.mode`.
+  /// - `auth.prefers` + mode's creds absent → fall back to the other mode.
+  /// - `auth.prefers` + neither mode configured → throw `.notConfigured`.
   ///
   /// - Throws: `CloudKitError.missingCredentials` when no populated credential
   ///   set can satisfy the requested combination,
@@ -52,63 +51,78 @@ extension Credentials {
   ///   read, or any error from `ServerToServerAuthManager.init` when the PEM
   ///   is malformed.
   internal func makeTokenManager(
-    for database: Database,
-    requiresUserContext: Bool = false
+    for database: Database
   ) throws -> any TokenManager {
-    if requiresUserContext {
-      return try makeUserContextTokenManager(database: database)
-    }
     switch database {
-    case .public:
-      return try makePublicTokenManager()
+    case .public(let auth):
+      return try makePublicTokenManager(auth: auth)
     case .private, .shared:
       return try makePrivateOrSharedTokenManager(database)
     }
   }
 
-  private func makeUserContextTokenManager(
-    database: Database
+  private func makePublicTokenManager(
+    auth: PublicAuthPreference
   ) throws -> any TokenManager {
-    guard let api = apiAuth, let webAuthToken = api.webAuthToken else {
-      throw CloudKitError.missingCredentials(
-        database: database,
-        reason: "user-context routes require apiAuth with a webAuthToken"
-      )
+    switch auth.mode {
+    case .serverToServer:
+      return try makePublicWithS2SPreference(auth: auth)
+    case .webAuth:
+      return try makePublicWithWebAuthPreference(auth: auth)
     }
-    return WebAuthTokenManager(
-      apiToken: api.apiToken,
-      webAuthToken: webAuthToken
-    )
   }
 
-  private func makePublicTokenManager() throws -> any TokenManager {
+  private func makePublicWithS2SPreference(
+    auth: PublicAuthPreference
+  ) throws -> any TokenManager {
     if let s2s = serverToServer {
-      let pem: String
-      do {
-        pem = try s2s.privateKey.loadPEM()
-      } catch {
-        throw CloudKitError.invalidPrivateKey(
-          path: s2s.privateKey.filePath,
-          underlying: error
-        )
-      }
-      return try ServerToServerAuthManager(
-        keyID: s2s.keyID,
-        pemString: pem
+      return try makeServerToServerManager(s2s)
+    }
+    if auth.required {
+      throw CloudKitError.missingCredentials(
+        database: .public(auth),
+        availability: .preferenceRequired,
+        reason: "PublicAuthPreference.requires(.serverToServer) "
+          + "but no serverToServer credentials are configured"
       )
     }
     if let api = apiAuth {
-      if let webAuthToken = api.webAuthToken {
-        return WebAuthTokenManager(
-          apiToken: api.apiToken,
-          webAuthToken: webAuthToken
-        )
-      }
-      return APITokenManager(apiToken: api.apiToken)
+      return makeAPITokenManager(api)
     }
     throw CloudKitError.missingCredentials(
-      database: .public,
+      database: .public(auth),
+      availability: .notConfigured,
       reason: "expected serverToServer or apiAuth credentials"
+    )
+  }
+
+  private func makePublicWithWebAuthPreference(
+    auth: PublicAuthPreference
+  ) throws -> any TokenManager {
+    if let api = apiAuth, let webAuthToken = api.webAuthToken {
+      return WebAuthTokenManager(
+        apiToken: api.apiToken,
+        webAuthToken: webAuthToken
+      )
+    }
+    if auth.required {
+      throw CloudKitError.missingCredentials(
+        database: .public(auth),
+        availability: .preferenceRequired,
+        reason: "PublicAuthPreference.requires(.webAuth) "
+          + "but no apiAuth.webAuthToken is configured"
+      )
+    }
+    if let s2s = serverToServer {
+      return try makeServerToServerManager(s2s)
+    }
+    if let api = apiAuth {
+      return makeAPITokenManager(api)
+    }
+    throw CloudKitError.missingCredentials(
+      database: .public(auth),
+      availability: .notConfigured,
+      reason: "expected apiAuth.webAuthToken or serverToServer credentials"
     )
   }
 
@@ -118,6 +132,7 @@ extension Credentials {
     guard let api = apiAuth, let webAuthToken = api.webAuthToken else {
       throw CloudKitError.missingCredentials(
         database: database,
+        availability: .notConfigured,
         reason:
           "private and shared databases require apiAuth with a webAuthToken"
       )
@@ -126,5 +141,35 @@ extension Credentials {
       apiToken: api.apiToken,
       webAuthToken: webAuthToken
     )
+  }
+
+  private func makeServerToServerManager(
+    _ s2s: ServerToServerCredentials
+  ) throws -> any TokenManager {
+    let pem: String
+    do {
+      pem = try s2s.privateKey.loadPEM()
+    } catch {
+      throw CloudKitError.invalidPrivateKey(
+        path: s2s.privateKey.filePath,
+        underlying: error
+      )
+    }
+    return try ServerToServerAuthManager(
+      keyID: s2s.keyID,
+      pemString: pem
+    )
+  }
+
+  private func makeAPITokenManager(
+    _ api: APICredentials
+  ) -> any TokenManager {
+    if let webAuthToken = api.webAuthToken {
+      return WebAuthTokenManager(
+        apiToken: api.apiToken,
+        webAuthToken: webAuthToken
+      )
+    }
+    return APITokenManager(apiToken: api.apiToken)
   }
 }

--- a/Sources/MistKit/Authentication/PublicAuthPreference.swift
+++ b/Sources/MistKit/Authentication/PublicAuthPreference.swift
@@ -1,0 +1,79 @@
+//
+//  PublicAuthPreference.swift
+//  MistKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+/// Per-call attribution choice for `Database.public` requests.
+///
+/// CloudKit's public database accepts two signing methods:
+/// server-to-server (key-pair signed, attributed to the developer key) and
+/// web-auth (user session token, attributed to the iCloud user). The same
+/// server legitimately writes some records as "the app" and others as
+/// "this user", so the choice is genuinely per-call.
+///
+/// Construct via the static factories — `internal init` keeps the four
+/// valid `(mode, required)` combinations the only reachable ones.
+///
+/// ```swift
+/// // Server-attributed write, fall back to web-auth if S2S isn't configured.
+/// service.createRecord(..., database: .public(.prefers(.serverToServer)))
+///
+/// // User-attributed write, throw if web-auth credentials aren't configured.
+/// service.createRecord(..., database: .public(.requires(.webAuth)))
+/// ```
+public struct PublicAuthPreference: Sendable, Hashable {
+  /// Which signing material to use for a `.public` request.
+  public enum Mode: Sendable, Hashable {
+    /// Sign with the server-to-server key pair. Records are attributed to
+    /// the developer key, not an end user.
+    case serverToServer
+
+    /// Sign with the user's web-auth token. Records are attributed to the
+    /// iCloud user that issued the token.
+    case webAuth
+  }
+
+  /// The signing material the caller wants.
+  public let mode: Mode
+
+  /// Whether to throw if `mode`'s credentials aren't configured.
+  ///
+  /// - `true` → throw `CloudKitError.missingCredentials(availability: .preferenceRequired)`.
+  /// - `false` → fall back to the other configured credential set when possible.
+  public let required: Bool
+
+  /// Prefer the given mode; fall back to the other if it isn't configured.
+  public static func prefers(_ mode: Mode) -> Self {
+    .init(mode: mode, required: false)
+  }
+
+  /// Require the given mode; throw `missingCredentials(.preferenceRequired)`
+  /// if its credentials aren't configured.
+  public static func requires(_ mode: Mode) -> Self {
+    .init(mode: mode, required: true)
+  }
+}

--- a/Sources/MistKit/Database.swift
+++ b/Sources/MistKit/Database.swift
@@ -27,11 +27,36 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import Foundation
+/// CloudKit database scope plus, for `.public`, the per-call attribution
+/// choice between server-to-server signing and web-auth signing.
+///
+/// The auth payload is part of `.public` rather than a separate parameter
+/// because it only matters there — CloudKit rejects server-to-server signing
+/// on `.private` and `.shared`, so those cases carry no payload. Encoding
+/// the choice in the type means call sites either pick one explicitly
+/// (`Database.public(.requires(.webAuth))`) or use a scope where the choice
+/// doesn't exist (`Database.private`).
+public enum Database: Sendable, Hashable {
+  /// Public database. Caller must pick a signing method via
+  /// `PublicAuthPreference`.
+  case `public`(PublicAuthPreference)
 
-/// CloudKit database types
-public enum Database: String, Sendable {
-  case `public`
+  /// Private database. Web-auth is the only valid signing method.
   case `private`
+
+  /// Shared database. Web-auth is the only valid signing method.
   case shared
+
+  /// The path segment used to build CloudKit Web Services URLs
+  /// (`/database/{version}/{container}/{environment}/{database}/…`).
+  public var pathSegment: String {
+    switch self {
+    case .public:
+      return "public"
+    case .private:
+      return "private"
+    case .shared:
+      return "shared"
+    }
+  }
 }

--- a/Sources/MistKit/MistKitConfiguration+ConvenienceInitializers.swift
+++ b/Sources/MistKit/MistKitConfiguration+ConvenienceInitializers.swift
@@ -100,7 +100,8 @@ extension MistKitConfiguration {
     MistKitConfiguration(
       container: container,
       environment: environment,
-      database: .public,  // Server-to-server only supports public database
+      database: .public(.requires(.serverToServer)),
+      // Server-to-server only supports public database
       apiToken: "",  // Not used with server-to-server auth
       webAuthToken: nil,
       keyID: keyID,

--- a/Sources/MistKit/Service/Extensions/CloudKitService+AssetOperations.swift
+++ b/Sources/MistKit/Service/Extensions/CloudKitService+AssetOperations.swift
@@ -75,7 +75,7 @@ extension CloudKitService {
     fieldName: String,
     recordName: String? = nil,
     using uploader: AssetUploader? = nil,
-    database: Database = .public
+    database: Database
   ) async throws(CloudKitError) -> AssetUploadReceipt {
     let maxSize: Int = 15 * 1_024 * 1_024
     guard data.count <= maxSize else {
@@ -138,7 +138,7 @@ extension CloudKitService {
     fieldName: String,
     recordName: String? = nil,
     zoneID: ZoneID? = nil,
-    database: Database = .public
+    database: Database
   ) async throws(CloudKitError) -> AssetUploadToken {
     do {
       let tokenRequest =

--- a/Sources/MistKit/Service/Extensions/CloudKitService+Classification.swift
+++ b/Sources/MistKit/Service/Extensions/CloudKitService+Classification.swift
@@ -64,11 +64,13 @@ extension CloudKitService {
   /// - Throws: `CloudKitError` if the underlying query fails.
   public func fetchExistingRecordNames(
     recordType: String,
-    limit: Int? = nil
+    limit: Int? = nil,
+    database: Database
   ) async throws(CloudKitError) -> Set<String> {
     let result: QueryResult = try await queryRecords(
       recordType: recordType,
-      limit: limit ?? Self.maxRecordsPerRequest
+      limit: limit ?? Self.maxRecordsPerRequest,
+      database: database
     )
     return Set(result.records.map(\.recordName))
   }
@@ -108,9 +110,14 @@ extension CloudKitService {
   public func modifyRecords(
     _ operations: [RecordOperation],
     classification: OperationClassification,
-    atomic: Bool = false
+    atomic: Bool = false,
+    database: Database
   ) async throws(CloudKitError) -> BatchSyncResult {
-    let records = try await modifyRecords(operations, atomic: atomic)
+    let records = try await modifyRecords(
+      operations,
+      atomic: atomic,
+      database: database
+    )
     return BatchSyncResult(records: records, classification: classification)
   }
 }

--- a/Sources/MistKit/Service/Extensions/CloudKitService+ClientDispatch.swift
+++ b/Sources/MistKit/Service/Extensions/CloudKitService+ClientDispatch.swift
@@ -35,29 +35,29 @@ extension CloudKitService {
   /// Resolve the token manager for an outgoing request and build a fresh
   /// OpenAPI `Client` whose middleware chain authenticates against it.
   ///
-  /// Called once per dispatched operation. When the service was built with a
-  /// caller-supplied `tokenManager:`, that fixed manager is used regardless of
-  /// `database` / `requiresUserContext`. Otherwise `Credentials` picks an
-  /// appropriate manager via its `makeTokenManager(for:requiresUserContext:)`
-  /// extension.
+  /// Called once per dispatched operation. The signing choice for `.public`
+  /// requests is carried by the `Database` value itself
+  /// (`.public(PublicAuthPreference)`); `.private` / `.shared` always use
+  /// web-auth.
+  ///
+  /// When the service was built with a caller-supplied `tokenManager:`, that
+  /// fixed manager is used regardless of `database`. Otherwise `Credentials`
+  /// resolves the manager via `makeTokenManager(for:)`.
   ///
   /// - Throws: `CloudKitError.missingCredentials` when `Credentials` cannot
   ///   satisfy the requested combination.
   internal func client(
-    for database: Database,
-    requiresUserContext: Bool = false
+    for database: Database
   ) throws -> Client {
     let tokenManager: any TokenManager
     if let fixedTokenManager {
       tokenManager = fixedTokenManager
     } else if let credentials {
-      tokenManager = try credentials.makeTokenManager(
-        for: database,
-        requiresUserContext: requiresUserContext
-      )
+      tokenManager = try credentials.makeTokenManager(for: database)
     } else {
       throw CloudKitError.missingCredentials(
         database: database,
+        availability: .notConfigured,
         reason: "service has neither credentials nor a fixed token manager"
       )
     }

--- a/Sources/MistKit/Service/Extensions/CloudKitService+LookupOperations.swift
+++ b/Sources/MistKit/Service/Extensions/CloudKitService+LookupOperations.swift
@@ -39,7 +39,7 @@ extension CloudKitService {
   internal func modifyRecords(
     operations: [Components.Schemas.RecordOperation],
     atomic: Bool = true,
-    database: Database = .public
+    database: Database
   ) async throws(CloudKitError) -> [RecordInfo] {
     do {
       let client = try self.client(for: database)
@@ -71,7 +71,7 @@ extension CloudKitService {
   public func lookupRecords(
     recordNames: [String],
     desiredKeys: [String]? = nil,
-    database: Database = .public
+    database: Database
   ) async throws(CloudKitError) -> [RecordInfo] {
     do {
       let client = try self.client(for: database)

--- a/Sources/MistKit/Service/Extensions/CloudKitService+Operations.swift
+++ b/Sources/MistKit/Service/Extensions/CloudKitService+Operations.swift
@@ -96,7 +96,7 @@ extension CloudKitService {
     sortBy: [QuerySort]? = nil,
     limit: Int? = nil,
     desiredKeys: [String]? = nil,
-    database: Database = .public
+    database: Database
   ) async throws(CloudKitError) -> [RecordInfo] {
     let result: QueryResult = try await queryRecords(
       recordType: recordType,
@@ -149,7 +149,7 @@ extension CloudKitService {
     limit: Int? = nil,
     desiredKeys: [String]? = nil,
     continuationMarker: String? = nil,
-    database: Database = .public
+    database: Database
   ) async throws(CloudKitError) -> QueryResult {
     let effectiveLimit = limit ?? defaultQueryLimit
 

--- a/Sources/MistKit/Service/Extensions/CloudKitService+QueryPagination.swift
+++ b/Sources/MistKit/Service/Extensions/CloudKitService+QueryPagination.swift
@@ -62,7 +62,7 @@ extension CloudKitService {
     pageSize: Int? = nil,
     desiredKeys: [String]? = nil,
     maxPages: Int = 1_000,
-    database: Database = .public
+    database: Database
   ) async throws(CloudKitError) -> [RecordInfo] {
     var allRecords: [RecordInfo] = []
     var currentMarker: String?

--- a/Sources/MistKit/Service/Extensions/CloudKitService+RecordManaging.swift
+++ b/Sources/MistKit/Service/Extensions/CloudKitService+RecordManaging.swift
@@ -36,6 +36,12 @@ import Foundation
 @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
 extension CloudKitService: RecordManaging {
   /// Query records of a specific type from CloudKit (deprecated single-page form)
+  ///
+  /// `RecordManaging` is a database-agnostic abstraction predating per-call
+  /// `PublicAuthPreference`; this conformance targets the public database
+  /// with `.requires(.serverToServer)` to preserve the previous "S2S when
+  /// configured" behavior. Callers who need different attribution should
+  /// call `CloudKitService` directly with an explicit `Database` value.
   @available(
     *, deprecated,
     message: "Silently truncates at one page. Use queryAllRecords or queryRecords -> QueryResult."
@@ -47,7 +53,8 @@ extension CloudKitService: RecordManaging {
       sortBy: nil,
       limit: 200,
       desiredKeys: nil,
-      continuationMarker: nil
+      continuationMarker: nil,
+      database: .public(.prefers(.serverToServer))
     )
     return result.records
   }
@@ -57,7 +64,10 @@ extension CloudKitService: RecordManaging {
     _ operations: [RecordOperation],
     recordType: String
   ) async throws {
-    _ = try await self.modifyRecords(operations)
+    _ = try await self.modifyRecords(
+      operations,
+      database: .public(.prefers(.serverToServer))
+    )
   }
 
   /// Query all records of a specific type, automatically paginating
@@ -66,7 +76,8 @@ extension CloudKitService: RecordManaging {
       recordType: recordType,
       filters: nil,
       sortBy: nil,
-      pageSize: nil
+      pageSize: nil,
+      database: .public(.prefers(.serverToServer))
     )
   }
 }

--- a/Sources/MistKit/Service/Extensions/CloudKitService+SyncOperations.swift
+++ b/Sources/MistKit/Service/Extensions/CloudKitService+SyncOperations.swift
@@ -81,7 +81,7 @@ extension CloudKitService {
     zoneID: ZoneID? = nil,
     syncToken: String? = nil,
     resultsLimit: Int? = nil,
-    database: Database = .public
+    database: Database
   ) async throws(CloudKitError) -> RecordChangesResult {
     if let limit = resultsLimit {
       guard limit > 0 && limit <= 200 else {
@@ -166,7 +166,7 @@ extension CloudKitService {
     syncToken: String? = nil,
     resultsLimit: Int? = nil,
     maxPages: Int = 1_000,
-    database: Database = .public
+    database: Database
   ) async throws(CloudKitError) -> (records: [RecordInfo], syncToken: String?) {
     var allRecords: [RecordInfo] = []
     var currentToken = syncToken

--- a/Sources/MistKit/Service/Extensions/CloudKitService+UserOperations.swift
+++ b/Sources/MistKit/Service/Extensions/CloudKitService+UserOperations.swift
@@ -50,13 +50,13 @@ extension CloudKitService {
   /// `Credentials` must include an `apiAuth` with a `webAuthToken`.
   public func fetchCaller() async throws(CloudKitError) -> UserInfo {
     do {
-      let client = try self.client(for: .public, requiresUserContext: true)
+      let client = try self.client(for: .public(.requires(.webAuth)))
       let response = try await client.getCaller(
         .init(
           path: Operations.getCaller.Input.Path(
             containerIdentifier: containerIdentifier,
             environment: environment,
-            database: .public
+            database: .public(.requires(.webAuth))
           )
         )
       )
@@ -91,13 +91,13 @@ extension CloudKitService {
   )
   public func discoverAllUserIdentities() async throws(CloudKitError) -> [UserIdentity] {
     do {
-      let client = try self.client(for: .public, requiresUserContext: true)
+      let client = try self.client(for: .public(.requires(.webAuth)))
       let response = try await client.discoverAllUserIdentities(
         .init(
           path: Operations.discoverAllUserIdentities.Input.Path(
             containerIdentifier: containerIdentifier,
             environment: environment,
-            database: .public
+            database: .public(.requires(.webAuth))
           )
         )
       )
@@ -121,13 +121,13 @@ extension CloudKitService {
     _ emails: [String]
   ) async throws(CloudKitError) -> [UserIdentity] {
     do {
-      let client = try self.client(for: .public, requiresUserContext: true)
+      let client = try self.client(for: .public(.requires(.webAuth)))
       let response = try await client.lookupUsersByEmail(
         .init(
           path: Operations.lookupUsersByEmail.Input.Path(
             containerIdentifier: containerIdentifier,
             environment: environment,
-            database: .public
+            database: .public(.requires(.webAuth))
           ),
           body: .json(
             .init(users: emails.map { .init(emailAddress: $0) })
@@ -151,13 +151,13 @@ extension CloudKitService {
     _ recordNames: [String]
   ) async throws(CloudKitError) -> [UserIdentity] {
     do {
-      let client = try self.client(for: .public, requiresUserContext: true)
+      let client = try self.client(for: .public(.requires(.webAuth)))
       let response = try await client.lookupUsersByRecordName(
         .init(
           path: Operations.lookupUsersByRecordName.Input.Path(
             containerIdentifier: containerIdentifier,
             environment: environment,
-            database: .public
+            database: .public(.requires(.webAuth))
           ),
           body: .json(
             .init(users: recordNames.map { .init(userRecordName: $0) })
@@ -181,13 +181,13 @@ extension CloudKitService {
     lookupInfos: [UserIdentityLookupInfo]
   ) async throws(CloudKitError) -> [UserIdentity] {
     do {
-      let client = try self.client(for: .public, requiresUserContext: true)
+      let client = try self.client(for: .public(.requires(.webAuth)))
       let response = try await client.discoverUserIdentities(
         .init(
           path: Operations.discoverUserIdentities.Input.Path(
             containerIdentifier: containerIdentifier,
             environment: environment,
-            database: .public
+            database: .public(.requires(.webAuth))
           ),
           body: .json(
             .init(

--- a/Sources/MistKit/Service/Extensions/CloudKitService+WriteOperations.swift
+++ b/Sources/MistKit/Service/Extensions/CloudKitService+WriteOperations.swift
@@ -49,7 +49,7 @@ extension CloudKitService {
   public func modifyRecords(
     _ operations: [RecordOperation],
     atomic: Bool = false,
-    database: Database = .public
+    database: Database
   ) async throws(CloudKitError) -> [RecordInfo] {
     do {
       let apiOperations = try operations.map {
@@ -97,7 +97,7 @@ extension CloudKitService {
     recordType: String,
     recordName: String? = nil,
     fields: [String: FieldValue],
-    database: Database = .public
+    database: Database
   ) async throws(CloudKitError) -> RecordInfo {
     let operation = RecordOperation.create(
       recordType: recordType,
@@ -125,7 +125,7 @@ extension CloudKitService {
     recordName: String,
     fields: [String: FieldValue],
     recordChangeTag: String? = nil,
-    database: Database = .public
+    database: Database
   ) async throws(CloudKitError) -> RecordInfo {
     let operation = RecordOperation.update(
       recordType: recordType,
@@ -151,7 +151,7 @@ extension CloudKitService {
     recordType: String,
     recordName: String,
     recordChangeTag: String? = nil,
-    database: Database = .public
+    database: Database
   ) async throws(CloudKitError) {
     let operation = RecordOperation.delete(
       recordType: recordType,

--- a/Sources/MistKit/Service/ResponseProcessing/CloudKitError.swift
+++ b/Sources/MistKit/Service/ResponseProcessing/CloudKitError.swift
@@ -45,7 +45,11 @@ public enum CloudKitError: LocalizedError, Sendable {
   case networkError(URLError)
   case unsupportedOperationType(String)
   case paginationLimitExceeded(maxPages: Int, records: [RecordInfo])
-  case missingCredentials(database: Database, reason: String)
+  case missingCredentials(
+    database: Database,
+    availability: CredentialAvailability = .notConfigured,
+    reason: String
+  )
   case invalidPrivateKey(path: String?, underlying: any Error)
 
   /// HTTP status code if this error originated from an HTTP response, otherwise nil.
@@ -127,9 +131,17 @@ public enum CloudKitError: LocalizedError, Sendable {
       return
         "CloudKit query exceeded pagination limit of \(maxPages) pages "
         + "(collected \(records.count) records)"
-    case .missingCredentials(let database, let reason):
+    case .missingCredentials(let database, let availability, let reason):
+      let availabilityLabel: String
+      switch availability {
+      case .notConfigured:
+        availabilityLabel = "not configured"
+      case .preferenceRequired:
+        availabilityLabel = "required by preference but not configured"
+      }
       return
-        "Missing credentials for database '\(database.rawValue)': \(reason)"
+        "Missing credentials for database '\(database.pathSegment)' "
+        + "(\(availabilityLabel)): \(reason)"
     case .invalidPrivateKey(let path, let underlying):
       let location = path.map { "from '\($0)'" } ?? "from inline material"
       return

--- a/Sources/MistKit/Service/ResponseProcessing/CredentialAvailability.swift
+++ b/Sources/MistKit/Service/ResponseProcessing/CredentialAvailability.swift
@@ -1,5 +1,5 @@
 //
-//  CloudKitServiceTests.FetchZoneChanges+Validation.swift
+//  CredentialAvailability.swift
 //  MistKit
 //
 //  Created by Leo Dion.
@@ -27,25 +27,20 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import Foundation
-import Testing
+/// Why a credential set was missing when the dispatcher tried to satisfy
+/// a request.
+///
+/// Attached to `CloudKitError.missingCredentials(_:availability:reason:)` so
+/// callers can distinguish a misconfiguration ("no credentials at all") from
+/// a deliberate `PublicAuthPreference.requires(...)` that couldn't be
+/// satisfied ("we have web-auth but the caller required server-to-server").
+public enum CredentialAvailability: Sendable, Hashable {
+  /// No credential of the type the route needs is configured on
+  /// `Credentials`.
+  case notConfigured
 
-@testable import MistKit
-
-extension CloudKitServiceTests.FetchZoneChanges {
-  @Suite("Validation")
-  internal struct Validation {
-    @Test("fetchZoneChanges() throws on authentication error")
-    internal func fetchZoneChangesThrowsOnAuthError() async throws {
-      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
-        Issue.record("CloudKitService is not available on this operating system.")
-        return
-      }
-      let service = try await CloudKitServiceTests.FetchZoneChanges.makeAuthErrorService()
-
-      await #expect(throws: CloudKitError.self) {
-        try await service.fetchZoneChanges(database: .public(.prefers(.serverToServer)))
-      }
-    }
-  }
+  /// A credential type was required by `PublicAuthPreference.requires(_:)`
+  /// but is not configured. The dispatcher refuses to silently substitute
+  /// the other credential set.
+  case preferenceRequired
 }

--- a/Tests/MistKitTests/Authentication/Credentials/CredentialsTokenManagerTests+PrivateKeyLoad.swift
+++ b/Tests/MistKitTests/Authentication/Credentials/CredentialsTokenManagerTests+PrivateKeyLoad.swift
@@ -48,7 +48,7 @@ extension CredentialsTokenManagerTests {
         )
       )
       do {
-        _ = try credentials.makeTokenManager(for: .public)
+        _ = try credentials.makeTokenManager(for: .public(.requires(.serverToServer)))
         Issue.record("expected makeTokenManager to throw .invalidPrivateKey")
       } catch let error as CloudKitError {
         guard case .invalidPrivateKey(let path, _) = error else {

--- a/Tests/MistKitTests/Authentication/Credentials/CredentialsTokenManagerTests+PublicDatabase.swift
+++ b/Tests/MistKitTests/Authentication/Credentials/CredentialsTokenManagerTests+PublicDatabase.swift
@@ -35,8 +35,10 @@ import Testing
 extension CredentialsTokenManagerTests {
   @Suite("Public Database")
   internal struct PublicDatabase {
-    @Test(".public + serverToServer → ServerToServerAuthManager")
-    internal func publicPicksServerToServer() async throws {
+    // MARK: - prefers(.serverToServer)
+
+    @Test(".public(.prefers(.serverToServer)) + S2S only → S2S")
+    internal func prefersS2SOnlyS2SPicksS2S() async throws {
       guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
         Issue.record("ServerToServerAuthManager is not available on this operating system.")
         return
@@ -44,36 +46,14 @@ extension CredentialsTokenManagerTests {
       let credentials = try Credentials(
         serverToServer: CredentialsTokenManagerTests.makeServerToServerCredentials()
       )
-      let manager = try credentials.makeTokenManager(for: .public)
+      let manager = try credentials.makeTokenManager(
+        for: .public(.prefers(.serverToServer))
+      )
       #expect(manager is ServerToServerAuthManager)
     }
 
-    @Test(".public + apiAuth.webAuthToken → WebAuthTokenManager")
-    internal func publicPicksWebAuthOverAPIToken() async throws {
-      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
-        return
-      }
-      let credentials = try Credentials(
-        apiAuth: CredentialsTokenManagerTests.makeAPICredentialsWithWebAuth()
-      )
-      let manager = try credentials.makeTokenManager(for: .public)
-      #expect(manager is WebAuthTokenManager)
-    }
-
-    @Test(".public + apiAuth (token only) → APITokenManager")
-    internal func publicPicksAPITokenWhenNoWebAuth() async throws {
-      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
-        return
-      }
-      let credentials = try Credentials(
-        apiAuth: CredentialsTokenManagerTests.makeAPICredentialsTokenOnly()
-      )
-      let manager = try credentials.makeTokenManager(for: .public)
-      #expect(manager is APITokenManager)
-    }
-
-    @Test(".public + serverToServer prefers S2S over apiAuth")
-    internal func publicPrefersServerToServerOverAPIAuth() async throws {
+    @Test(".public(.prefers(.serverToServer)) + both creds → S2S")
+    internal func prefersS2SBothCredsPicksS2S() async throws {
       guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
         return
       }
@@ -81,8 +61,152 @@ extension CredentialsTokenManagerTests {
         serverToServer: CredentialsTokenManagerTests.makeServerToServerCredentials(),
         apiAuth: CredentialsTokenManagerTests.makeAPICredentialsWithWebAuth()
       )
-      let manager = try credentials.makeTokenManager(for: .public)
+      let manager = try credentials.makeTokenManager(
+        for: .public(.prefers(.serverToServer))
+      )
       #expect(manager is ServerToServerAuthManager)
     }
+
+    @Test(".public(.prefers(.serverToServer)) + web-auth only → falls back to web-auth")
+    internal func prefersS2SOnlyWebAuthFallsBackToWebAuth() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        return
+      }
+      let credentials = try Credentials(
+        apiAuth: CredentialsTokenManagerTests.makeAPICredentialsWithWebAuth()
+      )
+      let manager = try credentials.makeTokenManager(
+        for: .public(.prefers(.serverToServer))
+      )
+      #expect(manager is WebAuthTokenManager)
+    }
+
+    @Test(".public(.prefers(.serverToServer)) + API token only → APITokenManager")
+    internal func prefersS2SAPITokenOnlyFallsBackToAPIToken() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        return
+      }
+      let credentials = try Credentials(
+        apiAuth: CredentialsTokenManagerTests.makeAPICredentialsTokenOnly()
+      )
+      let manager = try credentials.makeTokenManager(
+        for: .public(.prefers(.serverToServer))
+      )
+      #expect(manager is APITokenManager)
+    }
+
+    // MARK: - prefers(.webAuth)
+
+    @Test(".public(.prefers(.webAuth)) + both creds → web-auth")
+    internal func prefersWebAuthBothCredsPicksWebAuth() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        return
+      }
+      let credentials = try Credentials(
+        serverToServer: CredentialsTokenManagerTests.makeServerToServerCredentials(),
+        apiAuth: CredentialsTokenManagerTests.makeAPICredentialsWithWebAuth()
+      )
+      let manager = try credentials.makeTokenManager(
+        for: .public(.prefers(.webAuth))
+      )
+      #expect(manager is WebAuthTokenManager)
+    }
+
+    @Test(".public(.prefers(.webAuth)) + S2S only → falls back to S2S")
+    internal func prefersWebAuthOnlyS2SFallsBackToS2S() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        return
+      }
+      let credentials = try Credentials(
+        serverToServer: CredentialsTokenManagerTests.makeServerToServerCredentials()
+      )
+      let manager = try credentials.makeTokenManager(
+        for: .public(.prefers(.webAuth))
+      )
+      #expect(manager is ServerToServerAuthManager)
+    }
+
+    // MARK: - requires(.serverToServer)
+
+    @Test(".public(.requires(.serverToServer)) + both creds → S2S")
+    internal func requiresS2SBothCredsPicksS2S() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        return
+      }
+      let credentials = try Credentials(
+        serverToServer: CredentialsTokenManagerTests.makeServerToServerCredentials(),
+        apiAuth: CredentialsTokenManagerTests.makeAPICredentialsWithWebAuth()
+      )
+      let manager = try credentials.makeTokenManager(
+        for: .public(.requires(.serverToServer))
+      )
+      #expect(manager is ServerToServerAuthManager)
+    }
+
+    @Test(".public(.requires(.serverToServer)) without S2S → throws preferenceRequired")
+    internal func requiresS2SWithoutS2SThrowsPreferenceRequired() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        return
+      }
+      let credentials = try Credentials(
+        apiAuth: CredentialsTokenManagerTests.makeAPICredentialsWithWebAuth()
+      )
+      #expect {
+        _ = try credentials.makeTokenManager(
+          for: .public(.requires(.serverToServer))
+        )
+      } throws: { error in
+        guard
+          let cloudKitError = error as? CloudKitError,
+          case .missingCredentials(_, let availability, _) = cloudKitError
+        else { return false }
+        return availability == .preferenceRequired
+      }
+    }
+
+    // MARK: - requires(.webAuth)
+
+    @Test(".public(.requires(.webAuth)) + both creds → web-auth")
+    internal func requiresWebAuthBothCredsPicksWebAuth() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        return
+      }
+      let credentials = try Credentials(
+        serverToServer: CredentialsTokenManagerTests.makeServerToServerCredentials(),
+        apiAuth: CredentialsTokenManagerTests.makeAPICredentialsWithWebAuth()
+      )
+      let manager = try credentials.makeTokenManager(
+        for: .public(.requires(.webAuth))
+      )
+      #expect(manager is WebAuthTokenManager)
+    }
+
+    @Test(".public(.requires(.webAuth)) without web-auth → throws preferenceRequired")
+    internal func requiresWebAuthWithoutWebAuthThrowsPreferenceRequired() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        return
+      }
+      let credentials = try Credentials(
+        serverToServer: CredentialsTokenManagerTests.makeServerToServerCredentials()
+      )
+      #expect {
+        _ = try credentials.makeTokenManager(
+          for: .public(.requires(.webAuth))
+        )
+      } throws: { error in
+        guard
+          let cloudKitError = error as? CloudKitError,
+          case .missingCredentials(_, let availability, _) = cloudKitError
+        else { return false }
+        return availability == .preferenceRequired
+      }
+    }
+
+    // Note: The "no creds at all" path in the dispatcher's resolution table
+    // (".prefers + neither mode configured → throws notConfigured") is not
+    // tested here because `Credentials.init` asserts that at least one of
+    // `serverToServer` or `apiAuth` is populated. Reaching `notConfigured`
+    // would require constructing an empty `Credentials`, which the type
+    // doesn't permit.
   }
 }

--- a/Tests/MistKitTests/Authentication/Credentials/CredentialsTokenManagerTests+PublicDatabase.swift
+++ b/Tests/MistKitTests/Authentication/Credentials/CredentialsTokenManagerTests+PublicDatabase.swift
@@ -126,6 +126,20 @@ extension CredentialsTokenManagerTests {
       #expect(manager is ServerToServerAuthManager)
     }
 
+    @Test(".public(.prefers(.webAuth)) + API token only → APITokenManager")
+    internal func prefersWebAuthAPITokenOnlyFallsBackToAPIToken() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        return
+      }
+      let credentials = try Credentials(
+        apiAuth: CredentialsTokenManagerTests.makeAPICredentialsTokenOnly()
+      )
+      let manager = try credentials.makeTokenManager(
+        for: .public(.prefers(.webAuth))
+      )
+      #expect(manager is APITokenManager)
+    }
+
     // MARK: - requires(.serverToServer)
 
     @Test(".public(.requires(.serverToServer)) + both creds → S2S")

--- a/Tests/MistKitTests/Authentication/Credentials/CredentialsTokenManagerTests+UserContext.swift
+++ b/Tests/MistKitTests/Authentication/Credentials/CredentialsTokenManagerTests+UserContext.swift
@@ -33,10 +33,15 @@ import Testing
 @testable import MistKit
 
 extension CredentialsTokenManagerTests {
+  /// Coverage for the "user-context" routes (`users/caller`,
+  /// `users/lookup/*`, `users/discover`). With the per-call
+  /// `PublicAuthPreference` rewrite these no longer take a separate
+  /// `requiresUserContext` flag — they pass `.public(.requires(.webAuth))`
+  /// directly to the dispatcher.
   @Suite("User-Context Branch")
   internal struct UserContext {
-    @Test("requiresUserContext on .public → WebAuthTokenManager")
-    internal func userContextOnPublicPicksWebAuth() async throws {
+    @Test(".public(.requires(.webAuth)) + both creds → web-auth (S2S ignored)")
+    internal func requiresWebAuthOnPublicIgnoresS2S() async throws {
       guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
         return
       }
@@ -45,14 +50,13 @@ extension CredentialsTokenManagerTests {
         apiAuth: CredentialsTokenManagerTests.makeAPICredentialsWithWebAuth()
       )
       let manager = try credentials.makeTokenManager(
-        for: .public, requiresUserContext: true
+        for: .public(.requires(.webAuth))
       )
-      // S2S is present, but user-context routes ignore it — must pick web-auth.
       #expect(manager is WebAuthTokenManager)
     }
 
-    @Test("requiresUserContext without web-auth → throws missingCredentials")
-    internal func userContextWithoutWebAuthThrows() async throws {
+    @Test(".public(.requires(.webAuth)) + S2S only → throws preferenceRequired")
+    internal func requiresWebAuthWithoutWebAuthThrows() async throws {
       guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
         return
       }
@@ -61,13 +65,13 @@ extension CredentialsTokenManagerTests {
       )
       #expect(throws: CloudKitError.self) {
         _ = try credentials.makeTokenManager(
-          for: .public, requiresUserContext: true
+          for: .public(.requires(.webAuth))
         )
       }
     }
 
-    @Test("requiresUserContext with apiAuth (token only) → throws missingCredentials")
-    internal func userContextWithAPITokenOnlyThrows() async throws {
+    @Test(".public(.requires(.webAuth)) + API token only → throws preferenceRequired")
+    internal func requiresWebAuthWithAPITokenOnlyThrows() async throws {
       guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
         return
       }
@@ -76,65 +80,7 @@ extension CredentialsTokenManagerTests {
       )
       #expect(throws: CloudKitError.self) {
         _ = try credentials.makeTokenManager(
-          for: .public, requiresUserContext: true
-        )
-      }
-    }
-
-    @Test("requiresUserContext on .private + web-auth → WebAuthTokenManager")
-    internal func userContextOnPrivatePicksWebAuth() async throws {
-      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
-        return
-      }
-      let credentials = try Credentials(
-        apiAuth: CredentialsTokenManagerTests.makeAPICredentialsWithWebAuth()
-      )
-      let manager = try credentials.makeTokenManager(
-        for: .private, requiresUserContext: true
-      )
-      #expect(manager is WebAuthTokenManager)
-    }
-
-    @Test("requiresUserContext on .shared + web-auth → WebAuthTokenManager")
-    internal func userContextOnSharedPicksWebAuth() async throws {
-      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
-        return
-      }
-      let credentials = try Credentials(
-        apiAuth: CredentialsTokenManagerTests.makeAPICredentialsWithWebAuth()
-      )
-      let manager = try credentials.makeTokenManager(
-        for: .shared, requiresUserContext: true
-      )
-      #expect(manager is WebAuthTokenManager)
-    }
-
-    @Test("requiresUserContext on .private + S2S only → throws missingCredentials")
-    internal func userContextOnPrivateRejectsServerToServerOnly() async throws {
-      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
-        return
-      }
-      let credentials = try Credentials(
-        serverToServer: CredentialsTokenManagerTests.makeServerToServerCredentials()
-      )
-      #expect(throws: CloudKitError.self) {
-        _ = try credentials.makeTokenManager(
-          for: .private, requiresUserContext: true
-        )
-      }
-    }
-
-    @Test("requiresUserContext on .shared + S2S only → throws missingCredentials")
-    internal func userContextOnSharedRejectsServerToServerOnly() async throws {
-      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
-        return
-      }
-      let credentials = try Credentials(
-        serverToServer: CredentialsTokenManagerTests.makeServerToServerCredentials()
-      )
-      #expect(throws: CloudKitError.self) {
-        _ = try credentials.makeTokenManager(
-          for: .shared, requiresUserContext: true
+          for: .public(.requires(.webAuth))
         )
       }
     }

--- a/Tests/MistKitTests/Core/DatabaseTests.swift
+++ b/Tests/MistKitTests/Core/DatabaseTests.swift
@@ -6,11 +6,12 @@ import Testing
 /// Test suite for Database enum functionality and behavior validation
 @Suite("Database")
 internal struct DatabaseTests {
-  /// Tests Database enum raw values
-  @Test("Database enum raw values")
-  internal func databaseRawValues() {
-    #expect(Database.public.rawValue == "public")
-    #expect(Database.private.rawValue == "private")
-    #expect(Database.shared.rawValue == "shared")
+  /// Tests that each Database scope produces the expected URL path segment.
+  @Test("Database pathSegment values")
+  internal func databasePathSegments() {
+    #expect(Database.public(.prefers(.serverToServer)).pathSegment == "public")
+    #expect(Database.public(.requires(.webAuth)).pathSegment == "public")
+    #expect(Database.private.pathSegment == "private")
+    #expect(Database.shared.pathSegment == "shared")
   }
 }

--- a/Tests/MistKitTests/PublicTypes/CloudKitErrorTests.swift
+++ b/Tests/MistKitTests/PublicTypes/CloudKitErrorTests.swift
@@ -1,0 +1,65 @@
+//
+//  CloudKitErrorTests.swift
+//  MistKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import Foundation
+import Testing
+
+@testable import MistKit
+
+@Suite("CloudKitError")
+internal struct CloudKitErrorTests {
+  @Test(".missingCredentials with .notConfigured describes as not configured")
+  internal func missingCredentialsNotConfiguredDescribesAsNotConfigured() throws {
+    let error = CloudKitError.missingCredentials(
+      database: .public(.prefers(.webAuth)),
+      availability: .notConfigured,
+      reason: "no API token provided"
+    )
+
+    let description = try #require(error.errorDescription)
+    #expect(description.contains("public"))
+    #expect(description.contains("not configured"))
+    #expect(!description.contains("required by preference"))
+    #expect(description.contains("no API token provided"))
+  }
+
+  @Test(".missingCredentials with .preferenceRequired describes as preference required")
+  internal func missingCredentialsPreferenceRequiredDescribesAsPreferenceRequired() throws {
+    let error = CloudKitError.missingCredentials(
+      database: .public(.requires(.webAuth)),
+      availability: .preferenceRequired,
+      reason: "web-auth preference required"
+    )
+
+    let description = try #require(error.errorDescription)
+    #expect(description.contains("public"))
+    #expect(description.contains("required by preference but not configured"))
+    #expect(description.contains("web-auth preference required"))
+  }
+}

--- a/Tests/MistKitTests/Service/CloudKitServiceFetchChanges/CloudKitServiceTests.FetchChanges+Concurrent.swift
+++ b/Tests/MistKitTests/Service/CloudKitServiceFetchChanges/CloudKitServiceTests.FetchChanges+Concurrent.swift
@@ -53,7 +53,7 @@ extension CloudKitServiceTests.FetchChanges {
       ) { group in
         for _ in 0..<taskCount {
           group.addTask {
-            try? await service.fetchAllRecordChanges()
+            try? await service.fetchAllRecordChanges(database: .public(.prefers(.serverToServer)))
           }
         }
         var collected: [(records: [RecordInfo], syncToken: String?)] = []

--- a/Tests/MistKitTests/Service/CloudKitServiceFetchChanges/CloudKitServiceTests.FetchChanges+ErrorHandling.swift
+++ b/Tests/MistKitTests/Service/CloudKitServiceFetchChanges/CloudKitServiceTests.FetchChanges+ErrorHandling.swift
@@ -46,7 +46,7 @@ extension CloudKitServiceTests.FetchChanges {
       )
 
       await #expect {
-        _ = try await service.fetchRecordChanges()
+        _ = try await service.fetchRecordChanges(database: .public(.prefers(.serverToServer)))
       } throws: { error in
         guard let ckError = error as? CloudKitError,
           case .networkError(let urlError) = ckError
@@ -64,7 +64,7 @@ extension CloudKitServiceTests.FetchChanges {
       let service = try CloudKitServiceTests.makeService(provider: ResponseProvider.timeout())
 
       await #expect {
-        _ = try await service.fetchRecordChanges()
+        _ = try await service.fetchRecordChanges(database: .public(.prefers(.serverToServer)))
       } throws: { error in
         guard let ckError = error as? CloudKitError,
           case .networkError(let urlError) = ckError
@@ -108,7 +108,10 @@ extension CloudKitServiceTests.FetchChanges {
       let service = try CloudKitServiceTests.makeService(provider: provider)
 
       do {
-        _ = try await service.fetchAllRecordChanges(maxPages: 2)
+        _ = try await service.fetchAllRecordChanges(
+          maxPages: 2,
+          database: .public(.prefers(.serverToServer))
+        )
         Issue.record("Expected paginationLimitExceeded to be thrown")
       } catch CloudKitError.paginationLimitExceeded(let maxPages, let records) {
         #expect(maxPages == 2)
@@ -148,7 +151,7 @@ extension CloudKitServiceTests.FetchChanges {
       let service = try CloudKitServiceTests.makeService(provider: provider)
 
       await #expect {
-        _ = try await service.fetchAllRecordChanges()
+        _ = try await service.fetchAllRecordChanges(database: .public(.prefers(.serverToServer)))
       } throws: { error in
         guard let ckError = error as? CloudKitError,
           case .networkError(let urlError) = ckError

--- a/Tests/MistKitTests/Service/CloudKitServiceFetchChanges/CloudKitServiceTests.FetchChanges+SuccessCases.swift
+++ b/Tests/MistKitTests/Service/CloudKitServiceFetchChanges/CloudKitServiceTests.FetchChanges+SuccessCases.swift
@@ -46,7 +46,9 @@ extension CloudKitServiceTests.FetchChanges {
         syncToken: "new-token-123"
       )
 
-      let result = try await service.fetchRecordChanges()
+      let result = try await service.fetchRecordChanges(
+        database: .public(.prefers(.serverToServer))
+      )
 
       #expect(result.records.count == 3)
       #expect(result.syncToken == "new-token-123")
@@ -64,7 +66,9 @@ extension CloudKitServiceTests.FetchChanges {
         moreComing: true
       )
 
-      let result = try await service.fetchRecordChanges()
+      let result = try await service.fetchRecordChanges(
+        database: .public(.prefers(.serverToServer))
+      )
 
       #expect(result.moreComing == true)
       #expect(result.records.count == 2)
@@ -78,7 +82,10 @@ extension CloudKitServiceTests.FetchChanges {
       }
       let service = try await CloudKitServiceTests.FetchChanges.makeSuccessfulService()
 
-      let result = try await service.fetchRecordChanges(syncToken: nil)
+      let result = try await service.fetchRecordChanges(
+        syncToken: nil,
+        database: .public(.prefers(.serverToServer))
+      )
 
       #expect(result.records.isEmpty == false)
       #expect(result.syncToken != nil)
@@ -95,7 +102,9 @@ extension CloudKitServiceTests.FetchChanges {
           recordCount: 2
         )
 
-      let result = try await service.fetchRecordChanges()
+      let result = try await service.fetchRecordChanges(
+        database: .public(.prefers(.serverToServer))
+      )
 
       #expect(result.records[0].recordName == "record-0")
       #expect(result.records[0].recordType == "Note")
@@ -114,7 +123,9 @@ extension CloudKitServiceTests.FetchChanges {
         syncToken: "final-token"
       )
 
-      let (records, token) = try await service.fetchAllRecordChanges()
+      let (records, token) = try await service.fetchAllRecordChanges(
+        database: .public(.prefers(.serverToServer))
+      )
 
       #expect(records.count == 3)
       #expect(token == "final-token")
@@ -131,7 +142,9 @@ extension CloudKitServiceTests.FetchChanges {
         (recordCount: 2, syncToken: "token-2"),
       ])
 
-      let (records, token) = try await service.fetchAllRecordChanges()
+      let (records, token) = try await service.fetchAllRecordChanges(
+        database: .public(.prefers(.serverToServer))
+      )
 
       #expect(records.count == 5)
       #expect(token == "token-2")
@@ -148,7 +161,9 @@ extension CloudKitServiceTests.FetchChanges {
         (recordCount: 1, syncToken: "final-token"),
       ])
 
-      let (_, token) = try await service.fetchAllRecordChanges()
+      let (_, token) = try await service.fetchAllRecordChanges(
+        database: .public(.prefers(.serverToServer))
+      )
 
       #expect(token == "final-token")
     }
@@ -164,7 +179,9 @@ extension CloudKitServiceTests.FetchChanges {
         (recordCount: 3, syncToken: "token-2"),
       ])
 
-      let (records, token) = try await service.fetchAllRecordChanges()
+      let (records, token) = try await service.fetchAllRecordChanges(
+        database: .public(.prefers(.serverToServer))
+      )
 
       #expect(records.count == 3)
       #expect(token == "token-2")
@@ -182,7 +199,9 @@ extension CloudKitServiceTests.FetchChanges {
         (recordCount: 2, syncToken: "token-3"),
       ])
 
-      let (records, token) = try await service.fetchAllRecordChanges()
+      let (records, token) = try await service.fetchAllRecordChanges(
+        database: .public(.prefers(.serverToServer))
+      )
 
       #expect(records.count == 7)
       #expect(token == "token-3")
@@ -204,7 +223,9 @@ extension CloudKitServiceTests.FetchChanges {
         transport: transport
       )
 
-      let result = try await service.fetchRecordChanges()
+      let result = try await service.fetchRecordChanges(
+        database: .public(.prefers(.serverToServer))
+      )
 
       #expect(result.records.count == 2)
       let deletedRecord = try #require(result.records.first { $0.recordName == "deleted-record-0" })

--- a/Tests/MistKitTests/Service/CloudKitServiceFetchChanges/CloudKitServiceTests.FetchChanges+Validation.swift
+++ b/Tests/MistKitTests/Service/CloudKitServiceFetchChanges/CloudKitServiceTests.FetchChanges+Validation.swift
@@ -44,7 +44,10 @@ extension CloudKitServiceTests.FetchChanges {
       let service = try await CloudKitServiceTests.FetchChanges.makeSuccessfulService()
 
       await #expect {
-        try await service.fetchRecordChanges(resultsLimit: 0)
+        try await service.fetchRecordChanges(
+          resultsLimit: 0,
+          database: .public(.prefers(.serverToServer))
+        )
       } throws: { error in
         guard let ckError = error as? CloudKitError,
           case .httpErrorWithRawResponse(let status, _) = ckError
@@ -62,7 +65,10 @@ extension CloudKitServiceTests.FetchChanges {
       let service = try await CloudKitServiceTests.FetchChanges.makeSuccessfulService()
 
       await #expect {
-        try await service.fetchRecordChanges(resultsLimit: 201)
+        try await service.fetchRecordChanges(
+          resultsLimit: 201,
+          database: .public(.prefers(.serverToServer))
+        )
       } throws: { error in
         guard let ckError = error as? CloudKitError,
           case .httpErrorWithRawResponse(let status, _) = ckError
@@ -80,11 +86,17 @@ extension CloudKitServiceTests.FetchChanges {
       let service = try await CloudKitServiceTests.FetchChanges.makeSuccessfulService()
 
       // Minimum valid limit
-      let result1 = try await service.fetchRecordChanges(resultsLimit: 1)
+      let result1 = try await service.fetchRecordChanges(
+        resultsLimit: 1,
+        database: .public(.prefers(.serverToServer))
+      )
       #expect(result1.records.isEmpty == false || result1.syncToken != nil)
 
       // Maximum valid limit
-      let result200 = try await service.fetchRecordChanges(resultsLimit: 200)
+      let result200 = try await service.fetchRecordChanges(
+        resultsLimit: 200,
+        database: .public(.prefers(.serverToServer))
+      )
       #expect(result200.records.isEmpty == false || result200.syncToken != nil)
     }
 
@@ -105,7 +117,7 @@ extension CloudKitServiceTests.FetchChanges {
       )
 
       await #expect(throws: CloudKitError.self) {
-        _ = try await service.fetchAllRecordChanges()
+        _ = try await service.fetchAllRecordChanges(database: .public(.prefers(.serverToServer)))
       }
     }
 
@@ -121,7 +133,9 @@ extension CloudKitServiceTests.FetchChanges {
         syncToken: "stuck-token"
       )
 
-      let (records, token) = try await service.fetchAllRecordChanges()
+      let (records, token) = try await service.fetchAllRecordChanges(
+        database: .public(.prefers(.serverToServer))
+      )
 
       #expect(records.isEmpty)
       #expect(token == "stuck-token")

--- a/Tests/MistKitTests/Service/CloudKitServiceFetchZoneChanges/CloudKitServiceTests.FetchZoneChanges+SuccessCases.swift
+++ b/Tests/MistKitTests/Service/CloudKitServiceFetchZoneChanges/CloudKitServiceTests.FetchZoneChanges+SuccessCases.swift
@@ -46,7 +46,7 @@ extension CloudKitServiceTests.FetchZoneChanges {
         syncToken: "zone-token-xyz"
       )
 
-      let result = try await service.fetchZoneChanges(database: .public)
+      let result = try await service.fetchZoneChanges(database: .public(.prefers(.serverToServer)))
 
       #expect(result.zones.count == 2)
       #expect(result.syncToken == "zone-token-xyz")
@@ -62,7 +62,7 @@ extension CloudKitServiceTests.FetchZoneChanges {
         zoneCount: 1
       )
 
-      let result = try await service.fetchZoneChanges(database: .public)
+      let result = try await service.fetchZoneChanges(database: .public(.prefers(.serverToServer)))
 
       #expect(result.zones.first?.zoneName == "test-zone-0")
     }
@@ -77,7 +77,7 @@ extension CloudKitServiceTests.FetchZoneChanges {
         zoneCount: 0
       )
 
-      let result = try await service.fetchZoneChanges(database: .public)
+      let result = try await service.fetchZoneChanges(database: .public(.prefers(.serverToServer)))
 
       #expect(result.zones.isEmpty)
       #expect(result.syncToken != nil)
@@ -96,7 +96,7 @@ extension CloudKitServiceTests.FetchZoneChanges {
 
       let result = try await service.fetchZoneChanges(
         syncToken: "previous-token",
-        database: .public
+        database: .public(.prefers(.serverToServer))
       )
 
       #expect(result.zones.count == 1)
@@ -119,7 +119,7 @@ extension CloudKitServiceTests.FetchZoneChanges {
         transport: transport
       )
 
-      let result = try await service.fetchZoneChanges(database: .public)
+      let result = try await service.fetchZoneChanges(database: .public(.prefers(.serverToServer)))
 
       #expect(result.zones.count == 1, "Zone with nil zoneID should be filtered out")
       #expect(result.zones.first?.zoneName == "valid-zone")

--- a/Tests/MistKitTests/Service/CloudKitServiceLookupZones/CloudKitServiceTests.LookupZones+SuccessCases.swift
+++ b/Tests/MistKitTests/Service/CloudKitServiceLookupZones/CloudKitServiceTests.LookupZones+SuccessCases.swift
@@ -45,7 +45,7 @@ extension CloudKitServiceTests.LookupZones {
 
       let zones = try await service.lookupZones(
         zoneIDs: [ZoneID(zoneName: "_defaultZone", ownerName: nil)],
-        database: .public
+        database: .public(.prefers(.serverToServer))
       )
 
       #expect(zones.count == 1)
@@ -66,7 +66,7 @@ extension CloudKitServiceTests.LookupZones {
           ZoneID(zoneName: "zone2", ownerName: nil),
           ZoneID(zoneName: "zone3", ownerName: nil),
         ],
-        database: .public
+        database: .public(.prefers(.serverToServer))
       )
 
       #expect(zones.count == 3)
@@ -85,7 +85,7 @@ extension CloudKitServiceTests.LookupZones {
 
       let zones = try await service.lookupZones(
         zoneIDs: [ZoneID(zoneName: "nonexistent", ownerName: nil)],
-        database: .public
+        database: .public(.prefers(.serverToServer))
       )
 
       #expect(zones.isEmpty)

--- a/Tests/MistKitTests/Service/CloudKitServiceQuery/CloudKitServiceTests.Query+EdgeCases.swift
+++ b/Tests/MistKitTests/Service/CloudKitServiceQuery/CloudKitServiceTests.Query+EdgeCases.swift
@@ -46,7 +46,11 @@ extension CloudKitServiceTests.Query {
       // With nil limit, should use defaultQueryLimit (100)
       // This test verifies the parameter handling - actual call will fail without auth
       do {
-        _ = try await service.queryRecords(recordType: "Article", limit: nil as Int?)
+        _ = try await service.queryRecords(
+          recordType: "Article",
+          limit: nil as Int?,
+          database: .public(.prefers(.serverToServer))
+        )
       } catch {
         // Validation should pass (no 400 error)
         if case .httpErrorWithRawResponse(let statusCode, _) = error {
@@ -67,7 +71,8 @@ extension CloudKitServiceTests.Query {
         _ = try await service.queryRecords(
           recordType: "Article",
           filters: [],
-          limit: 10
+          limit: 10,
+          database: .public(.prefers(.serverToServer))
         )
       } catch {
         // Should not fail validation
@@ -89,7 +94,8 @@ extension CloudKitServiceTests.Query {
         _ = try await service.queryRecords(
           recordType: "Article",
           sortBy: [],
-          limit: 10
+          limit: 10,
+          database: .public(.prefers(.serverToServer))
         )
       } catch {
         // Should not fail validation

--- a/Tests/MistKitTests/Service/CloudKitServiceQuery/CloudKitServiceTests.Query+ExistingRecordNames.swift
+++ b/Tests/MistKitTests/Service/CloudKitServiceQuery/CloudKitServiceTests.Query+ExistingRecordNames.swift
@@ -1,0 +1,78 @@
+//
+//  CloudKitServiceTests.Query+ExistingRecordNames.swift
+//  MistKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import Foundation
+import Testing
+
+@testable import MistKit
+
+extension CloudKitServiceTests.Query {
+  @Suite("fetchExistingRecordNames", .enabled(if: Platform.isCryptoAvailable))
+  internal struct ExistingRecordNames {
+    @Test("fetchExistingRecordNames returns the set of existing record names")
+    internal func fetchExistingRecordNamesReturnsExistingNames() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let service = try CloudKitServiceTests.QueryPagination.makeSuccessfulService(
+        recordCount: 3,
+        continuationMarker: nil
+      )
+
+      let existing = try await service.fetchExistingRecordNames(
+        recordType: "TestRecord",
+        database: .public(.prefers(.serverToServer))
+      )
+
+      #expect(existing == Set(["record-0", "record-1", "record-2"]))
+    }
+
+    @Test("deprecated RecordManaging.queryRecords(recordType:) returns parsed records")
+    @available(
+      *, deprecated,
+      message: "Exercises the deprecated single-page RecordManaging wrapper."
+    )
+    internal func deprecatedQueryRecordsReturnsRecords() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let service = try CloudKitServiceTests.QueryPagination.makeSuccessfulService(
+        recordCount: 2,
+        continuationMarker: nil
+      )
+
+      let records = try await service.queryRecords(recordType: "TestRecord")
+
+      #expect(records.count == 2)
+      #expect(records.map(\.recordName) == ["record-0", "record-1"])
+    }
+  }
+}

--- a/Tests/MistKitTests/Service/CloudKitServiceQuery/CloudKitServiceTests.Query+Validation.swift
+++ b/Tests/MistKitTests/Service/CloudKitServiceQuery/CloudKitServiceTests.Query+Validation.swift
@@ -44,7 +44,10 @@ extension CloudKitServiceTests.Query {
       let service = try CloudKitServiceTests.Query.makeValidationErrorService(.emptyRecordType)
 
       do {
-        _ = try await service.queryRecords(recordType: "")
+        _ = try await service.queryRecords(
+          recordType: "",
+          database: .public(.prefers(.serverToServer))
+        )
         Issue.record("Expected error for empty recordType")
       } catch let error as CloudKitError {
         // Verify we get the correct validation error
@@ -68,7 +71,11 @@ extension CloudKitServiceTests.Query {
       let service = try CloudKitServiceTests.Query.makeValidationErrorService(.limitTooSmall(limit))
 
       do {
-        _ = try await service.queryRecords(recordType: "Article", limit: limit)
+        _ = try await service.queryRecords(
+          recordType: "Article",
+          limit: limit,
+          database: .public(.prefers(.serverToServer))
+        )
         Issue.record("Expected error for limit \(limit)")
       } catch {
         if case .httpErrorWithRawResponse(let statusCode, let response) = error {
@@ -89,7 +96,11 @@ extension CloudKitServiceTests.Query {
       let service = try CloudKitServiceTests.Query.makeValidationErrorService(.limitTooLarge(limit))
 
       do {
-        _ = try await service.queryRecords(recordType: "Article", limit: limit)
+        _ = try await service.queryRecords(
+          recordType: "Article",
+          limit: limit,
+          database: .public(.prefers(.serverToServer))
+        )
         Issue.record("Expected error for limit \(limit)")
       } catch {
         if case .httpErrorWithRawResponse(let statusCode, let response) = error {
@@ -112,7 +123,11 @@ extension CloudKitServiceTests.Query {
       // This test verifies validation passes - actual API call will fail without real credentials
       // but we're testing that validation doesn't throw
       do {
-        _ = try await service.queryRecords(recordType: "Article", limit: limit)
+        _ = try await service.queryRecords(
+          recordType: "Article",
+          limit: limit,
+          database: .public(.prefers(.serverToServer))
+        )
         Issue.record("Expected network error since we don't have real credentials")
       } catch {
         // We expect a network/auth error, not a validation error

--- a/Tests/MistKitTests/Service/CloudKitServiceQueryPagination/CloudKitServiceTests.QueryPagination+ErrorCases.swift
+++ b/Tests/MistKitTests/Service/CloudKitServiceQueryPagination/CloudKitServiceTests.QueryPagination+ErrorCases.swift
@@ -52,7 +52,8 @@ extension CloudKitServiceTests.QueryPagination {
       do {
         _ = try await service.queryAllRecords(
           recordType: "TestRecord",
-          maxPages: 2
+          maxPages: 2,
+          database: .public(.prefers(.serverToServer))
         )
         Issue.record("Expected paginationLimitExceeded to be thrown")
       } catch CloudKitError.paginationLimitExceeded(let maxPages, let records) {

--- a/Tests/MistKitTests/Service/CloudKitServiceQueryPagination/CloudKitServiceTests.QueryPagination+SuccessCases.swift
+++ b/Tests/MistKitTests/Service/CloudKitServiceQueryPagination/CloudKitServiceTests.QueryPagination+SuccessCases.swift
@@ -50,7 +50,8 @@ extension CloudKitServiceTests.QueryPagination {
 
       let result: QueryResult = try await service.queryRecords(
         recordType: "TestRecord",
-        continuationMarker: nil
+        continuationMarker: nil,
+        database: .public(.prefers(.serverToServer))
       )
 
       #expect(result.records.count == 3)
@@ -69,7 +70,8 @@ extension CloudKitServiceTests.QueryPagination {
       )
 
       let result: QueryResult = try await service.queryRecords(
-        recordType: "TestRecord"
+        recordType: "TestRecord",
+        database: .public(.prefers(.serverToServer))
       )
 
       #expect(result.records.count == 2)
@@ -89,7 +91,8 @@ extension CloudKitServiceTests.QueryPagination {
 
       let result: QueryResult = try await service.queryRecords(
         recordType: "TestRecord",
-        continuationMarker: "previous-marker"
+        continuationMarker: "previous-marker",
+        database: .public(.prefers(.serverToServer))
       )
 
       #expect(result.records.count == 1)

--- a/Tests/MistKitTests/Service/CloudKitServiceUpload/CloudKitServiceTests.Upload+ErrorHandling.swift
+++ b/Tests/MistKitTests/Service/CloudKitServiceUpload/CloudKitServiceTests.Upload+ErrorHandling.swift
@@ -48,7 +48,8 @@ extension CloudKitServiceTests.Upload {
         _ = try await service.uploadAssets(
           data: testData,
           recordType: "Note",
-          fieldName: "image"
+          fieldName: "image",
+          database: .public(.prefers(.serverToServer))
         )
         Issue.record("Expected authentication error")
       } catch let error as CloudKitError {
@@ -79,7 +80,8 @@ extension CloudKitServiceTests.Upload {
         _ = try await service.uploadAssets(
           data: testData,
           recordType: "Note",
-          fieldName: "image"
+          fieldName: "image",
+          database: .public(.prefers(.serverToServer))
         )
         Issue.record("Expected bad request error")
       } catch let error as CloudKitError {

--- a/Tests/MistKitTests/Service/CloudKitServiceUpload/CloudKitServiceTests.Upload+NetworkErrors.swift
+++ b/Tests/MistKitTests/Service/CloudKitServiceUpload/CloudKitServiceTests.Upload+NetworkErrors.swift
@@ -48,7 +48,8 @@ extension CloudKitServiceTests.Upload {
         _ = try await service.uploadAssets(
           data: testData,
           recordType: "Note",
-          fieldName: "image"
+          fieldName: "image",
+          database: .public(.prefers(.serverToServer))
         )
       } throws: { error in
         guard let ckError = error as? CloudKitError,
@@ -77,7 +78,8 @@ extension CloudKitServiceTests.Upload {
           data: testData,
           recordType: "Note",
           fieldName: "image",
-          using: throwingUploader
+          using: throwingUploader,
+          database: .public(.prefers(.serverToServer))
         )
       } throws: { error in
         guard let ckError = error as? CloudKitError,
@@ -105,7 +107,8 @@ extension CloudKitServiceTests.Upload {
           data: testData,
           recordType: "Note",
           fieldName: "image",
-          using: misdirectedUploader
+          using: misdirectedUploader,
+          database: .public(.prefers(.serverToServer))
         )
       } throws: { error in
         guard let ckError = error as? CloudKitError,

--- a/Tests/MistKitTests/Service/CloudKitServiceUpload/CloudKitServiceTests.Upload+SuccessCases.swift
+++ b/Tests/MistKitTests/Service/CloudKitServiceUpload/CloudKitServiceTests.Upload+SuccessCases.swift
@@ -48,7 +48,8 @@ extension CloudKitServiceTests.Upload {
         data: testData,
         recordType: "Note",
         fieldName: "image",
-        using: CloudKitServiceTests.Upload.makeMockAssetUploader()
+        using: CloudKitServiceTests.Upload.makeMockAssetUploader(),
+        database: .public(.prefers(.serverToServer))
       )
 
       #expect(result.recordName.isEmpty == false, "Result should have a record name")
@@ -69,7 +70,8 @@ extension CloudKitServiceTests.Upload {
         data: testData,
         recordType: "Note",
         fieldName: "image",
-        using: CloudKitServiceTests.Upload.makeMockAssetUploader()
+        using: CloudKitServiceTests.Upload.makeMockAssetUploader(),
+        database: .public(.prefers(.serverToServer))
       )
 
       #expect(result.recordName == "test-record-0")
@@ -90,7 +92,8 @@ extension CloudKitServiceTests.Upload {
         data: testData,
         recordType: "Note",
         fieldName: "image",
-        using: CloudKitServiceTests.Upload.makeMockAssetUploader()
+        using: CloudKitServiceTests.Upload.makeMockAssetUploader(),
+        database: .public(.prefers(.serverToServer))
       )
 
       #expect(result.recordName == "test-record-0")
@@ -108,7 +111,8 @@ extension CloudKitServiceTests.Upload {
 
       let token = try await service.requestAssetUploadURL(
         recordType: "Note",
-        fieldName: "image"
+        fieldName: "image",
+        database: .public(.prefers(.serverToServer))
       )
 
       #expect(token.url != nil)
@@ -150,7 +154,8 @@ extension CloudKitServiceTests.Upload {
         data: Data(count: 1_024),
         recordType: "Note",
         fieldName: "image",
-        using: trackingUploader
+        using: trackingUploader,
+        database: .public(.prefers(.serverToServer))
       )
 
       let count = await tracker.callCount

--- a/Tests/MistKitTests/Service/CloudKitServiceUpload/CloudKitServiceTests.Upload+Validation.swift
+++ b/Tests/MistKitTests/Service/CloudKitServiceUpload/CloudKitServiceTests.Upload+Validation.swift
@@ -49,7 +49,8 @@ extension CloudKitServiceTests.Upload {
         _ = try await service.uploadAssets(
           data: Data(),
           recordType: "Note",
-          fieldName: "image"
+          fieldName: "image",
+          database: .public(.prefers(.serverToServer))
         )
         Issue.record("Expected error for empty data")
       } catch {
@@ -78,7 +79,8 @@ extension CloudKitServiceTests.Upload {
         _ = try await service.uploadAssets(
           data: oversizedData,
           recordType: "Note",
-          fieldName: "image"
+          fieldName: "image",
+          database: .public(.prefers(.serverToServer))
         )
         Issue.record("Expected error for oversized asset")
       } catch {
@@ -115,7 +117,8 @@ extension CloudKitServiceTests.Upload {
             data: data,
             recordType: "Note",
             fieldName: "image",
-            using: CloudKitServiceTests.Upload.makeMockAssetUploader()
+            using: CloudKitServiceTests.Upload.makeMockAssetUploader(),
+            database: .public(.prefers(.serverToServer))
           )
           #expect(result.asset.receipt != nil, "Should receive asset with receipt")
         } catch {
@@ -145,7 +148,8 @@ extension CloudKitServiceTests.Upload {
           data: Data(count: 1_024),
           recordType: "Note",
           fieldName: "image",
-          using: CloudKitServiceTests.Upload.makeMockAssetUploader()
+          using: CloudKitServiceTests.Upload.makeMockAssetUploader(),
+          database: .public(.prefers(.serverToServer))
         )
       }
     }


### PR DESCRIPTION
## Summary

- `Database.public` now carries a `PublicAuthPreference` (`.prefers(...)` or `.requires(...)`); the dispatcher's silent "S2S wins when present" policy is gone. Caller picks attribution explicitly at every public-DB call site.
- `Credentials.makeTokenManager(for:)` lost the `requiresUserContext` flag — user-context routes (`users/*`) pass `.public(.requires(.webAuth))` directly, collapsing the carve-out into the same machinery (per #338).
- `CloudKitError.missingCredentials` gained `CredentialAvailability` so `.preferenceRequired` (caller used `.requires(_:)` but creds absent) is distinguishable from `.notConfigured`.
- Two departures from the design comment in #338, agreed on during planning:
  - **No defaults** on `PublicAuthPreference` — a defaulted `auth:` parameter would recreate the silent-policy problem at a different layer.
  - **Encoded in `Database`**, not a separate `auth:` parameter — so the knob appears only where it's meaningful. `.private` / `.shared` callers don't type meaningless `auth:` arguments.

Library-only PR. The demo's Option C toggle (and the "You" badge fix under MistKit + Public) live in a follow-up branch off ` 330-interactive-mistdemo`.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 485/485 pass (rewrote `CredentialsTokenManagerTests+PublicDatabase.swift` for the new `prefers`/`requires` matrix; rewrote `+UserContext.swift` to assert the carve-out collapse; updated `DatabaseTests` for `pathSegment`; mechanical sweep added explicit `database:` arguments to 14 Service test files)
- [x] `./Scripts/lint.sh` — `Linting completed successfully`
- [ ] Demo end-to-end verification (`mistdemo web` + "You" badge under MistKit + Public + `.requires(.webAuth)`) — lives in the follow-up branch off `330-interactive-mistdemo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)