### PR TITLE
Scaffold MistDemo (CLI + App + Web) for v1.0.0-beta.2 endpoints

### DIFF
--- a/Examples/MistDemo/.swiftlint.yml
+++ b/Examples/MistDemo/.swiftlint.yml
@@ -126,6 +126,10 @@ indentation_width:
 file_name:
     severity: error
     excluded:
+      # Holds only the per-platform `#if`-selected typealiases; named neutrally
+      # so no alias is misread as a `main_type` by `file_types_order` (see the
+      # file's header comment). The resulting `file_name` mismatch is expected.
+      - PlatformAliases.swift
       - Package.swift
       - AsyncHelpers.swift
       - UserInfoTestExtension.swift

--- a/Examples/MistDemo/App/MistDemoApp.swift
+++ b/Examples/MistDemo/App/MistDemoApp.swift
@@ -32,4 +32,14 @@ internal import SwiftUI
 
 @main
 internal struct MistDemoAppMain: AppMain {
+  // SwiftUI owns the AppDelegate's lifecycle via this adaptor; the
+  // delegate's static-weak `receiver` is wired from `CloudKitStore.init`
+  // so the OS-delivered APNs token lands back in the observable store.
+  #if canImport(AppKit) && !targetEnvironment(macCatalyst)
+    @NSApplicationDelegateAdaptor(PushNotificationDelegate.self)
+    private var pushDelegate
+  #elseif canImport(UIKit)
+    @UIApplicationDelegateAdaptor(PushNotificationDelegate.self)
+    private var pushDelegate
+  #endif
 }

--- a/Examples/MistDemo/MistDemoApp.entitlements
+++ b/Examples/MistDemo/MistDemoApp.entitlements
@@ -14,5 +14,9 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.aps-environment</key>
+	<string>development</string>
 </dict>
 </plist>

--- a/Examples/MistDemo/Package.swift
+++ b/Examples/MistDemo/Package.swift
@@ -156,6 +156,8 @@ let package = Package(
       ],
       resources: [
         .copy("Resources/index.html"),
+        .copy("Resources/styles.css"),
+        .copy("Resources/js"),
       ],
       swiftSettings: swiftSettings
     ),

--- a/Examples/MistDemo/Sources/MistDemoApp/Models/RecordZoneChangesSnapshot.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Models/RecordZoneChangesSnapshot.swift
@@ -1,5 +1,5 @@
 //
-//  DetailColumnRoot.swift
+//  RecordZoneChangesSnapshot.swift
 //  MistDemo
 //
 //  Created by Leo Dion.
@@ -27,38 +27,16 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if canImport(SwiftUI)
-  internal import SwiftUI
+#if canImport(CloudKit)
+  internal import CloudKit
+  internal import Foundation
 
-  /// Routes the sidebar selection to the appropriate detail view.
-  internal struct DetailColumnRoot: View {
-    internal let selection: SidebarItem?
-
-    internal var body: some View {
-      switch selection {
-      case .account:
-        AccountView()
-      case .zones:
-        ZoneListView()
-      case .query:
-        QueryView()
-      case .records:
-        RecordsView()
-      case .subscriptions:
-        SubscriptionsView()
-      case .pushTokens:
-        PushTokensView()
-      case .assets:
-        AssetsView()
-      case .users:
-        UsersView()
-      case nil:
-        ContentUnavailableView(
-          "Pick a section from the sidebar",
-          systemImage: "sidebar.left",
-          description: Text("Account, Zones, Records, Subscriptions, …")
-        )
-      }
-    }
+  /// Snapshot from `CKFetchRecordZoneChangesOperation` so the UI can show
+  /// what changed since the last sync token.
+  internal struct RecordZoneChangesSnapshot: Sendable {
+    internal let changedRecordNames: [String]
+    internal let deletedRecordNames: [String]
+    internal let serverChangeToken: CKServerChangeToken?
+    internal let moreComing: Bool
   }
 #endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Models/ResolveResult.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Models/ResolveResult.swift
@@ -1,5 +1,5 @@
 //
-//  DetailColumnRoot.swift
+//  ResolveResult.swift
 //  MistDemo
 //
 //  Created by Leo Dion.
@@ -27,38 +27,21 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if canImport(SwiftUI)
-  internal import SwiftUI
+#if canImport(CloudKit)
+  internal import Foundation
 
-  /// Routes the sidebar selection to the appropriate detail view.
-  internal struct DetailColumnRoot: View {
-    internal let selection: SidebarItem?
-
-    internal var body: some View {
-      switch selection {
-      case .account:
-        AccountView()
-      case .zones:
-        ZoneListView()
-      case .query:
-        QueryView()
-      case .records:
-        RecordsView()
-      case .subscriptions:
-        SubscriptionsView()
-      case .pushTokens:
-        PushTokensView()
-      case .assets:
-        AssetsView()
-      case .users:
-        UsersView()
-      case nil:
-        ContentUnavailableView(
-          "Pick a section from the sidebar",
-          systemImage: "sidebar.left",
-          description: Text("Account, Zones, Records, Subscriptions, …")
-        )
-      }
+  /// Result of a composed `records/resolve`. The REST endpoint takes
+  /// either a record name or a share URL; the native CloudKit surface
+  /// branches on the input shape, so we record which branch ran.
+  internal struct ResolveResult: Sendable {
+    internal enum Source: String, Sendable {
+      case recordName
+      case shareURL
     }
+
+    internal let source: Source
+    internal let recordName: String?
+    internal let recordType: String?
+    internal let shareTitle: String?
   }
 #endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/CloudKitStore+Assets.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/CloudKitStore+Assets.swift
@@ -1,0 +1,90 @@
+//
+//  CloudKitStore+Assets.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if canImport(CloudKit)
+  internal import CloudKit
+  internal import Foundation
+  internal import MistDemoKit
+
+  /// Result of a composed `assets/rereference`. The native CloudKit surface
+  /// can't move asset metadata between records in one call — we fetch the
+  /// source record, reuse its `CKAsset`, then save it onto the target
+  /// record. The result records both the source and target.
+  internal struct RereferenceResult: Sendable {
+    internal let sourceRecordName: String
+    internal let assetField: String
+    internal let targetRecordName: String
+    internal let targetAssetField: String
+  }
+
+  extension CloudKitStore {
+    /// Upload `fileURL` as the `image` asset on a new Note record. Maps to
+    /// `assets/upload` in the REST surface — native CloudKit does the
+    /// upload inline as part of `database.save(_:)`.
+    internal func uploadAssetNote(
+      title: String,
+      index: Int64,
+      fileURL: URL
+    ) async throws -> Note {
+      try await createNote(title: title, index: index, imageURL: fileURL)
+    }
+
+    /// Re-reference an asset from one record onto another. Composed call:
+    /// fetch the source record, pull its `CKAsset`, save the target with
+    /// that same asset. Native CloudKit doesn't expose a single-call
+    /// equivalent of the REST `assets/rereference` endpoint, hence the
+    /// composition.
+    internal func rereferenceAsset(
+      sourceRecordName: String,
+      assetField: String,
+      targetRecordName: String,
+      targetAssetField: String? = nil
+    ) async throws -> RereferenceResult {
+      let resolvedTargetField = targetAssetField ?? assetField
+
+      let sourceID = CKRecord.ID(recordName: sourceRecordName)
+      let sourceRecord = try await database.record(for: sourceID)
+      guard let asset = sourceRecord[assetField] as? CKAsset else {
+        throw CloudKitStoreError.unexpectedSaveResult
+      }
+
+      let targetID = CKRecord.ID(recordName: targetRecordName)
+      let targetRecord = try await database.record(for: targetID)
+      targetRecord[resolvedTargetField] = asset
+      _ = try await database.save(targetRecord)
+
+      return RereferenceResult(
+        sourceRecordName: sourceRecordName,
+        assetField: assetField,
+        targetRecordName: targetRecordName,
+        targetAssetField: resolvedTargetField
+      )
+    }
+  }
+#endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/CloudKitStore+PushTokens.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/CloudKitStore+PushTokens.swift
@@ -1,0 +1,105 @@
+//
+//  CloudKitStore+PushTokens.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if canImport(CloudKit)
+  internal import CloudKit
+  internal import Foundation
+  internal import MistDemoKit
+
+  #if canImport(AppKit) && !targetEnvironment(macCatalyst)
+    internal import AppKit
+  #elseif canImport(UIKit)
+    internal import UIKit
+  #endif
+
+  /// The push-token registration state surfaced to the UI. APNs requires a
+  /// signed app + push entitlement; on simulators or unentitled builds the
+  /// OS reports an error which the UI renders inline.
+  internal enum PushTokenStatus: Sendable {
+    case idle
+    case requesting
+    case registered(hexToken: String)
+    case failed(message: String)
+  }
+
+  extension CloudKitStore {
+    /// Trigger APNs registration. Returns immediately after asking the OS;
+    /// the actual token arrives via the platform app delegate hook, which
+    /// the demo app forwards back into the store via `recordDeviceToken`.
+    /// On platforms where APNs isn't available we report `.failed`.
+    internal func requestPushNotificationRegistration() {
+      #if canImport(AppKit) && !targetEnvironment(macCatalyst)
+        NSApplication.shared.registerForRemoteNotifications()
+        pushTokenStatus = .requesting
+      #elseif canImport(UIKit)
+        UIApplication.shared.registerForRemoteNotifications()
+        pushTokenStatus = .requesting
+      #else
+        pushTokenStatus = .failed(
+          message: "APNs registration is unavailable on this platform."
+        )
+      #endif
+    }
+
+    /// Forward the APNs device token captured by the platform app delegate.
+    internal func recordDeviceToken(_ data: Data) {
+      let hex = data.map { String(format: "%02x", $0) }.joined()
+      pushTokenStatus = .registered(hexToken: hex)
+    }
+
+    /// Forward the APNs registration error captured by the platform app delegate.
+    /// Surfaces the underlying NSError domain + code alongside the localized
+    /// message — the default `localizedDescription` for sandboxed-app /
+    /// signing failures collapses to "the operation couldn't be completed.
+    /// (OSStatus error N)" which by itself doesn't say what failed.
+    internal func recordDeviceTokenError(_ error: any Error) {
+      let nsError = error as NSError
+      let summary =
+        "\(error.localizedDescription)\n"
+        + "[\(nsError.domain) code \(nsError.code)]"
+      pushTokenStatus = .failed(message: summary)
+    }
+  }
+
+  #if canImport(AppKit) || canImport(UIKit)
+    extension CloudKitStore: PushTokenReceiver {
+      internal func didRegisterForRemoteNotifications(deviceToken: Data) {
+        recordDeviceToken(deviceToken)
+      }
+
+      internal func didFailToRegisterForRemoteNotifications(error: any Error) {
+        recordDeviceTokenError(error)
+      }
+
+      internal func didReceiveRemoteNotification(userInfo: [AnyHashable: Any]) {
+        lastReceivedNotification = String(describing: userInfo)
+      }
+    }
+  #endif
+#endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/CloudKitStore+PushTokens.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/CloudKitStore+PushTokens.swift
@@ -34,7 +34,7 @@
 
   #if canImport(AppKit) && !targetEnvironment(macCatalyst)
     internal import AppKit
-  #elseif canImport(UIKit)
+  #elseif canImport(UIKit) && !os(watchOS)
     internal import UIKit
   #endif
 
@@ -54,11 +54,8 @@
     /// the demo app forwards back into the store via `recordDeviceToken`.
     /// On platforms where APNs isn't available we report `.failed`.
     internal func requestPushNotificationRegistration() {
-      #if canImport(AppKit) && !targetEnvironment(macCatalyst)
-        NSApplication.shared.registerForRemoteNotifications()
-        pushTokenStatus = .requesting
-      #elseif canImport(UIKit)
-        UIApplication.shared.registerForRemoteNotifications()
+      #if (canImport(AppKit) && !targetEnvironment(macCatalyst)) || (canImport(UIKit) && !os(watchOS))
+        PlatformApplication.registerSharedForRemoteNotifications()
         pushTokenStatus = .requesting
       #else
         pushTokenStatus = .failed(
@@ -87,7 +84,7 @@
     }
   }
 
-  #if canImport(AppKit) || canImport(UIKit)
+  #if (canImport(AppKit) && !targetEnvironment(macCatalyst)) || (canImport(UIKit) && !os(watchOS))
     extension CloudKitStore: PushTokenReceiver {
       internal func didRegisterForRemoteNotifications(deviceToken: Data) {
         recordDeviceToken(deviceToken)

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/CloudKitStore+PushTokens.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/CloudKitStore+PushTokens.swift
@@ -29,7 +29,7 @@
 
 #if canImport(CloudKit)
   internal import CloudKit
-  internal import Foundation
+  public import Foundation
   internal import MistDemoKit
 
   #if canImport(AppKit) && !targetEnvironment(macCatalyst)
@@ -38,30 +38,19 @@
     internal import UIKit
   #endif
 
-  /// The push-token registration state surfaced to the UI. APNs requires a
-  /// signed app + push entitlement; on simulators or unentitled builds the
-  /// OS reports an error which the UI renders inline.
-  internal enum PushTokenStatus: Sendable {
-    case idle
-    case requesting
-    case registered(hexToken: String)
-    case failed(message: String)
-  }
-
   extension CloudKitStore {
     /// Trigger APNs registration. Returns immediately after asking the OS;
     /// the actual token arrives via the platform app delegate hook, which
     /// the demo app forwards back into the store via `recordDeviceToken`.
     /// On platforms where APNs isn't available we report `.failed`.
     internal func requestPushNotificationRegistration() {
-      #if (canImport(AppKit) && !targetEnvironment(macCatalyst)) || (canImport(UIKit) && !os(watchOS))
-        PlatformApplication.registerSharedForRemoteNotifications()
-        pushTokenStatus = .requesting
-      #else
-        pushTokenStatus = .failed(
-          message: "APNs registration is unavailable on this platform."
-        )
-      #endif
+      PlatformApplication.registerSharedForRemoteNotifications()
+      pushTokenStatus = .requesting
+      //      #else
+      //        pushTokenStatus = .failed(
+      //          message: "APNs registration is unavailable on this platform."
+      //        )
+      //      #endif
     }
 
     /// Forward the APNs device token captured by the platform app delegate.
@@ -84,19 +73,22 @@
     }
   }
 
-  #if (canImport(AppKit) && !targetEnvironment(macCatalyst)) || (canImport(UIKit) && !os(watchOS))
-    extension CloudKitStore: PushTokenReceiver {
-      internal func didRegisterForRemoteNotifications(deviceToken: Data) {
-        recordDeviceToken(deviceToken)
-      }
-
-      internal func didFailToRegisterForRemoteNotifications(error: any Error) {
-        recordDeviceTokenError(error)
-      }
-
-      internal func didReceiveRemoteNotification(userInfo: [AnyHashable: Any]) {
-        lastReceivedNotification = String(describing: userInfo)
-      }
+  extension CloudKitStore: PushTokenReceiver {
+    /// Records the APNs device token forwarded by the platform app delegate.
+    public func didRegisterForRemoteNotifications(deviceToken: Data) {
+      recordDeviceToken(deviceToken)
     }
-  #endif
+
+    /// Records the APNs registration failure forwarded by the platform app
+    /// delegate.
+    public func didFailToRegisterForRemoteNotifications(error: any Error) {
+      recordDeviceTokenError(error)
+    }
+
+    /// Stores a description of the most recent remote notification payload.
+    public func didReceiveRemoteNotification(userInfo: [AnyHashable: Any]) {
+      lastReceivedNotification = String(describing: userInfo)
+    }
+  }
+
 #endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/CloudKitStore+Records.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/CloudKitStore+Records.swift
@@ -1,0 +1,130 @@
+//
+//  CloudKitStore+Records.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if canImport(CloudKit)
+  internal import CloudKit
+  internal import Foundation
+  internal import MistDemoKit
+
+  extension CloudKitStore {
+    /// Look up records by name. Maps to `records/lookup` in the REST
+    /// surface; uses `database.record(for:)` per ID.
+    internal func lookupRecords(names: [String]) async throws -> [Note] {
+      var notes: [Note] = []
+      for name in names {
+        let recordID = CKRecord.ID(recordName: name)
+        let record = try await database.record(for: recordID)
+        if let note = Note(record) {
+          notes.append(note)
+        }
+      }
+      return notes
+    }
+
+    /// Fetch record-level deltas for the given zone since `previousToken`.
+    /// Returns the changed and deleted record names plus the new sync
+    /// token. Pass that token back on the next call for an incremental
+    /// fetch. Maps to `records/changes` in the REST surface.
+    internal func fetchRecordZoneChanges(
+      zoneID: CKRecordZone.ID,
+      since previousToken: CKServerChangeToken? = nil
+    ) async throws -> RecordZoneChangesSnapshot {
+      try await withCheckedThrowingContinuation { continuation in
+        let configuration =
+          CKFetchRecordZoneChangesOperation
+          .ZoneConfiguration(previousServerChangeToken: previousToken)
+        let operation = CKFetchRecordZoneChangesOperation(
+          recordZoneIDs: [zoneID],
+          configurationsByRecordZoneID: [zoneID: configuration]
+        )
+
+        var changed: [String] = []
+        var deleted: [String] = []
+        var resolvedToken: CKServerChangeToken?
+        var moreComing = false
+
+        operation.recordWasChangedBlock = { recordID, _ in
+          changed.append(recordID.recordName)
+        }
+        operation.recordWithIDWasDeletedBlock = { recordID, _ in
+          deleted.append(recordID.recordName)
+        }
+        operation.recordZoneFetchResultBlock = { _, result in
+          if case .success(let payload) = result {
+            resolvedToken = payload.serverChangeToken
+            moreComing = payload.moreComing
+          }
+        }
+        operation.fetchRecordZoneChangesResultBlock = { result in
+          switch result {
+          case .failure(let error):
+            continuation.resume(throwing: error)
+          case .success:
+            continuation.resume(
+              returning: RecordZoneChangesSnapshot(
+                changedRecordNames: changed,
+                deletedRecordNames: deleted,
+                serverChangeToken: resolvedToken,
+                moreComing: moreComing
+              )
+            )
+          }
+        }
+
+        database.add(operation)
+      }
+    }
+
+    /// Resolve a record reference. Accepts either a CloudKit record name
+    /// (routed through `database.record(for:)`) or a share URL (routed
+    /// through `CKContainer.share(metadataFor:)`). Maps to `records/resolve`
+    /// in the REST surface as a composed call.
+    internal func resolveReference(input: String) async throws -> ResolveResult {
+      if let url = URL(string: input), url.scheme?.hasPrefix("http") == true {
+        let container = CKContainer(identifier: containerIdentifier)
+        let metadata = try await container.shareMetadata(for: url)
+        return ResolveResult(
+          source: .shareURL,
+          recordName: metadata.rootRecordID.recordName,
+          recordType: metadata.rootRecord?.recordType,
+          shareTitle: metadata.share[CKShare.SystemFieldKey.title] as? String
+        )
+      }
+      let record = try await database.record(
+        for: CKRecord.ID(recordName: input)
+      )
+      return ResolveResult(
+        source: .recordName,
+        recordName: record.recordID.recordName,
+        recordType: record.recordType,
+        shareTitle: nil
+      )
+    }
+  }
+#endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/CloudKitStore+Subscriptions.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/CloudKitStore+Subscriptions.swift
@@ -1,0 +1,115 @@
+//
+//  CloudKitStore+Subscriptions.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if canImport(CloudKit)
+  internal import CloudKit
+  internal import Foundation
+  internal import MistDemoKit
+
+  /// Display-friendly snapshot of a CKSubscription.
+  internal struct SubscriptionRow: Identifiable, Hashable, Sendable {
+    internal let id: String
+    internal let kind: String
+    internal let recordType: String?
+
+    internal init(_ subscription: CKSubscription) {
+      self.id = subscription.subscriptionID
+      switch subscription {
+      case let query as CKQuerySubscription:
+        self.kind = "Query"
+        self.recordType = query.recordType
+      case let zone as CKRecordZoneSubscription:
+        self.kind = "Zone (\(zone.zoneID.zoneName))"
+        self.recordType = nil
+      case is CKDatabaseSubscription:
+        self.kind = "Database"
+        self.recordType = nil
+      default:
+        self.kind = "Other"
+        self.recordType = nil
+      }
+    }
+  }
+
+  extension CloudKitStore {
+    /// List every CloudKit subscription registered on the selected
+    /// database. Maps to `subscriptions/list` in the REST surface.
+    internal func loadSubscriptions() async throws -> [SubscriptionRow] {
+      let subscriptions = try await database.allSubscriptions()
+      return subscriptions.map(SubscriptionRow.init).sorted { $0.id < $1.id }
+    }
+
+    /// Look up specific subscriptions by ID. Maps to `subscriptions/lookup`.
+    internal func lookupSubscriptions(
+      ids: [String]
+    ) async throws -> [SubscriptionRow] {
+      try await withCheckedThrowingContinuation { continuation in
+        let operation = CKFetchSubscriptionsOperation(subscriptionIDs: ids)
+        var rows: [SubscriptionRow] = []
+        operation.perSubscriptionResultBlock = { _, result in
+          if case .success(let subscription) = result {
+            rows.append(SubscriptionRow(subscription))
+          }
+        }
+        operation.fetchSubscriptionsResultBlock = { result in
+          switch result {
+          case .success:
+            continuation.resume(returning: rows.sorted { $0.id < $1.id })
+          case .failure(let error):
+            continuation.resume(throwing: error)
+          }
+        }
+        database.add(operation)
+      }
+    }
+
+    /// Create a demo Note-query subscription so the subscriptions list has
+    /// something visible. Uses a fixed `subscriptionID` so repeated taps are
+    /// idempotent — CloudKit returns a conflict if it already exists, which
+    /// the UI surfaces via the standard error path.
+    internal func createDemoSubscription() async throws -> SubscriptionRow {
+      let subscription = CKQuerySubscription(
+        recordType: Note.recordType,
+        predicate: NSPredicate(value: true),
+        subscriptionID: "MistDemo.noteCreated",
+        options: [.firesOnRecordCreation]
+      )
+      let info = CKSubscription.NotificationInfo()
+      info.shouldSendContentAvailable = true
+      subscription.notificationInfo = info
+      let saved = try await database.save(subscription)
+      return SubscriptionRow(saved)
+    }
+
+    /// Delete a subscription by ID.
+    internal func deleteSubscription(id: String) async throws {
+      _ = try await database.deleteSubscription(withID: id)
+    }
+  }
+#endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/CloudKitStore+Users.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/CloudKitStore+Users.swift
@@ -1,0 +1,123 @@
+//
+//  CloudKitStore+Users.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if canImport(CloudKit)
+  internal import CloudKit
+  internal import Foundation
+  internal import MistDemoKit
+
+  /// Display-friendly snapshot of a CKUserIdentity.
+  internal struct UserIdentityRow: Identifiable, Hashable, Sendable {
+    internal let id: String
+    internal let displayName: String?
+    internal let recordName: String?
+    internal let lookupHint: String?
+
+    internal init(_ identity: CKUserIdentity, lookupHint: String? = nil) {
+      let recordName = identity.userRecordID?.recordName
+      self.id =
+        recordName
+        ?? identity.lookupInfo?.emailAddress
+        ?? identity.lookupInfo?.phoneNumber
+        ?? lookupHint
+        ?? UUID().uuidString
+      self.recordName = recordName
+      self.displayName = Self.formatName(identity.nameComponents)
+      self.lookupHint = lookupHint
+    }
+
+    private static func formatName(
+      _ components: PersonNameComponents?
+    ) -> String? {
+      guard let components else {
+        return nil
+      }
+      let formatter = PersonNameComponentsFormatter()
+      let formatted = formatter.string(from: components)
+      return formatted.isEmpty ? nil : formatted
+    }
+  }
+
+  extension CloudKitStore {
+    /// Look up a user identity by iCloud email address. Maps to
+    /// `users/lookup/email` in the REST surface; uses CloudKit's
+    /// `discoverUserIdentity(withEmailAddress:)`.
+    ///
+    /// `discoverUserIdentity(withEmailAddress:)` is deprecated as of macOS
+    /// 14 / iOS 17 but still ships on the supported platforms — the
+    /// CloudKit framework hasn't published an async replacement, so the
+    /// completion-handler form is wrapped via `withCheckedThrowingContinuation`.
+    internal func lookupUser(byEmail email: String) async throws -> UserIdentityRow? {
+      let container = CKContainer(identifier: containerIdentifier)
+      let identity: CKUserIdentity? = try await withCheckedThrowingContinuation {
+        continuation in
+        container.discoverUserIdentity(withEmailAddress: email) {
+          identity, error in
+          if let error {
+            continuation.resume(throwing: error)
+          } else {
+            continuation.resume(returning: identity)
+          }
+        }
+      }
+      return identity.map { UserIdentityRow($0, lookupHint: email) }
+    }
+
+    /// Look up a user identity by record name. Maps to `users/lookup/id`.
+    internal func lookupUser(byRecordName recordName: String) async throws -> UserIdentityRow? {
+      let container = CKContainer(identifier: containerIdentifier)
+      let recordID = CKRecord.ID(recordName: recordName)
+      let identity: CKUserIdentity? = try await withCheckedThrowingContinuation {
+        continuation in
+        container.discoverUserIdentity(withUserRecordID: recordID) {
+          identity, error in
+          if let error {
+            continuation.resume(throwing: error)
+          } else {
+            continuation.resume(returning: identity)
+          }
+        }
+      }
+      return identity.map { UserIdentityRow($0, lookupHint: recordName) }
+    }
+
+    /// Discover identities for a batch of email addresses, looping the
+    /// per-call API since the framework doesn't expose a batch entry point.
+    /// Maps to `users/discover` (POST) in the REST surface.
+    internal func discoverUsers(byEmails emails: [String]) async throws -> [UserIdentityRow] {
+      var rows: [UserIdentityRow] = []
+      for email in emails {
+        if let row = try await lookupUser(byEmail: email) {
+          rows.append(row)
+        }
+      }
+      return rows
+    }
+  }
+#endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/CloudKitStore+Zones.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/CloudKitStore+Zones.swift
@@ -1,0 +1,99 @@
+//
+//  CloudKitStore+Zones.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if canImport(CloudKit)
+  internal import CloudKit
+  internal import Foundation
+  internal import MistDemoKit
+
+  /// Snapshot returned by `CKFetchDatabaseChangesOperation` so the UI can
+  /// show what changed since the last sync token.
+  internal struct DatabaseChangesSnapshot: Sendable {
+    internal let changedZoneIDs: [CKRecordZone.ID]
+    internal let deletedZoneIDs: [CKRecordZone.ID]
+    internal let serverChangeToken: CKServerChangeToken?
+    internal let moreComing: Bool
+  }
+
+  extension CloudKitStore {
+    /// Create a new custom record zone in the selected database. Public
+    /// databases reject this — `CKModifyRecordZonesOperation` returns an
+    /// error which we surface to the UI.
+    internal func createZone(named name: String) async throws -> ZoneRow {
+      let zone = CKRecordZone(zoneName: name)
+      let saved = try await database.save(zone)
+      return ZoneRow(saved)
+    }
+
+    /// Delete a custom record zone by name in the selected database.
+    internal func deleteZone(named name: String) async throws {
+      _ = try await database.deleteRecordZone(
+        withID: CKRecordZone.ID(
+          zoneName: name, ownerName: CKCurrentUserDefaultName
+        )
+      )
+    }
+
+    /// Fetch database-scope changes since `previousToken`. Returns the
+    /// changed/deleted zone IDs plus the new sync token. Pass the returned
+    /// token on the next call to receive a delta.
+    internal func fetchDatabaseChanges(
+      since previousToken: CKServerChangeToken? = nil
+    ) async throws -> DatabaseChangesSnapshot {
+      try await withCheckedThrowingContinuation { continuation in
+        let operation = CKFetchDatabaseChangesOperation(
+          previousServerChangeToken: previousToken
+        )
+
+        var changed: [CKRecordZone.ID] = []
+        var deleted: [CKRecordZone.ID] = []
+
+        operation.recordZoneWithIDWasDeletedBlock = { deleted.append($0) }
+        operation.recordZoneWithIDChangedBlock = { changed.append($0) }
+        operation.fetchDatabaseChangesResultBlock = { result in
+          switch result {
+          case .failure(let error):
+            continuation.resume(throwing: error)
+          case .success(let payload):
+            continuation.resume(
+              returning: DatabaseChangesSnapshot(
+                changedZoneIDs: changed,
+                deletedZoneIDs: deleted,
+                serverChangeToken: payload.serverChangeToken,
+                moreComing: payload.moreComing
+              )
+            )
+          }
+        }
+
+        database.add(operation)
+      }
+    }
+  }
+#endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/CloudKitStore.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/CloudKitStore.swift
@@ -73,7 +73,7 @@
     public init(containerIdentifier: String) {
       self.containerIdentifier = containerIdentifier
       self.container = CKContainer(identifier: containerIdentifier)
-      #if canImport(AppKit) || canImport(UIKit)
+      #if (canImport(AppKit) && !targetEnvironment(macCatalyst)) || (canImport(UIKit) && !os(watchOS))
         // The platform AppDelegate is owned by SwiftUI; weak-link this store
         // as the sink for its APNs callbacks.
         PushNotificationDelegate.receiver = self

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/CloudKitStore.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/CloudKitStore.swift
@@ -73,11 +73,10 @@
     public init(containerIdentifier: String) {
       self.containerIdentifier = containerIdentifier
       self.container = CKContainer(identifier: containerIdentifier)
-      #if (canImport(AppKit) && !targetEnvironment(macCatalyst)) || (canImport(UIKit) && !os(watchOS))
-        // The platform AppDelegate is owned by SwiftUI; weak-link this store
-        // as the sink for its APNs callbacks.
-        PushNotificationDelegate.receiver = self
-      #endif
+
+      // The platform AppDelegate is owned by SwiftUI; weak-link this store
+      // as the sink for its APNs callbacks.
+      PushNotificationDelegate.receiver = self
     }
 
     /// Apply the editable fields onto a CKRecord. CloudKit's system metadata

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/CloudKitStore.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/CloudKitStore.swift
@@ -48,6 +48,15 @@
     internal var lastError: String?
     internal var databaseScope: CKDatabase.Scope = .private
 
+    /// Latest APNs registration state. Driven by
+    /// `CloudKitStore+PushTokens.swift`; the SwiftUI Push Tokens view
+    /// observes this for live status updates.
+    internal var pushTokenStatus: PushTokenStatus = .idle
+
+    /// Pretty-printed payload of the most recent remote notification
+    /// delivered while the app was running. Cleared on launch.
+    internal var lastReceivedNotification: String?
+
     /// The signed-in iCloud user's record name. Mirrors `currentUserRecordName`
     /// in the web demo and is used to flag the "You" badge on notes the
     /// current user created.
@@ -64,6 +73,11 @@
     public init(containerIdentifier: String) {
       self.containerIdentifier = containerIdentifier
       self.container = CKContainer(identifier: containerIdentifier)
+      #if canImport(AppKit) || canImport(UIKit)
+        // The platform AppDelegate is owned by SwiftUI; weak-link this store
+        // as the sink for its APNs callbacks.
+        PushNotificationDelegate.receiver = self
+      #endif
     }
 
     /// Apply the editable fields onto a CKRecord. CloudKit's system metadata

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformAliases.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformAliases.swift
@@ -1,5 +1,5 @@
 //
-//  PlatformApplication.swift
+//  PlatformAliases.swift
 //  MistDemo
 //
 //  Created by Leo Dion.
@@ -27,14 +27,15 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
+// The per-platform aliases live together (rather than one type per file)
+// because each is a thin, `#if`-selected typealias. The file is deliberately
+// not named after any one alias — in project-mode lint SwiftLint parses every
+// `#if` branch, so a filename-matching typealias ladder would be misread as a
+// `main_type` sitting amongst `supporting_type`s (`file_types_order`). Naming
+// the file neutrally keeps every alias a plain supporting type; the resulting
+// `file_name` mismatch is waived for this file in `.swiftlint.yml`.
 #if canImport(SwiftUI)
   public import SwiftUI
-
-  // The filename-matching `PlatformApplication` typealias necessarily sits
-  // beside the other per-platform typealiases (a `#if` ladder can't be
-  // reordered to satisfy file_types_order), so the rule is disabled for the
-  // typealias/protocol region and re-enabled at the end of the file.
-  // swiftlint:disable file_types_order
 
   #if canImport(AppKit) && !targetEnvironment(macCatalyst)
     public import AppKit
@@ -80,39 +81,4 @@
     /// ``ApplicationDelegate``.
     public typealias PlatformApplicationDelegateAdaptor = UIApplicationDelegateAdaptor
   #endif
-
-  /// Unifies the per-platform "register for remote notifications" entry point
-  /// so push code can call it through ``PlatformApplication`` without
-  /// branching. The accessor is named `sharedApplication` rather than `shared`
-  /// because `WKApplication.shared()` is a method, not a property — reusing the
-  /// `shared` name would collide with it.
-  @MainActor
-  internal protocol RemoteNotificationRegistering {
-    static var sharedApplication: PlatformApplication { get }
-    func registerForRemoteNotifications()
-  }
-
-  extension RemoteNotificationRegistering {
-    /// Registers the shared platform application for remote notifications —
-    /// the single cross-platform entry point push code calls.
-    internal static func registerSharedForRemoteNotifications() {
-      sharedApplication.registerForRemoteNotifications()
-    }
-  }
-
-  #if canImport(AppKit) && !targetEnvironment(macCatalyst)
-    extension NSApplication: RemoteNotificationRegistering {
-      internal static var sharedApplication: NSApplication { shared }
-    }
-  #elseif canImport(WatchKit)
-    extension WKApplication: RemoteNotificationRegistering {
-      internal static var sharedApplication: WKApplication { shared() }
-    }
-  #elseif canImport(UIKit)
-    extension UIApplication: RemoteNotificationRegistering {
-      internal static var sharedApplication: UIApplication { shared }
-    }
-  #endif
 #endif
-
-// swiftlint:enable file_types_order

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplication.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplication.swift
@@ -1,0 +1,62 @@
+//
+//  PlatformApplication.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+// Per-platform typealiases for the same logical names mean the
+// file has parallel "main_type" declarations under different `#if`
+// branches, which the rule mis-flags.
+// swiftlint:disable file_types_order
+
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
+  public import AppKit
+
+  /// The platform application type (`NSApplication` on AppKit,
+  /// `UIApplication` on UIKit). Used so the demo's push-notification
+  /// delegate can implement the
+  /// `application(_:didRegisterForRemoteNotificationsWithDeviceToken:)`-style
+  /// hooks once instead of twice. Public so the executable target's `@main`
+  /// can reach `PushNotificationDelegate` (which conforms via the matching
+  /// `PlatformApplicationDelegate` alias).
+  public typealias PlatformApplication = NSApplication
+
+  /// The platform application delegate protocol matching
+  /// ``PlatformApplication``.
+  public typealias PlatformApplicationDelegate = NSApplicationDelegate
+#elseif canImport(UIKit)
+  public import UIKit
+
+  /// The platform application type (`NSApplication` on AppKit,
+  /// `UIApplication` on UIKit). See the AppKit branch for full notes.
+  public typealias PlatformApplication = UIApplication
+
+  /// The platform application delegate protocol matching
+  /// ``PlatformApplication``.
+  public typealias PlatformApplicationDelegate = UIApplicationDelegate
+#endif
+
+// swiftlint:enable file_types_order

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplication.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplication.swift
@@ -30,6 +30,12 @@
 #if canImport(SwiftUI)
   public import SwiftUI
 
+  // The filename-matching `PlatformApplication` typealias necessarily sits
+  // beside the other per-platform typealiases (a `#if` ladder can't be
+  // reordered to satisfy file_types_order), so the rule is disabled for the
+  // typealias/protocol region and re-enabled at the end of the file.
+  // swiftlint:disable file_types_order
+
   #if canImport(AppKit) && !targetEnvironment(macCatalyst)
     public import AppKit
 

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplication.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplication.swift
@@ -27,36 +27,40 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-// Per-platform typealiases for the same logical names mean the
-// file has parallel "main_type" declarations under different `#if`
-// branches, which the rule mis-flags.
-// swiftlint:disable file_types_order
-
-// Remote-notification registration is available on AppKit (non-Catalyst),
-// iOS, tvOS, Catalyst, and visionOS — but NOT watchOS, where `UIApplication`
-// and its delegate are unavailable even though UIKit imports. This combined
-// condition is the single source of truth for "the platform has APNs
-// registration"; every push call site guards on the same shape.
-#if (canImport(AppKit) && !targetEnvironment(macCatalyst)) || (canImport(UIKit) && !os(watchOS))
+#if canImport(SwiftUI)
   public import SwiftUI
 
   #if canImport(AppKit) && !targetEnvironment(macCatalyst)
     public import AppKit
 
     /// The platform application type (`NSApplication` on AppKit,
-    /// `UIApplication` on UIKit). Lets the push-notification delegate and
-    /// registration call sites name one type instead of branching.
+    /// `UIApplication` on UIKit, `WKApplication` on watchOS). Lets the
+    /// push-notification delegate and registration call sites name one type
+    /// instead of branching.
     public typealias PlatformApplication = NSApplication
 
     /// The platform application delegate protocol matching
     /// ``PlatformApplication``.
-    public typealias PlatformApplicationDelegate = NSApplicationDelegate
+    public typealias ApplicationDelegate = NSApplicationDelegate
 
     /// SwiftUI's delegate-adaptor property wrapper matching
-    /// ``PlatformApplicationDelegate``. Lets `@main` declare the adaptor once
+    /// ``ApplicationDelegate``. Lets `@main` declare the adaptor once
     /// rather than under parallel `#if` branches.
     public typealias PlatformApplicationDelegateAdaptor = NSApplicationDelegateAdaptor
-  #elseif canImport(UIKit) && !os(watchOS)
+  #elseif canImport(WatchKit)
+    public import WatchKit
+
+    /// The platform application type. See the AppKit branch for full notes.
+    public typealias PlatformApplication = WKApplication
+
+    /// The platform application delegate protocol matching
+    /// ``PlatformApplication``.
+    public typealias ApplicationDelegate = WKApplicationDelegate
+
+    /// SwiftUI's delegate-adaptor property wrapper matching
+    /// ``ApplicationDelegate``.
+    public typealias PlatformApplicationDelegateAdaptor = WKApplicationDelegateAdaptor
+  #elseif canImport(UIKit)
     public import UIKit
 
     /// The platform application type. See the AppKit branch for full notes.
@@ -64,20 +68,21 @@
 
     /// The platform application delegate protocol matching
     /// ``PlatformApplication``.
-    public typealias PlatformApplicationDelegate = UIApplicationDelegate
+    public typealias ApplicationDelegate = UIApplicationDelegate
 
     /// SwiftUI's delegate-adaptor property wrapper matching
-    /// ``PlatformApplicationDelegate``.
+    /// ``ApplicationDelegate``.
     public typealias PlatformApplicationDelegateAdaptor = UIApplicationDelegateAdaptor
   #endif
 
   /// Unifies the per-platform "register for remote notifications" entry point
   /// so push code can call it through ``PlatformApplication`` without
-  /// branching. Both `NSApplication` and `UIApplication` already expose this
-  /// surface; the protocol just names the shared shape.
+  /// branching. The accessor is named `sharedApplication` rather than `shared`
+  /// because `WKApplication.shared()` is a method, not a property — reusing the
+  /// `shared` name would collide with it.
   @MainActor
   internal protocol RemoteNotificationRegistering {
-    static var shared: PlatformApplication { get }
+    static var sharedApplication: PlatformApplication { get }
     func registerForRemoteNotifications()
   }
 
@@ -85,11 +90,23 @@
     /// Registers the shared platform application for remote notifications —
     /// the single cross-platform entry point push code calls.
     internal static func registerSharedForRemoteNotifications() {
-      shared.registerForRemoteNotifications()
+      sharedApplication.registerForRemoteNotifications()
     }
   }
 
-  extension PlatformApplication: RemoteNotificationRegistering {}
+  #if canImport(AppKit) && !targetEnvironment(macCatalyst)
+    extension NSApplication: RemoteNotificationRegistering {
+      internal static var sharedApplication: NSApplication { shared }
+    }
+  #elseif canImport(WatchKit)
+    extension WKApplication: RemoteNotificationRegistering {
+      internal static var sharedApplication: WKApplication { shared() }
+    }
+  #elseif canImport(UIKit)
+    extension UIApplication: RemoteNotificationRegistering {
+      internal static var sharedApplication: UIApplication { shared }
+    }
+  #endif
 #endif
 
 // swiftlint:enable file_types_order

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplication.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplication.swift
@@ -32,31 +32,64 @@
 // branches, which the rule mis-flags.
 // swiftlint:disable file_types_order
 
-#if canImport(AppKit) && !targetEnvironment(macCatalyst)
-  public import AppKit
+// Remote-notification registration is available on AppKit (non-Catalyst),
+// iOS, tvOS, Catalyst, and visionOS — but NOT watchOS, where `UIApplication`
+// and its delegate are unavailable even though UIKit imports. This combined
+// condition is the single source of truth for "the platform has APNs
+// registration"; every push call site guards on the same shape.
+#if (canImport(AppKit) && !targetEnvironment(macCatalyst)) || (canImport(UIKit) && !os(watchOS))
+  public import SwiftUI
 
-  /// The platform application type (`NSApplication` on AppKit,
-  /// `UIApplication` on UIKit). Used so the demo's push-notification
-  /// delegate can implement the
-  /// `application(_:didRegisterForRemoteNotificationsWithDeviceToken:)`-style
-  /// hooks once instead of twice. Public so the executable target's `@main`
-  /// can reach `PushNotificationDelegate` (which conforms via the matching
-  /// `PlatformApplicationDelegate` alias).
-  public typealias PlatformApplication = NSApplication
+  #if canImport(AppKit) && !targetEnvironment(macCatalyst)
+    public import AppKit
 
-  /// The platform application delegate protocol matching
-  /// ``PlatformApplication``.
-  public typealias PlatformApplicationDelegate = NSApplicationDelegate
-#elseif canImport(UIKit)
-  public import UIKit
+    /// The platform application type (`NSApplication` on AppKit,
+    /// `UIApplication` on UIKit). Lets the push-notification delegate and
+    /// registration call sites name one type instead of branching.
+    public typealias PlatformApplication = NSApplication
 
-  /// The platform application type (`NSApplication` on AppKit,
-  /// `UIApplication` on UIKit). See the AppKit branch for full notes.
-  public typealias PlatformApplication = UIApplication
+    /// The platform application delegate protocol matching
+    /// ``PlatformApplication``.
+    public typealias PlatformApplicationDelegate = NSApplicationDelegate
 
-  /// The platform application delegate protocol matching
-  /// ``PlatformApplication``.
-  public typealias PlatformApplicationDelegate = UIApplicationDelegate
+    /// SwiftUI's delegate-adaptor property wrapper matching
+    /// ``PlatformApplicationDelegate``. Lets `@main` declare the adaptor once
+    /// rather than under parallel `#if` branches.
+    public typealias PlatformApplicationDelegateAdaptor = NSApplicationDelegateAdaptor
+  #elseif canImport(UIKit) && !os(watchOS)
+    public import UIKit
+
+    /// The platform application type. See the AppKit branch for full notes.
+    public typealias PlatformApplication = UIApplication
+
+    /// The platform application delegate protocol matching
+    /// ``PlatformApplication``.
+    public typealias PlatformApplicationDelegate = UIApplicationDelegate
+
+    /// SwiftUI's delegate-adaptor property wrapper matching
+    /// ``PlatformApplicationDelegate``.
+    public typealias PlatformApplicationDelegateAdaptor = UIApplicationDelegateAdaptor
+  #endif
+
+  /// Unifies the per-platform "register for remote notifications" entry point
+  /// so push code can call it through ``PlatformApplication`` without
+  /// branching. Both `NSApplication` and `UIApplication` already expose this
+  /// surface; the protocol just names the shared shape.
+  @MainActor
+  internal protocol RemoteNotificationRegistering {
+    static var shared: PlatformApplication { get }
+    func registerForRemoteNotifications()
+  }
+
+  extension RemoteNotificationRegistering {
+    /// Registers the shared platform application for remote notifications —
+    /// the single cross-platform entry point push code calls.
+    internal static func registerSharedForRemoteNotifications() {
+      shared.registerForRemoteNotifications()
+    }
+  }
+
+  extension PlatformApplication: RemoteNotificationRegistering {}
 #endif
 
 // swiftlint:enable file_types_order

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplicationDelegate+NSApplicationDelegate.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplicationDelegate+NSApplicationDelegate.swift
@@ -1,6 +1,6 @@
 //
-//  MistDemoApp.swift
-//  MistDemoApp
+//  PlatformApplicationDelegate+NSApplicationDelegate.swift
+//  MistDemo
 //
 //  Created by Leo Dion.
 //  Copyright © 2026 BrightDigit.
@@ -27,14 +27,17 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-internal import MistDemoApp
-internal import SwiftUI
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
+  public import AppKit
+  internal import Foundation
 
-@main
-internal struct MistDemoAppMain: AppMain {
-  // SwiftUI owns the AppDelegate's lifecycle via this adaptor; the
-  // delegate's static-weak `receiver` is wired from `CloudKitStore.init`
-  // so the OS-delivered APNs token lands back in the observable store.
-    @PlatformApplicationDelegateAdaptor(PushNotificationDelegate.self)
-    private var pushDelegate
-}
+  extension PlatformApplicationDelegate where Self: NSApplicationDelegate {
+    /// A remote notification arrived (AppKit variant).
+    public func application(
+      _ application: NSApplication,
+      didReceiveRemoteNotification userInfo: [String: Any]
+    ) {
+      Self.receiver?.didReceiveRemoteNotification(userInfo: userInfo)
+    }
+  }
+#endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplicationDelegate+RemoteNotifications.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplicationDelegate+RemoteNotifications.swift
@@ -1,0 +1,59 @@
+//
+//  PlatformApplicationDelegate+RemoteNotifications.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+// The `application(_:didRegister…)` / `didFail…` selectors are identical on
+// AppKit and UIKit (both take the unified ``PlatformApplication``), so they
+// share one extension here. watchOS's `WKApplicationDelegate` uses
+// parameter-less selectors, so its variants live in
+// `PlatformApplicationDelegate+WKApplicationDelegate.swift` instead.
+#if (canImport(AppKit) && !targetEnvironment(macCatalyst)) || (canImport(UIKit) && !os(watchOS))
+  public import Foundation
+
+  extension PlatformApplicationDelegate {
+    /// APNs delivered a device token — forward it to the registered receiver.
+    ///
+    /// `public` because, when adopted by a `public` class, this satisfies the
+    /// matching requirement in the `public` system delegate protocol.
+    public func application(
+      _ application: PlatformApplication,
+      didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+      Self.receiver?.didRegisterForRemoteNotifications(deviceToken: deviceToken)
+    }
+
+    /// APNs refused registration — forward the error to the receiver so it
+    /// can surface in the UI.
+    public func application(
+      _ application: PlatformApplication,
+      didFailToRegisterForRemoteNotificationsWithError error: any Error
+    ) {
+      Self.receiver?.didFailToRegisterForRemoteNotifications(error: error)
+    }
+  }
+#endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplicationDelegate+UIApplicationDelegate.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplicationDelegate+UIApplicationDelegate.swift
@@ -1,6 +1,6 @@
 //
-//  MistDemoApp.swift
-//  MistDemoApp
+//  PlatformApplicationDelegate+UIApplicationDelegate.swift
+//  MistDemo
 //
 //  Created by Leo Dion.
 //  Copyright © 2026 BrightDigit.
@@ -27,14 +27,19 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-internal import MistDemoApp
-internal import SwiftUI
+#if canImport(UIKit) && !os(watchOS)
+  internal import Foundation
+  public import UIKit
 
-@main
-internal struct MistDemoAppMain: AppMain {
-  // SwiftUI owns the AppDelegate's lifecycle via this adaptor; the
-  // delegate's static-weak `receiver` is wired from `CloudKitStore.init`
-  // so the OS-delivered APNs token lands back in the observable store.
-    @PlatformApplicationDelegateAdaptor(PushNotificationDelegate.self)
-    private var pushDelegate
-}
+  extension PlatformApplicationDelegate where Self: UIApplicationDelegate {
+    /// A remote notification arrived (UIKit variant).
+    public func application(
+      _ application: UIApplication,
+      didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+      fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+    ) {
+      Self.receiver?.didReceiveRemoteNotification(userInfo: userInfo)
+      completionHandler(.newData)
+    }
+  }
+#endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplicationDelegate+WKApplicationDelegate.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplicationDelegate+WKApplicationDelegate.swift
@@ -1,5 +1,5 @@
 //
-//  PushNotificationDelegate+ReceiveNotification.swift
+//  PlatformApplicationDelegate+WKApplicationDelegate.swift
 //  MistDemo
 //
 //  Created by Leo Dion.
@@ -27,35 +27,25 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-// The inbound `didReceiveRemoteNotification` delegate selector genuinely
-// differs between platforms — UIKit hands back a fetch-completion handler,
-// AppKit does not — so each variant lives in its own platform extension
-// rather than as inline `#if` branches inside the delegate class. Both funnel
-// through the same `PushTokenReceiver` method.
+#if canImport(WatchKit)
+  internal import Foundation
+  public import WatchKit
 
-#if canImport(AppKit) && !targetEnvironment(macCatalyst)
-  public import AppKit
-  public import Foundation
-
-  extension PushNotificationDelegate {
-    /// A remote notification arrived (AppKit variant).
-    public func application(
-      _ application: NSApplication,
-      didReceiveRemoteNotification userInfo: [String: Any]
-    ) {
-      Self.receiver?.didReceiveRemoteNotification(userInfo: userInfo)
+  extension PlatformApplicationDelegate where Self: WKApplicationDelegate {
+    /// APNs delivered a device token — forward it to the registered receiver.
+    public func didRegisterForRemoteNotifications(withDeviceToken deviceToken: Data) {
+      Self.receiver?.didRegisterForRemoteNotifications(deviceToken: deviceToken)
     }
-  }
-#elseif canImport(UIKit) && !os(watchOS)
-  public import Foundation
-  public import UIKit
 
-  extension PushNotificationDelegate {
-    /// A remote notification arrived (UIKit variant).
-    public func application(
-      _ application: UIApplication,
-      didReceiveRemoteNotification userInfo: [AnyHashable: Any],
-      fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+    /// APNs refused registration — forward the error to the receiver.
+    public func didFailToRegisterForRemoteNotificationsWithError(_ error: any Error) {
+      Self.receiver?.didFailToRegisterForRemoteNotifications(error: error)
+    }
+
+    /// A remote notification arrived (watchOS variant).
+    public func didReceiveRemoteNotification(
+      _ userInfo: [AnyHashable: Any],
+      fetchCompletionHandler completionHandler: @escaping (WKBackgroundFetchResult) -> Void
     ) {
       Self.receiver?.didReceiveRemoteNotification(userInfo: userInfo)
       completionHandler(.newData)

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplicationDelegate.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplicationDelegate.swift
@@ -27,19 +27,24 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-public import Foundation
+// `@objc` requires the Objective-C runtime, which is absent on
+// Linux/Windows. This delegate protocol exists only to bridge APNs callbacks
+// on Apple platforms, so gate it on Objective-C interop availability.
+#if canImport(ObjectiveC)
+  public import Foundation
 
-/// App-level delegate behavior that funnels APNs callbacks to a
-/// ``PushTokenReceiver``. Deliberately independent of the system delegate
-/// protocol (``ApplicationDelegate``) and of the concrete
-/// ``PushNotificationDelegate`` class — it only knows about the receiver. The
-/// shared callbacks are supplied by the extensions below (and the per-platform
-/// extension files), keyed off the static `receiver`.
-@MainActor
-@objc
-public protocol PlatformApplicationDelegate: AnyObject {
-  static var receiver: (any PushTokenReceiver)? { get }
-}
+  /// App-level delegate behavior that funnels APNs callbacks to a
+  /// ``PushTokenReceiver``. Deliberately independent of the system delegate
+  /// protocol (``ApplicationDelegate``) and of the concrete
+  /// ``PushNotificationDelegate`` class — it only knows about the receiver. The
+  /// shared callbacks are supplied by the extensions below (and the
+  /// per-platform extension files), keyed off the static `receiver`.
+  @MainActor
+  @objc
+  public protocol PlatformApplicationDelegate: AnyObject {
+    static var receiver: (any PushTokenReceiver)? { get }
+  }
+#endif
 
 // The `application(_:didRegister…)` / `didFail…` selectors are identical on
 // AppKit and UIKit (both take the unified ``PlatformApplication``), so they

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplicationDelegate.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplicationDelegate.swift
@@ -1,0 +1,71 @@
+//
+//  PlatformApplicationDelegate.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+public import Foundation
+
+/// App-level delegate behavior that funnels APNs callbacks to a
+/// ``PushTokenReceiver``. Deliberately independent of the system delegate
+/// protocol (``ApplicationDelegate``) and of the concrete
+/// ``PushNotificationDelegate`` class — it only knows about the receiver. The
+/// shared callbacks are supplied by the extensions below (and the per-platform
+/// extension files), keyed off the static `receiver`.
+@MainActor
+@objc
+public protocol PlatformApplicationDelegate: AnyObject {
+  static var receiver: (any PushTokenReceiver)? { get }
+}
+
+// The `application(_:didRegister…)` / `didFail…` selectors are identical on
+// AppKit and UIKit (both take the unified ``PlatformApplication``), so they
+// share one extension here. watchOS's `WKApplicationDelegate` uses
+// parameter-less selectors, so its variants live in
+// `PlatformApplicationDelegate+WKApplicationDelegate.swift` instead.
+#if (canImport(AppKit) && !targetEnvironment(macCatalyst)) || (canImport(UIKit) && !os(watchOS))
+  extension PlatformApplicationDelegate {
+    /// APNs delivered a device token — forward it to the registered receiver.
+    ///
+    /// `public` because, when adopted by a `public` class, this satisfies the
+    /// matching requirement in the `public` system delegate protocol.
+    public func application(
+      _ application: PlatformApplication,
+      didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+      Self.receiver?.didRegisterForRemoteNotifications(deviceToken: deviceToken)
+    }
+
+    /// APNs refused registration — forward the error to the receiver so it
+    /// can surface in the UI.
+    public func application(
+      _ application: PlatformApplication,
+      didFailToRegisterForRemoteNotificationsWithError error: any Error
+    ) {
+      Self.receiver?.didFailToRegisterForRemoteNotifications(error: error)
+    }
+  }
+#endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplicationDelegate.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplicationDelegate.swift
@@ -31,7 +31,8 @@
 // Linux/Windows. This delegate protocol exists only to bridge APNs callbacks
 // on Apple platforms, so gate it on Objective-C interop availability.
 #if canImport(ObjectiveC)
-  public import Foundation
+  // `@objc` requires the Objective-C runtime, surfaced here via Foundation.
+  internal import Foundation
 
   /// App-level delegate behavior that funnels APNs callbacks to a
   /// ``PushTokenReceiver``. Deliberately independent of the system delegate
@@ -43,34 +44,5 @@
   @objc
   public protocol PlatformApplicationDelegate: AnyObject {
     static var receiver: (any PushTokenReceiver)? { get }
-  }
-#endif
-
-// The `application(_:didRegister…)` / `didFail…` selectors are identical on
-// AppKit and UIKit (both take the unified ``PlatformApplication``), so they
-// share one extension here. watchOS's `WKApplicationDelegate` uses
-// parameter-less selectors, so its variants live in
-// `PlatformApplicationDelegate+WKApplicationDelegate.swift` instead.
-#if (canImport(AppKit) && !targetEnvironment(macCatalyst)) || (canImport(UIKit) && !os(watchOS))
-  extension PlatformApplicationDelegate {
-    /// APNs delivered a device token — forward it to the registered receiver.
-    ///
-    /// `public` because, when adopted by a `public` class, this satisfies the
-    /// matching requirement in the `public` system delegate protocol.
-    public func application(
-      _ application: PlatformApplication,
-      didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
-    ) {
-      Self.receiver?.didRegisterForRemoteNotifications(deviceToken: deviceToken)
-    }
-
-    /// APNs refused registration — forward the error to the receiver so it
-    /// can surface in the UI.
-    public func application(
-      _ application: PlatformApplication,
-      didFailToRegisterForRemoteNotificationsWithError error: any Error
-    ) {
-      Self.receiver?.didFailToRegisterForRemoteNotifications(error: error)
-    }
   }
 #endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PushNotificationDelegate+ReceiveNotification.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PushNotificationDelegate+ReceiveNotification.swift
@@ -1,0 +1,64 @@
+//
+//  PushNotificationDelegate+ReceiveNotification.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+// The inbound `didReceiveRemoteNotification` delegate selector genuinely
+// differs between platforms — UIKit hands back a fetch-completion handler,
+// AppKit does not — so each variant lives in its own platform extension
+// rather than as inline `#if` branches inside the delegate class. Both funnel
+// through the same `PushTokenReceiver` method.
+
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
+  public import AppKit
+  public import Foundation
+
+  extension PushNotificationDelegate {
+    /// A remote notification arrived (AppKit variant).
+    public func application(
+      _ application: NSApplication,
+      didReceiveRemoteNotification userInfo: [String: Any]
+    ) {
+      Self.receiver?.didReceiveRemoteNotification(userInfo: userInfo)
+    }
+  }
+#elseif canImport(UIKit) && !os(watchOS)
+  public import Foundation
+  public import UIKit
+
+  extension PushNotificationDelegate {
+    /// A remote notification arrived (UIKit variant).
+    public func application(
+      _ application: UIApplication,
+      didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+      fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+    ) {
+      Self.receiver?.didReceiveRemoteNotification(userInfo: userInfo)
+      completionHandler(.newData)
+    }
+  }
+#endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PushNotificationDelegate.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PushNotificationDelegate.swift
@@ -27,51 +27,38 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if (canImport(AppKit) && !targetEnvironment(macCatalyst)) || (canImport(UIKit) && !os(watchOS))
-  public import Foundation
+public import Foundation
 
-  #if canImport(AppKit) && !targetEnvironment(macCatalyst)
-    public import AppKit
-  #elseif canImport(UIKit) && !os(watchOS)
-    public import UIKit
-  #endif
-
-  /// Universal AppKit/UIKit delegate that catches APNs callbacks SwiftUI
-  /// can't observe directly. SwiftUI's `@NSApplicationDelegateAdaptor` /
-  /// `@UIApplicationDelegateAdaptor` instantiates this with the parameterless
-  /// `NSObject` init, so the receiver is wired via a `static weak` set by
-  /// `CloudKitStore.init` rather than passed in.
-  @MainActor
-  public final class PushNotificationDelegate: NSObject, PlatformApplicationDelegate {
-    internal static weak var receiver: (any PushTokenReceiver)?
-
-    /// Required by SwiftUI's delegate adaptor, which constructs the
-    /// delegate with no arguments at app launch.
-    override public init() {
-      super.init()
-    }
-
-    /// APNs delivered a device token — forward it to the registered receiver.
-    public func application(
-      _ application: PlatformApplication,
-      didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
-    ) {
-      Self.receiver?.didRegisterForRemoteNotifications(deviceToken: deviceToken)
-    }
-
-    /// APNs refused registration — forward the error to the receiver so it
-    /// can surface in the UI.
-    public func application(
-      _ application: PlatformApplication,
-      didFailToRegisterForRemoteNotificationsWithError error: any Error
-    ) {
-      Self.receiver?.didFailToRegisterForRemoteNotifications(error: error)
-    }
-
-    // The inbound `didReceiveRemoteNotification` signatures genuinely differ
-    // between platforms (UIKit takes a fetch-completion handler, AppKit does
-    // not), so each lives in its own platform extension in
-    // `PushNotificationDelegate+ReceiveNotification.swift` rather than as
-    // inline `#if` branches here.
-  }
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
+  public import AppKit
+#elseif canImport(WatchKit)
+  public import WatchKit
+#elseif canImport(UIKit) && !os(watchOS)
+  public import UIKit
 #endif
+
+/// Universal AppKit/UIKit/watchOS delegate that catches APNs callbacks
+/// SwiftUI can't observe directly. SwiftUI's `@NSApplicationDelegateAdaptor`
+/// / `@UIApplicationDelegateAdaptor` / `@WKApplicationDelegateAdaptor`
+/// instantiates this with the parameterless `NSObject` init, so the receiver
+/// is wired via a `static weak` set by `CloudKitStore.init` rather than
+/// passed in.
+///
+/// The APNs callbacks themselves are supplied by ``PlatformApplicationDelegate``
+/// and its per-platform extensions; conforming to both that protocol and the
+/// system ``ApplicationDelegate`` (required by the SwiftUI adaptor) is all
+/// this class needs to declare.
+@MainActor
+public final class PushNotificationDelegate:
+  NSObject, ApplicationDelegate, PlatformApplicationDelegate
+{
+  /// The object the platform delegate forwards APNs callbacks to. Set by
+  /// `CloudKitStore.init`; held weakly so the store's lifetime governs it.
+  public static weak var receiver: (any PushTokenReceiver)?
+
+  /// Required by SwiftUI's delegate adaptor, which constructs the
+  /// delegate with no arguments at app launch.
+  override public init() {
+    super.init()
+  }
+}

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PushNotificationDelegate.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PushNotificationDelegate.swift
@@ -1,0 +1,94 @@
+//
+//  PushNotificationDelegate.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if canImport(AppKit) || canImport(UIKit)
+  public import Foundation
+
+  #if canImport(AppKit) && !targetEnvironment(macCatalyst)
+    public import AppKit
+  #elseif canImport(UIKit)
+    public import UIKit
+  #endif
+
+  /// Universal AppKit/UIKit delegate that catches APNs callbacks SwiftUI
+  /// can't observe directly. SwiftUI's `@NSApplicationDelegateAdaptor` /
+  /// `@UIApplicationDelegateAdaptor` instantiates this with the parameterless
+  /// `NSObject` init, so the receiver is wired via a `static weak` set by
+  /// `CloudKitStore.init` rather than passed in.
+  @MainActor
+  public final class PushNotificationDelegate: NSObject, PlatformApplicationDelegate {
+    internal static weak var receiver: (any PushTokenReceiver)?
+
+    /// Required by SwiftUI's delegate adaptor, which constructs the
+    /// delegate with no arguments at app launch.
+    override public init() {
+      super.init()
+    }
+
+    /// APNs delivered a device token — forward it to the registered receiver.
+    public func application(
+      _ application: PlatformApplication,
+      didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+      Self.receiver?.didRegisterForRemoteNotifications(deviceToken: deviceToken)
+    }
+
+    /// APNs refused registration — forward the error to the receiver so it
+    /// can surface in the UI.
+    public func application(
+      _ application: PlatformApplication,
+      didFailToRegisterForRemoteNotificationsWithError error: any Error
+    ) {
+      Self.receiver?.didFailToRegisterForRemoteNotifications(error: error)
+    }
+
+    // Inbound notification signatures genuinely differ between platforms —
+    // UIKit takes a fetch-completion handler, AppKit does not. Both branches
+    // funnel through the same receiver method.
+    #if canImport(UIKit) && !canImport(AppKit)
+      /// A remote notification arrived (UIKit variant).
+      public func application(
+        _ application: UIApplication,
+        didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+        fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+      ) {
+        Self.receiver?.didReceiveRemoteNotification(userInfo: userInfo)
+        completionHandler(.newData)
+      }
+    #elseif canImport(AppKit) && !targetEnvironment(macCatalyst)
+      /// A remote notification arrived (AppKit variant).
+      public func application(
+        _ application: NSApplication,
+        didReceiveRemoteNotification userInfo: [String: Any]
+      ) {
+        Self.receiver?.didReceiveRemoteNotification(userInfo: userInfo)
+      }
+    #endif
+  }
+#endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PushNotificationDelegate.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PushNotificationDelegate.swift
@@ -27,38 +27,43 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-public import Foundation
+// Conforms to the SwiftUI-defined ``ApplicationDelegate`` typealias and uses
+// `NSObject`/`@objc` machinery, so gate on SwiftUI (which implies an Apple
+// platform with Objective-C interop) to keep Linux/Windows builds clean.
+#if canImport(SwiftUI)
+  public import Foundation
 
-#if canImport(AppKit) && !targetEnvironment(macCatalyst)
-  public import AppKit
-#elseif canImport(WatchKit)
-  public import WatchKit
-#elseif canImport(UIKit) && !os(watchOS)
-  public import UIKit
-#endif
+  #if canImport(AppKit) && !targetEnvironment(macCatalyst)
+    public import AppKit
+  #elseif canImport(WatchKit)
+    public import WatchKit
+  #elseif canImport(UIKit) && !os(watchOS)
+    public import UIKit
+  #endif
 
-/// Universal AppKit/UIKit/watchOS delegate that catches APNs callbacks
-/// SwiftUI can't observe directly. SwiftUI's `@NSApplicationDelegateAdaptor`
-/// / `@UIApplicationDelegateAdaptor` / `@WKApplicationDelegateAdaptor`
-/// instantiates this with the parameterless `NSObject` init, so the receiver
-/// is wired via a `static weak` set by `CloudKitStore.init` rather than
-/// passed in.
-///
-/// The APNs callbacks themselves are supplied by ``PlatformApplicationDelegate``
-/// and its per-platform extensions; conforming to both that protocol and the
-/// system ``ApplicationDelegate`` (required by the SwiftUI adaptor) is all
-/// this class needs to declare.
-@MainActor
-public final class PushNotificationDelegate:
-  NSObject, ApplicationDelegate, PlatformApplicationDelegate
-{
-  /// The object the platform delegate forwards APNs callbacks to. Set by
-  /// `CloudKitStore.init`; held weakly so the store's lifetime governs it.
-  public static weak var receiver: (any PushTokenReceiver)?
+  /// Universal AppKit/UIKit/watchOS delegate that catches APNs callbacks
+  /// SwiftUI can't observe directly. SwiftUI's `@NSApplicationDelegateAdaptor`
+  /// / `@UIApplicationDelegateAdaptor` / `@WKApplicationDelegateAdaptor`
+  /// instantiates this with the parameterless `NSObject` init, so the receiver
+  /// is wired via a `static weak` set by `CloudKitStore.init` rather than
+  /// passed in.
+  ///
+  /// The APNs callbacks themselves are supplied by
+  /// ``PlatformApplicationDelegate`` and its per-platform extensions;
+  /// conforming to both that protocol and the system ``ApplicationDelegate``
+  /// (required by the SwiftUI adaptor) is all this class needs to declare.
+  @MainActor
+  public final class PushNotificationDelegate:
+    NSObject, ApplicationDelegate, PlatformApplicationDelegate
+  {
+    /// The object the platform delegate forwards APNs callbacks to. Set by
+    /// `CloudKitStore.init`; held weakly so the store's lifetime governs it.
+    public static weak var receiver: (any PushTokenReceiver)?
 
-  /// Required by SwiftUI's delegate adaptor, which constructs the
-  /// delegate with no arguments at app launch.
-  override public init() {
-    super.init()
+    /// Required by SwiftUI's delegate adaptor, which constructs the
+    /// delegate with no arguments at app launch.
+    override public init() {
+      super.init()
+    }
   }
-}
+#endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PushNotificationDelegate.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PushNotificationDelegate.swift
@@ -27,12 +27,12 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if canImport(AppKit) || canImport(UIKit)
+#if (canImport(AppKit) && !targetEnvironment(macCatalyst)) || (canImport(UIKit) && !os(watchOS))
   public import Foundation
 
   #if canImport(AppKit) && !targetEnvironment(macCatalyst)
     public import AppKit
-  #elseif canImport(UIKit)
+  #elseif canImport(UIKit) && !os(watchOS)
     public import UIKit
   #endif
 
@@ -68,27 +68,10 @@
       Self.receiver?.didFailToRegisterForRemoteNotifications(error: error)
     }
 
-    // Inbound notification signatures genuinely differ between platforms —
-    // UIKit takes a fetch-completion handler, AppKit does not. Both branches
-    // funnel through the same receiver method.
-    #if canImport(UIKit) && !canImport(AppKit)
-      /// A remote notification arrived (UIKit variant).
-      public func application(
-        _ application: UIApplication,
-        didReceiveRemoteNotification userInfo: [AnyHashable: Any],
-        fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
-      ) {
-        Self.receiver?.didReceiveRemoteNotification(userInfo: userInfo)
-        completionHandler(.newData)
-      }
-    #elseif canImport(AppKit) && !targetEnvironment(macCatalyst)
-      /// A remote notification arrived (AppKit variant).
-      public func application(
-        _ application: NSApplication,
-        didReceiveRemoteNotification userInfo: [String: Any]
-      ) {
-        Self.receiver?.didReceiveRemoteNotification(userInfo: userInfo)
-      }
-    #endif
+    // The inbound `didReceiveRemoteNotification` signatures genuinely differ
+    // between platforms (UIKit takes a fetch-completion handler, AppKit does
+    // not), so each lives in its own platform extension in
+    // `PushNotificationDelegate+ReceiveNotification.swift` rather than as
+    // inline `#if` branches here.
   }
 #endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PushTokenReceiver.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PushTokenReceiver.swift
@@ -1,5 +1,5 @@
 //
-//  DetailColumnRoot.swift
+//  PushTokenReceiver.swift
 //  MistDemo
 //
 //  Created by Leo Dion.
@@ -27,38 +27,15 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if canImport(SwiftUI)
-  internal import SwiftUI
+internal import Foundation
 
-  /// Routes the sidebar selection to the appropriate detail view.
-  internal struct DetailColumnRoot: View {
-    internal let selection: SidebarItem?
-
-    internal var body: some View {
-      switch selection {
-      case .account:
-        AccountView()
-      case .zones:
-        ZoneListView()
-      case .query:
-        QueryView()
-      case .records:
-        RecordsView()
-      case .subscriptions:
-        SubscriptionsView()
-      case .pushTokens:
-        PushTokensView()
-      case .assets:
-        AssetsView()
-      case .users:
-        UsersView()
-      case nil:
-        ContentUnavailableView(
-          "Pick a section from the sidebar",
-          systemImage: "sidebar.left",
-          description: Text("Account, Zones, Records, Subscriptions, …")
-        )
-      }
-    }
-  }
-#endif
+/// Receiver side of the platform push-notification bridge. The
+/// `PushNotificationDelegate` (AppKit / UIKit) forwards OS callbacks
+/// to whatever object is currently registered as
+/// `PushNotificationDelegate.receiver`.
+@MainActor
+internal protocol PushTokenReceiver: AnyObject {
+  func didRegisterForRemoteNotifications(deviceToken: Data)
+  func didFailToRegisterForRemoteNotifications(error: any Error)
+  func didReceiveRemoteNotification(userInfo: [AnyHashable: Any])
+}

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PushTokenReceiver.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PushTokenReceiver.swift
@@ -27,14 +27,15 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-internal import Foundation
+public import Foundation
 
 /// Receiver side of the platform push-notification bridge. The
 /// `PushNotificationDelegate` (AppKit / UIKit) forwards OS callbacks
 /// to whatever object is currently registered as
 /// `PushNotificationDelegate.receiver`.
 @MainActor
-internal protocol PushTokenReceiver: AnyObject {
+@objc
+public protocol PushTokenReceiver: AnyObject {
   func didRegisterForRemoteNotifications(deviceToken: Data)
   func didFailToRegisterForRemoteNotifications(error: any Error)
   func didReceiveRemoteNotification(userInfo: [AnyHashable: Any])

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PushTokenReceiver.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PushTokenReceiver.swift
@@ -27,16 +27,21 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-public import Foundation
+// `@objc` requires the Objective-C runtime, which is absent on
+// Linux/Windows. The push-notification bridge is Apple-only, so gate the
+// whole protocol on Objective-C interop availability.
+#if canImport(ObjectiveC)
+  public import Foundation
 
-/// Receiver side of the platform push-notification bridge. The
-/// `PushNotificationDelegate` (AppKit / UIKit) forwards OS callbacks
-/// to whatever object is currently registered as
-/// `PushNotificationDelegate.receiver`.
-@MainActor
-@objc
-public protocol PushTokenReceiver: AnyObject {
-  func didRegisterForRemoteNotifications(deviceToken: Data)
-  func didFailToRegisterForRemoteNotifications(error: any Error)
-  func didReceiveRemoteNotification(userInfo: [AnyHashable: Any])
-}
+  /// Receiver side of the platform push-notification bridge. The
+  /// `PushNotificationDelegate` (AppKit / UIKit) forwards OS callbacks
+  /// to whatever object is currently registered as
+  /// `PushNotificationDelegate.receiver`.
+  @MainActor
+  @objc
+  public protocol PushTokenReceiver: AnyObject {
+    func didRegisterForRemoteNotifications(deviceToken: Data)
+    func didFailToRegisterForRemoteNotifications(error: any Error)
+    func didReceiveRemoteNotification(userInfo: [AnyHashable: Any])
+  }
+#endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/RemoteNotificationRegistering.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/RemoteNotificationRegistering.swift
@@ -1,0 +1,65 @@
+//
+//  RemoteNotificationRegistering.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if canImport(SwiftUI)
+  public import SwiftUI
+
+  /// Unifies the per-platform "register for remote notifications" entry point
+  /// so push code can call it through ``PlatformApplication`` without
+  /// branching. The accessor is named `sharedApplication` rather than `shared`
+  /// because `WKApplication.shared()` is a method, not a property — reusing the
+  /// `shared` name would collide with it.
+  @MainActor
+  internal protocol RemoteNotificationRegistering {
+    static var sharedApplication: PlatformApplication { get }
+    func registerForRemoteNotifications()
+  }
+
+  extension RemoteNotificationRegistering {
+    /// Registers the shared platform application for remote notifications —
+    /// the single cross-platform entry point push code calls.
+    internal static func registerSharedForRemoteNotifications() {
+      sharedApplication.registerForRemoteNotifications()
+    }
+  }
+
+  #if canImport(AppKit) && !targetEnvironment(macCatalyst)
+    extension NSApplication: RemoteNotificationRegistering {
+      internal static var sharedApplication: NSApplication { shared }
+    }
+  #elseif canImport(WatchKit)
+    extension WKApplication: RemoteNotificationRegistering {
+      internal static var sharedApplication: WKApplication { shared() }
+    }
+  #elseif canImport(UIKit)
+    extension UIApplication: RemoteNotificationRegistering {
+      internal static var sharedApplication: UIApplication { shared }
+    }
+  #endif
+#endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Views/AssetsView.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Views/AssetsView.swift
@@ -1,0 +1,158 @@
+//
+//  AssetsView.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if canImport(SwiftUI) && canImport(CloudKit)
+  internal import MistDemoKit
+  internal import SwiftUI
+
+  /// View driving `assets/upload` and the composed `assets/rereference`
+  /// against native CloudKit. Upload is a one-step `database.save(_:)`
+  /// with a `CKAsset` payload; rereference fetches the source record,
+  /// reuses its asset descriptor, and saves the target — surfaced via
+  /// `CompositionDisclosure`.
+  internal struct AssetsView: View {
+    @Environment(CloudKitStore.self) private var service
+    @State private var uploadTitle: String = "Asset demo"
+    @State private var uploadIndex: Int64 = 0
+    @State private var uploadFilePath: String = ""
+    @State private var uploadResult: Note?
+    @State private var uploadError: String?
+    @State private var sourceRecord: String = ""
+    @State private var assetField: String = "image"
+    @State private var targetRecord: String = ""
+    @State private var targetAssetField: String = ""
+    @State private var rereferenceResult: RereferenceResult?
+    @State private var rereferenceError: String?
+
+    internal var body: some View {
+      Form {
+        uploadSection
+        rereferenceSection
+      }
+      .formStyle(.grouped)
+      .navigationTitle("Assets")
+    }
+
+    private var uploadSection: some View {
+      Section {
+        TextField("Note title", text: $uploadTitle)
+        TextField(
+          "Sort index", value: $uploadIndex, format: .number
+        )
+        TextField("Local file path", text: $uploadFilePath)
+          .font(.body.monospaced())
+        Button("Upload") { Task { await runUpload() } }
+          .disabled(uploadTitle.isEmpty || uploadFilePath.isEmpty)
+        if let uploadError {
+          Text(uploadError).font(.callout).foregroundStyle(.red)
+        }
+        if let uploadResult {
+          LabeledContent("Created", value: uploadResult.id)
+        }
+      } header: {
+        Text("Upload — assets/upload")
+      } footer: {
+        Text(
+          "Creates a Note with the file at the given path as its "
+            + "`image` asset. Native CKAsset upload runs inline as part of "
+            + "database.save(_:)."
+        )
+        .font(.caption)
+      }
+    }
+
+    private var rereferenceSection: some View {
+      Section {
+        TextField("Source record name", text: $sourceRecord)
+          .font(.body.monospaced())
+        TextField("Asset field name", text: $assetField)
+        TextField("Target record name", text: $targetRecord)
+          .font(.body.monospaced())
+        TextField(
+          "Target asset field (optional)",
+          text: $targetAssetField
+        )
+        Button("Rereference") { Task { await runRereference() } }
+          .disabled(
+            sourceRecord.isEmpty || targetRecord.isEmpty
+              || assetField.isEmpty
+          )
+        if let rereferenceError {
+          Text(rereferenceError).font(.callout).foregroundStyle(.red)
+        }
+        if let result = rereferenceResult {
+          LabeledContent("Source", value: result.sourceRecordName)
+          LabeledContent("Target", value: result.targetRecordName)
+          LabeledContent("Field", value: result.targetAssetField)
+        }
+        CompositionDisclosure(
+          restEndpoint: "assets/rereference",
+          steps: [
+            "database.record(for: source) — fetch source record",
+            "Read source[assetField] as CKAsset",
+            "database.record(for: target) — fetch target record",
+            "target[targetAssetField] = asset; database.save(target)",
+          ]
+        )
+      } header: {
+        Text("Rereference — assets/rereference (composed)")
+      }
+    }
+
+    private func runUpload() async {
+      uploadError = nil
+      uploadResult = nil
+      let url = URL(fileURLWithPath: uploadFilePath)
+      do {
+        uploadResult = try await service.uploadAssetNote(
+          title: uploadTitle,
+          index: uploadIndex,
+          fileURL: url
+        )
+      } catch {
+        uploadError = error.localizedDescription
+      }
+    }
+
+    private func runRereference() async {
+      rereferenceError = nil
+      rereferenceResult = nil
+      do {
+        rereferenceResult = try await service.rereferenceAsset(
+          sourceRecordName: sourceRecord,
+          assetField: assetField,
+          targetRecordName: targetRecord,
+          targetAssetField: targetAssetField.isEmpty ? nil : targetAssetField
+        )
+      } catch {
+        rereferenceError = error.localizedDescription
+      }
+    }
+  }
+#endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Views/CompositionDisclosure.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Views/CompositionDisclosure.swift
@@ -1,5 +1,5 @@
 //
-//  DetailColumnRoot.swift
+//  CompositionDisclosure.swift
 //  MistDemo
 //
 //  Created by Leo Dion.
@@ -30,35 +30,37 @@
 #if canImport(SwiftUI)
   internal import SwiftUI
 
-  /// Routes the sidebar selection to the appropriate detail view.
-  internal struct DetailColumnRoot: View {
-    internal let selection: SidebarItem?
+  /// Disclosure group documenting the underlying CloudKit operations that
+  /// compose a single REST endpoint. Used by `RecordsView` (`records/resolve`)
+  /// and `AssetsView` (`assets/rereference`) so users learning the SDK can
+  /// see where native CloudKit's API shape diverges from the REST surface.
+  internal struct CompositionDisclosure: View {
+    internal let restEndpoint: String
+    internal let steps: [String]
 
     internal var body: some View {
-      switch selection {
-      case .account:
-        AccountView()
-      case .zones:
-        ZoneListView()
-      case .query:
-        QueryView()
-      case .records:
-        RecordsView()
-      case .subscriptions:
-        SubscriptionsView()
-      case .pushTokens:
-        PushTokensView()
-      case .assets:
-        AssetsView()
-      case .users:
-        UsersView()
-      case nil:
-        ContentUnavailableView(
-          "Pick a section from the sidebar",
-          systemImage: "sidebar.left",
-          description: Text("Account, Zones, Records, Subscriptions, …")
-        )
+      DisclosureGroup("📎 Composition") {
+        VStack(alignment: .leading, spacing: 6) {
+          Text("REST endpoint: ").font(.caption.bold())
+            + Text(restEndpoint).font(.caption.monospaced())
+          Text("Underlying CloudKit operations:")
+            .font(.caption.bold())
+          ForEach(Array(steps.enumerated()), id: \.offset) { index, step in
+            HStack(alignment: .top, spacing: 6) {
+              Text("\(index + 1).").font(.caption)
+              Text(step).font(.caption.monospaced())
+            }
+          }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 4)
       }
+      .font(.subheadline)
+    }
+
+    internal init(restEndpoint: String, steps: [String]) {
+      self.restEndpoint = restEndpoint
+      self.steps = steps
     }
   }
 #endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Views/CompositionDisclosure.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Views/CompositionDisclosure.swift
@@ -39,23 +39,37 @@
     internal let steps: [String]
 
     internal var body: some View {
-      DisclosureGroup("📎 Composition") {
+      // `DisclosureGroup` is unavailable on watchOS and tvOS, so there the
+      // composition detail is shown inline (non-collapsible) under a plain
+      // header.
+      #if os(watchOS) || os(tvOS)
         VStack(alignment: .leading, spacing: 6) {
-          Text("REST endpoint: ").font(.caption.bold())
-            + Text(restEndpoint).font(.caption.monospaced())
-          Text("Underlying CloudKit operations:")
-            .font(.caption.bold())
-          ForEach(Array(steps.enumerated()), id: \.offset) { index, step in
-            HStack(alignment: .top, spacing: 6) {
-              Text("\(index + 1).").font(.caption)
-              Text(step).font(.caption.monospaced())
-            }
+          Text("📎 Composition").font(.subheadline.bold())
+          compositionDetail
+        }
+      #else
+        DisclosureGroup("📎 Composition") {
+          compositionDetail
+        }
+        .font(.subheadline)
+      #endif
+    }
+
+    private var compositionDetail: some View {
+      VStack(alignment: .leading, spacing: 6) {
+        Text("REST endpoint: ").font(.caption.bold())
+          + Text(restEndpoint).font(.caption.monospaced())
+        Text("Underlying CloudKit operations:")
+          .font(.caption.bold())
+        ForEach(Array(steps.enumerated()), id: \.offset) { index, step in
+          HStack(alignment: .top, spacing: 6) {
+            Text("\(index + 1).").font(.caption)
+            Text(step).font(.caption.monospaced())
           }
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.vertical, 4)
       }
-      .font(.subheadline)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .padding(.vertical, 4)
     }
 
     internal init(restEndpoint: String, steps: [String]) {

--- a/Examples/MistDemo/Sources/MistDemoApp/Views/PushTokensView.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Views/PushTokensView.swift
@@ -1,0 +1,109 @@
+//
+//  PushTokensView.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if canImport(SwiftUI) && canImport(CloudKit)
+  internal import MistDemoKit
+  internal import SwiftUI
+
+  /// Surfaces the device's APNs token for cross-reference with the REST
+  /// `tokens/create` / `tokens/register` workflows. The native demo uses
+  /// the CloudKit framework, so the token here is informational only:
+  /// iCloud routes pushes to the signed-in user's devices without anyone
+  /// passing the device token to CloudKit. See the Subscriptions view for
+  /// the actual server-side notification setup.
+  internal struct PushTokensView: View {
+    @Environment(CloudKitStore.self) private var service
+
+    internal var body: some View {
+      Form {
+        Section {
+          tokenStatus
+          Button("Register for Remote Notifications") {
+            service.requestPushNotificationRegistration()
+          }
+        } header: {
+          Text("APNs device token")
+        } footer: {
+          Text(
+            "Real push delivery requires a signed build with the push "
+              + "entitlement and a paid developer account. Simulators and "
+              + "unentitled builds surface the registration error path "
+              + "below instead of a token. The native CloudKit framework "
+              + "binds this token to the signed-in iCloud account "
+              + "automatically — to actually receive a push, create a "
+              + "CKSubscription from the Subscriptions tab. The MistKit "
+              + "REST tokens/create + tokens/register endpoints exist for "
+              + "server-side scenarios where there's no iCloud user "
+              + "context to route through."
+          )
+          .font(.caption)
+        }
+        if let payload = service.lastReceivedNotification {
+          Section {
+            Text(payload)
+              .font(.callout.monospaced())
+              #if !os(tvOS) && !os(watchOS)
+                .textSelection(.enabled)
+              #endif
+          } header: {
+            Text("Last received remote notification")
+          }
+        }
+      }
+      .formStyle(.grouped)
+      .navigationTitle("Push Tokens")
+    }
+
+    @ViewBuilder
+    private var tokenStatus: some View {
+      switch service.pushTokenStatus {
+      case .idle:
+        LabeledContent("APNs Token", value: "Not requested yet")
+      case .requesting:
+        HStack {
+          ProgressView().controlSize(.small)
+          Text("Requesting…")
+        }
+      case .registered(let hex):
+        LabeledContent("APNs Token") {
+          Text(hex)
+            .font(.callout.monospaced())
+            .lineLimit(3)
+            .truncationMode(.middle)
+            #if !os(tvOS) && !os(watchOS)
+              .textSelection(.enabled)
+            #endif
+        }
+      case .failed(let message):
+        LabeledContent("APNs Token", value: "Failed")
+        Text(message).font(.caption).foregroundStyle(.red)
+      }
+    }
+  }
+#endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Views/RecordsView.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Views/RecordsView.swift
@@ -1,0 +1,189 @@
+//
+//  RecordsView.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if canImport(SwiftUI) && canImport(CloudKit)
+  internal import CloudKit
+  internal import MistDemoKit
+  internal import SwiftUI
+
+  /// View driving `records/lookup`, `records/changes`, and the composed
+  /// `records/resolve` against native CloudKit. Lookup and resolve accept
+  /// the same input shape (a record name) but resolve also accepts a
+  /// share URL; the underlying composition is documented inline via
+  /// `CompositionDisclosure`.
+  internal struct RecordsView: View {
+    @Environment(CloudKitStore.self) private var service
+    @State private var lookupInput: String = ""
+    @State private var lookupResults: [Note] = []
+    @State private var lookupError: String?
+    @State private var resolveInput: String = ""
+    @State private var resolveResult: ResolveResult?
+    @State private var resolveError: String?
+    @State private var changesSnapshot: RecordZoneChangesSnapshot?
+    @State private var changesError: String?
+    @State private var changesToken: CKServerChangeToken?
+    @State private var loading = false
+
+    internal var body: some View {
+      Form {
+        lookupSection
+        changesSection
+        resolveSection
+      }
+      .formStyle(.grouped)
+      .navigationTitle("Records")
+    }
+
+    private var lookupSection: some View {
+      Section {
+        TextField("Record name", text: $lookupInput)
+          .font(.body.monospaced())
+        Button("Lookup") { Task { await runLookup() } }
+          .disabled(lookupInput.isEmpty || loading)
+        if let lookupError {
+          Text(lookupError).font(.callout).foregroundStyle(.red)
+        }
+        ForEach(lookupResults) { note in
+          VStack(alignment: .leading, spacing: 2) {
+            Text(note.title ?? "(untitled)").font(.headline)
+            Text(note.id).font(.caption.monospaced())
+              .foregroundStyle(.secondary)
+          }
+        }
+      } header: {
+        Text("Lookup — records/lookup")
+      } footer: {
+        Text("CKFetchRecordsOperation / database.record(for:)")
+          .font(.caption)
+      }
+    }
+
+    private var changesSection: some View {
+      Section {
+        Button("Fetch changes (_defaultZone)") {
+          Task { await runChanges() }
+        }
+        .disabled(loading)
+        if let changesError {
+          Text(changesError).font(.callout).foregroundStyle(.red)
+        }
+        if let snapshot = changesSnapshot {
+          LabeledContent("Changed", value: "\(snapshot.changedRecordNames.count)")
+          LabeledContent("Deleted", value: "\(snapshot.deletedRecordNames.count)")
+          LabeledContent("More coming", value: snapshot.moreComing ? "Yes" : "No")
+        }
+      } header: {
+        Text("Changes — records/changes")
+      } footer: {
+        Text("CKFetchRecordZoneChangesOperation. Repeat calls return deltas.")
+          .font(.caption)
+      }
+    }
+
+    private var resolveSection: some View {
+      Section {
+        TextField(
+          "Record name or share URL",
+          text: $resolveInput
+        )
+        .font(.body.monospaced())
+        Button("Resolve") { Task { await runResolve() } }
+          .disabled(resolveInput.isEmpty || loading)
+        if let resolveError {
+          Text(resolveError).font(.callout).foregroundStyle(.red)
+        }
+        if let result = resolveResult {
+          LabeledContent("Branch", value: result.source.rawValue)
+          if let name = result.recordName {
+            LabeledContent("Record", value: name)
+          }
+          if let type = result.recordType {
+            LabeledContent("Type", value: type)
+          }
+          if let title = result.shareTitle {
+            LabeledContent("Share title", value: title)
+          }
+        }
+        CompositionDisclosure(
+          restEndpoint: "records/resolve",
+          steps: [
+            "Record name → database.record(for: CKRecord.ID(recordName:))",
+            "Share URL → container.shareMetadata(for: url)",
+          ]
+        )
+      } header: {
+        Text("Resolve — records/resolve (composed)")
+      }
+    }
+
+    private func runLookup() async {
+      loading = true
+      lookupError = nil
+      defer { loading = false }
+      do {
+        let names = lookupInput.split(separator: ",")
+          .map { String($0).trimmingCharacters(in: .whitespaces) }
+          .filter { !$0.isEmpty }
+        lookupResults = try await service.lookupRecords(names: names)
+      } catch {
+        lookupResults = []
+        lookupError = error.localizedDescription
+      }
+    }
+
+    private func runChanges() async {
+      loading = true
+      changesError = nil
+      defer { loading = false }
+      do {
+        let snapshot = try await service.fetchRecordZoneChanges(
+          zoneID: CKRecordZone.ID(zoneName: CKRecordZone.ID.defaultZoneName),
+          since: changesToken
+        )
+        changesSnapshot = snapshot
+        changesToken = snapshot.serverChangeToken
+      } catch {
+        changesSnapshot = nil
+        changesError = error.localizedDescription
+      }
+    }
+
+    private func runResolve() async {
+      loading = true
+      resolveError = nil
+      defer { loading = false }
+      do {
+        resolveResult = try await service.resolveReference(input: resolveInput)
+      } catch {
+        resolveResult = nil
+        resolveError = error.localizedDescription
+      }
+    }
+  }
+#endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Views/SidebarItem.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Views/SidebarItem.swift
@@ -32,12 +32,22 @@ internal enum SidebarItem: Hashable, CaseIterable {
   case account
   case zones
   case query
+  case records
+  case subscriptions
+  case pushTokens
+  case assets
+  case users
 
   internal var label: String {
     switch self {
     case .account: return "iCloud Account"
     case .zones: return "Zones"
     case .query: return "Query Records"
+    case .records: return "Records"
+    case .subscriptions: return "Subscriptions"
+    case .pushTokens: return "Push Tokens"
+    case .assets: return "Assets"
+    case .users: return "Users"
     }
   }
 
@@ -46,6 +56,11 @@ internal enum SidebarItem: Hashable, CaseIterable {
     case .account: return "person.crop.circle"
     case .zones: return "tray.full"
     case .query: return "magnifyingglass"
+    case .records: return "doc.text"
+    case .subscriptions: return "bell"
+    case .pushTokens: return "key.radiowaves.forward"
+    case .assets: return "photo"
+    case .users: return "person.2"
     }
   }
 }

--- a/Examples/MistDemo/Sources/MistDemoApp/Views/SubscriptionsView.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Views/SubscriptionsView.swift
@@ -1,0 +1,158 @@
+//
+//  SubscriptionsView.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if canImport(SwiftUI) && canImport(CloudKit)
+  internal import MistDemoKit
+  internal import SwiftUI
+
+  /// View driving `subscriptions/list` and `subscriptions/lookup` against
+  /// native CloudKit. Includes a "Create demo subscription" button so the
+  /// list has something to render against a fresh container.
+  internal struct SubscriptionsView: View {
+    @Environment(CloudKitStore.self) private var service
+    @State private var rows: [SubscriptionRow] = []
+    @State private var loading = false
+    @State private var loadError: String?
+    @State private var lookupInput: String = ""
+
+    internal var body: some View {
+      Group {
+        if loading {
+          ProgressView("Loading subscriptions…")
+        } else if let loadError {
+          ContentUnavailableView(
+            "Couldn't load subscriptions",
+            systemImage: "exclamationmark.triangle",
+            description: Text(loadError)
+          )
+        } else if rows.isEmpty {
+          ContentUnavailableView(
+            "No subscriptions yet",
+            systemImage: "bell.slash",
+            description: Text(
+              "Tap Create Demo to register a Note-created subscription."
+            )
+          )
+        } else {
+          List(rows) { row in
+            VStack(alignment: .leading, spacing: 2) {
+              Text(row.id).font(.body.monospaced())
+              Text(row.kind)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+              if let recordType = row.recordType {
+                Text("Record type: \(recordType)")
+                  .font(.caption)
+                  .foregroundStyle(.secondary)
+              }
+            }
+            .swipeActions {
+              Button("Delete", role: .destructive) {
+                Task { await deleteSubscription(id: row.id) }
+              }
+            }
+          }
+        }
+      }
+      .safeAreaInset(edge: .bottom) { lookupBar }
+      .navigationTitle("Subscriptions")
+      .toolbar {
+        ToolbarItem {
+          Button("Create Demo") { Task { await createDemo() } }
+        }
+        ToolbarItem {
+          Button("Refresh") { Task { await refresh() } }
+        }
+      }
+      .task { await refresh() }
+    }
+
+    private var lookupBar: some View {
+      HStack {
+        TextField(
+          "Lookup IDs (comma-separated)",
+          text: $lookupInput
+        )
+        .font(.body.monospaced())
+        Button("Lookup") { Task { await runLookup() } }
+          .disabled(lookupInput.isEmpty)
+      }
+      .padding(8)
+      .background(.thinMaterial)
+    }
+
+    private func refresh() async {
+      loading = true
+      loadError = nil
+      defer { loading = false }
+      do {
+        rows = try await service.loadSubscriptions()
+      } catch {
+        loadError = error.localizedDescription
+      }
+    }
+
+    private func createDemo() async {
+      do {
+        _ = try await service.createDemoSubscription()
+        await refresh()
+      } catch {
+        loadError = error.localizedDescription
+      }
+    }
+
+    private func runLookup() async {
+      let ids =
+        lookupInput
+        .split(separator: ",")
+        .map { String($0).trimmingCharacters(in: .whitespaces) }
+        .filter { !$0.isEmpty }
+      guard !ids.isEmpty else {
+        return
+      }
+      loading = true
+      loadError = nil
+      defer { loading = false }
+      do {
+        rows = try await service.lookupSubscriptions(ids: ids)
+      } catch {
+        loadError = error.localizedDescription
+      }
+    }
+
+    private func deleteSubscription(id: String) async {
+      do {
+        try await service.deleteSubscription(id: id)
+        await refresh()
+      } catch {
+        loadError = error.localizedDescription
+      }
+    }
+  }
+#endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Views/SubscriptionsView.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Views/SubscriptionsView.swift
@@ -72,10 +72,8 @@
                   .foregroundStyle(.secondary)
               }
             }
-            .swipeActions {
-              Button("Delete", role: .destructive) {
-                Task { await deleteSubscription(id: row.id) }
-              }
+            .deleteSwipeAction {
+              Task { await deleteSubscription(id: row.id) }
             }
           }
         }

--- a/Examples/MistDemo/Sources/MistDemoApp/Views/UsersView.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Views/UsersView.swift
@@ -1,0 +1,172 @@
+//
+//  UsersView.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if canImport(SwiftUI) && canImport(CloudKit)
+  internal import MistDemoKit
+  internal import SwiftUI
+
+  /// View driving `users/discover`, `users/lookup/email`, and
+  /// `users/lookup/id` against native CloudKit. CloudKit only returns
+  /// identities the caller is permitted to discover, so empty results
+  /// here usually mean the lookup target hasn't opted in to discovery.
+  internal struct UsersView: View {
+    @Environment(CloudKitStore.self) private var service
+    @State private var emailInput: String = ""
+    @State private var recordNameInput: String = ""
+    @State private var discoverInput: String = ""
+    @State private var results: [UserIdentityRow] = []
+    @State private var error: String?
+    @State private var loading = false
+
+    internal var body: some View {
+      Form {
+        emailSection
+        recordNameSection
+        discoverSection
+        if let error {
+          Section {
+            Text(error).font(.callout).foregroundStyle(.red)
+          }
+        }
+        if !results.isEmpty {
+          resultsSection
+        }
+      }
+      .formStyle(.grouped)
+      .navigationTitle("Users")
+    }
+
+    private var emailSection: some View {
+      Section {
+        TextField("Email address", text: $emailInput)
+        Button("Lookup by Email") {
+          Task { await lookupByEmail() }
+        }
+        .disabled(emailInput.isEmpty || loading)
+      } header: {
+        Text("users/lookup/email")
+      }
+    }
+
+    private var recordNameSection: some View {
+      Section {
+        TextField("User record name", text: $recordNameInput)
+          .font(.body.monospaced())
+        Button("Lookup by Record Name") {
+          Task { await lookupByRecordName() }
+        }
+        .disabled(recordNameInput.isEmpty || loading)
+      } header: {
+        Text("users/lookup/id")
+      }
+    }
+
+    private var discoverSection: some View {
+      Section {
+        TextField("Comma-separated emails", text: $discoverInput)
+        Button("Discover") {
+          Task { await discover() }
+        }
+        .disabled(discoverInput.isEmpty || loading)
+      } header: {
+        Text("users/discover (POST)")
+      } footer: {
+        Text(
+          "CloudKit JS exposes a per-email primitive only; the batch "
+            + "POST surface is composed by looping the per-call API."
+        )
+        .font(.caption)
+      }
+    }
+
+    private var resultsSection: some View {
+      Section("Results") {
+        ForEach(results) { row in
+          VStack(alignment: .leading, spacing: 2) {
+            Text(row.displayName ?? "(no display name)")
+              .font(.headline)
+            if let recordName = row.recordName {
+              Text(recordName).font(.caption.monospaced())
+                .foregroundStyle(.secondary)
+            }
+            if let hint = row.lookupHint {
+              Text("Looked up via: \(hint)")
+                .font(.caption).foregroundStyle(.secondary)
+            }
+          }
+        }
+      }
+    }
+
+    private func lookupByEmail() async {
+      await runLookup {
+        if let row = try await service.lookupUser(byEmail: emailInput) {
+          return [row]
+        }
+        return []
+      }
+    }
+
+    private func lookupByRecordName() async {
+      await runLookup {
+        if let row = try await service.lookupUser(
+          byRecordName: recordNameInput
+        ) {
+          return [row]
+        }
+        return []
+      }
+    }
+
+    private func discover() async {
+      let emails =
+        discoverInput
+        .split(separator: ",")
+        .map { String($0).trimmingCharacters(in: .whitespaces) }
+        .filter { !$0.isEmpty }
+      await runLookup {
+        try await service.discoverUsers(byEmails: emails)
+      }
+    }
+
+    private func runLookup(
+      _ operation: @Sendable () async throws -> [UserIdentityRow]
+    ) async {
+      loading = true
+      error = nil
+      defer { loading = false }
+      do {
+        results = try await operation()
+      } catch {
+        results = []
+        self.error = error.localizedDescription
+      }
+    }
+  }
+#endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Views/View+DeleteSwipeAction.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Views/View+DeleteSwipeAction.swift
@@ -1,6 +1,6 @@
 //
-//  MistDemoApp.swift
-//  MistDemoApp
+//  View+DeleteSwipeAction.swift
+//  MistDemo
 //
 //  Created by Leo Dion.
 //  Copyright © 2026 BrightDigit.
@@ -27,16 +27,26 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-internal import MistDemoApp
-internal import SwiftUI
+#if canImport(SwiftUI)
+  internal import SwiftUI
 
-@main
-internal struct MistDemoAppMain: AppMain {
-  // SwiftUI owns the AppDelegate's lifecycle via this adaptor; the
-  // delegate's static-weak `receiver` is wired from `CloudKitStore.init`
-  // so the OS-delivered APNs token lands back in the observable store.
-  #if (canImport(AppKit) && !targetEnvironment(macCatalyst)) || (canImport(UIKit) && !os(watchOS))
-    @PlatformApplicationDelegateAdaptor(PushNotificationDelegate.self)
-    private var pushDelegate
-  #endif
-}
+  extension View {
+    /// Attaches a trailing destructive "Delete" swipe action.
+    ///
+    /// `swipeActions(...)` is unavailable on tvOS, so this is a no-op there;
+    /// every list row that offers swipe-to-delete routes through this helper
+    /// so the platform guard lives in exactly one place.
+    @ViewBuilder
+    internal func deleteSwipeAction(
+      perform action: @escaping () -> Void
+    ) -> some View {
+      #if os(tvOS)
+        self
+      #else
+        self.swipeActions {
+          Button("Delete", role: .destructive, action: action)
+        }
+      #endif
+    }
+  }
+#endif

--- a/Examples/MistDemo/Sources/MistDemoApp/Views/ZoneListView.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Views/ZoneListView.swift
@@ -70,10 +70,8 @@
                 .foregroundStyle(.secondary)
             }
             .padding(.vertical, 2)
-            .swipeActions {
-              Button("Delete", role: .destructive) {
-                Task { await deleteZone(named: zone.zoneName) }
-              }
+            .deleteSwipeAction {
+              Task { await deleteZone(named: zone.zoneName) }
             }
           }
         }

--- a/Examples/MistDemo/Sources/MistDemoApp/Views/ZoneListView.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Views/ZoneListView.swift
@@ -31,12 +31,17 @@
   internal import MistDemoKit
   internal import SwiftUI
 
-  /// View listing all CloudKit record zones.
+  /// View listing all CloudKit record zones, with modify (create/delete)
+  /// and changes (database-scope sync token) actions. Covers `zones/list`,
+  /// `zones/lookup`, `zones/modify`, and `zones/changes` in one place.
   internal struct ZoneListView: View {
     @Environment(CloudKitStore.self) private var service
     @State private var zones: [ZoneRow] = []
     @State private var loading = false
     @State private var loadError: String?
+    @State private var newZoneName: String = ""
+    @State private var changesSnapshot: DatabaseChangesSnapshot?
+    @State private var changesError: String?
 
     internal var body: some View {
       Group {
@@ -65,13 +70,22 @@
                 .foregroundStyle(.secondary)
             }
             .padding(.vertical, 2)
+            .swipeActions {
+              Button("Delete", role: .destructive) {
+                Task { await deleteZone(named: zone.zoneName) }
+              }
+            }
           }
         }
       }
+      .safeAreaInset(edge: .bottom) { actionBar }
       .navigationTitle(service.databaseScope.label.map { "Zones — \($0)" } ?? "Zones")
       .toolbar {
         ToolbarItem {
           Button("Refresh") { Task { await refresh() } }
+        }
+        ToolbarItem {
+          Button("Fetch Changes") { Task { await fetchChanges() } }
         }
       }
       .task { await refresh() }
@@ -79,6 +93,39 @@
         zones = []
         Task { await refresh() }
       }
+    }
+
+    private var actionBar: some View {
+      VStack(spacing: 4) {
+        HStack {
+          TextField(
+            "New zone name", text: $newZoneName
+          )
+          .font(.body.monospaced())
+          Button("Create") {
+            Task { await createZone() }
+          }
+          .disabled(newZoneName.isEmpty)
+        }
+        if let snapshot = changesSnapshot {
+          HStack {
+            Text(
+              "Changed \(snapshot.changedZoneIDs.count), "
+                + "deleted \(snapshot.deletedZoneIDs.count)"
+            )
+            .font(.caption)
+            Spacer()
+            Text(snapshot.moreComing ? "more coming" : "in-sync")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+        if let changesError {
+          Text(changesError).font(.caption).foregroundStyle(.red)
+        }
+      }
+      .padding(8)
+      .background(.thinMaterial)
     }
 
     private func refresh() async {
@@ -89,6 +136,36 @@
         zones = try await service.loadZones()
       } catch {
         loadError = error.localizedDescription
+      }
+    }
+
+    private func createZone() async {
+      do {
+        _ = try await service.createZone(named: newZoneName)
+        newZoneName = ""
+        await refresh()
+      } catch {
+        loadError = error.localizedDescription
+      }
+    }
+
+    private func deleteZone(named name: String) async {
+      do {
+        try await service.deleteZone(named: name)
+        await refresh()
+      } catch {
+        loadError = error.localizedDescription
+      }
+    }
+
+    private func fetchChanges() async {
+      changesError = nil
+      do {
+        changesSnapshot = try await service.fetchDatabaseChanges(
+          since: changesSnapshot?.serverChangeToken
+        )
+      } catch {
+        changesError = error.localizedDescription
       }
     }
   }

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/CreateTokenCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/CreateTokenCommand.swift
@@ -1,0 +1,69 @@
+//
+//  CreateTokenCommand.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+internal import Foundation
+
+/// Stub command for `tokens/create`. Creates an APNs token CloudKit can use
+/// to deliver push notifications to a registered subscription. MistKit
+/// Swift wrapper tracked in #52.
+public struct CreateTokenCommand: MistDemoCommand {
+  /// The configuration type.
+  public typealias Config = CreateTokenConfig
+  /// The command name.
+  public static let commandName = "create-token"
+  /// The command abstract.
+  public static let abstract = "Create an APNs token for CloudKit subscriptions (pending #52)"
+  /// The command help text.
+  public static let helpText = """
+    CREATE-TOKEN - Create an APNs token for CloudKit subscriptions
+
+    USAGE:
+      mistdemo create-token --apns-token <hex> [--apns-environment <env>]
+
+    OPTIONS:
+      --apns-token <hex>             APNs device token (hex string)
+      --apns-environment <env>       APNs environment (development, production)
+      --output-format <format>       Output format (json, table, csv, yaml)
+
+    STATUS:
+      Not yet implemented — pending MistKit support, tracked in #52.
+    """
+
+  private let config: CreateTokenConfig
+
+  /// Creates a new instance.
+  public init(config: CreateTokenConfig) {
+    self.config = config
+  }
+
+  /// Executes the command.
+  public func execute() async throws {
+    PendingStub.printPending(endpoint: "tokens/create", trackingIssue: 52)
+  }
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/ListSubscriptionsCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/ListSubscriptionsCommand.swift
@@ -1,0 +1,68 @@
+//
+//  ListSubscriptionsCommand.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+internal import Foundation
+
+/// Stub command for `subscriptions/list`. Lists every CloudKit subscription
+/// registered against the selected database. MistKit Swift wrapper tracked
+/// in #49.
+public struct ListSubscriptionsCommand: MistDemoCommand {
+  /// The configuration type.
+  public typealias Config = ListSubscriptionsConfig
+  /// The command name.
+  public static let commandName = "list-subscriptions"
+  /// The command abstract.
+  public static let abstract = "List CloudKit subscriptions (pending #49)"
+  /// The command help text.
+  public static let helpText = """
+    LIST-SUBSCRIPTIONS - List CloudKit subscriptions
+
+    USAGE:
+      mistdemo list-subscriptions [options]
+
+    OPTIONS:
+      --database <type>          Database to target (private, shared, public)
+      --output-format <format>   Output format (json, table, csv, yaml)
+
+    STATUS:
+      Not yet implemented — pending MistKit support, tracked in #49.
+    """
+
+  private let config: ListSubscriptionsConfig
+
+  /// Creates a new instance.
+  public init(config: ListSubscriptionsConfig) {
+    self.config = config
+  }
+
+  /// Executes the command.
+  public func execute() async throws {
+    PendingStub.printPending(endpoint: "subscriptions/list", trackingIssue: 49)
+  }
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/LookupSubscriptionCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/LookupSubscriptionCommand.swift
@@ -1,0 +1,68 @@
+//
+//  LookupSubscriptionCommand.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+internal import Foundation
+
+/// Stub command for `subscriptions/lookup`. Looks up one or more
+/// CloudKit subscriptions by ID. MistKit Swift wrapper tracked in #50.
+public struct LookupSubscriptionCommand: MistDemoCommand {
+  /// The configuration type.
+  public typealias Config = LookupSubscriptionConfig
+  /// The command name.
+  public static let commandName = "lookup-subscription"
+  /// The command abstract.
+  public static let abstract = "Look up a CloudKit subscription by ID (pending #50)"
+  /// The command help text.
+  public static let helpText = """
+    LOOKUP-SUBSCRIPTION - Look up a CloudKit subscription by ID
+
+    USAGE:
+      mistdemo lookup-subscription --subscription-ids <list> [options]
+
+    OPTIONS:
+      --subscription-ids <list>  Comma-separated subscription IDs
+      --database <type>          Database to target
+      --output-format <format>   Output format (json, table, csv, yaml)
+
+    STATUS:
+      Not yet implemented — pending MistKit support, tracked in #50.
+    """
+
+  private let config: LookupSubscriptionConfig
+
+  /// Creates a new instance.
+  public init(config: LookupSubscriptionConfig) {
+    self.config = config
+  }
+
+  /// Executes the command.
+  public func execute() async throws {
+    PendingStub.printPending(endpoint: "subscriptions/lookup", trackingIssue: 50)
+  }
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/QueryCommand+FilterParsing.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/QueryCommand+FilterParsing.swift
@@ -68,8 +68,8 @@ extension QueryCommand {
     )
   }
 
+  // swiftlint:disable cyclomatic_complexity
   /// Build comparison-based filters (equals, not equals, greater/less than).
-  // swiftlint:disable:next cyclomatic_complexity
   internal static func buildComparisonFilter(
     field: String,
     operatorString: String,
@@ -96,6 +96,7 @@ extension QueryCommand {
       return nil
     }
   }
+  // swiftlint:enable cyclomatic_complexity
 
   /// Build string and list-based filters.
   internal static func buildSpecialFilter(

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/QueryCommand+FilterParsing.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/QueryCommand+FilterParsing.swift
@@ -31,6 +31,28 @@ internal import Foundation
 internal import MistKit
 
 extension QueryCommand {
+  /// Comparison operators keyed by every spelling we accept, each mapped to
+  /// the matching ``QueryFilter`` case. A lookup table replaces a `switch`
+  /// that tripped `cyclomatic_complexity`.
+  private static let comparisonFilterBuilders:
+    [String: @Sendable (String, FieldValue) -> QueryFilter] = [
+      "eq": QueryFilter.equals,
+      "equals": QueryFilter.equals,
+      "==": QueryFilter.equals,
+      "=": QueryFilter.equals,
+      "ne": QueryFilter.notEquals,
+      "not_equals": QueryFilter.notEquals,
+      "!=": QueryFilter.notEquals,
+      "gt": QueryFilter.greaterThan,
+      ">": QueryFilter.greaterThan,
+      "gte": QueryFilter.greaterThanOrEquals,
+      ">=": QueryFilter.greaterThanOrEquals,
+      "lt": QueryFilter.lessThan,
+      "<": QueryFilter.lessThan,
+      "lte": QueryFilter.lessThanOrEquals,
+      "<=": QueryFilter.lessThanOrEquals,
+    ]
+
   /// Parse a single filter expression "field:operator:value" into a QueryFilter
   internal static func parseFilter(_ filterString: String) throws -> QueryFilter {
     let components = filterString.split(
@@ -68,35 +90,18 @@ extension QueryCommand {
     )
   }
 
-  // swiftlint:disable cyclomatic_complexity
   /// Build comparison-based filters (equals, not equals, greater/less than).
   internal static func buildComparisonFilter(
     field: String,
     operatorString: String,
     value: String
   ) -> QueryFilter? {
-    switch operatorString.lowercased() {
-    case "eq", "equals", "==", "=":
-      return .equals(field, inferFieldValue(value))
-    case "ne", "not_equals", "!=":
-      return .notEquals(field, inferFieldValue(value))
-    case "gt", ">":
-      return .greaterThan(field, inferFieldValue(value))
-    case "gte", ">=":
-      return .greaterThanOrEquals(
-        field, inferFieldValue(value)
-      )
-    case "lt", "<":
-      return .lessThan(field, inferFieldValue(value))
-    case "lte", "<=":
-      return .lessThanOrEquals(
-        field, inferFieldValue(value)
-      )
-    default:
+    guard let makeFilter = comparisonFilterBuilders[operatorString.lowercased()]
+    else {
       return nil
     }
+    return makeFilter(field, inferFieldValue(value))
   }
-  // swiftlint:enable cyclomatic_complexity
 
   /// Build string and list-based filters.
   internal static func buildSpecialFilter(

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/RegisterTokenCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/RegisterTokenCommand.swift
@@ -1,0 +1,70 @@
+//
+//  RegisterTokenCommand.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+internal import Foundation
+
+/// Stub command for `tokens/register`. Wires an APNs token into a CloudKit
+/// subscription so push notifications get delivered. MistKit Swift wrapper
+/// tracked in #53.
+public struct RegisterTokenCommand: MistDemoCommand {
+  /// The configuration type.
+  public typealias Config = RegisterTokenConfig
+  /// The command name.
+  public static let commandName = "register-token"
+  /// The command abstract.
+  public static let abstract = "Register an APNs token with a subscription (pending #53)"
+  /// The command help text.
+  public static let helpText = """
+    REGISTER-TOKEN - Register an APNs token with a CloudKit subscription
+
+    USAGE:
+      mistdemo register-token --apns-token <hex> --subscription-id <id>
+
+    OPTIONS:
+      --apns-token <hex>             APNs device token (hex string)
+      --subscription-id <id>         CloudKit subscription ID
+      --database <type>              Database to target
+      --output-format <format>       Output format (json, table, csv, yaml)
+
+    STATUS:
+      Not yet implemented — pending MistKit support, tracked in #53.
+    """
+
+  private let config: RegisterTokenConfig
+
+  /// Creates a new instance.
+  public init(config: RegisterTokenConfig) {
+    self.config = config
+  }
+
+  /// Executes the command.
+  public func execute() async throws {
+    PendingStub.printPending(endpoint: "tokens/register", trackingIssue: 53)
+  }
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/RereferenceAssetCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/RereferenceAssetCommand.swift
@@ -1,0 +1,74 @@
+//
+//  RereferenceAssetCommand.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+internal import Foundation
+
+/// Stub command for `assets/rereference`. Reuses an existing CloudKit asset
+/// descriptor from one record on another, avoiding a second upload. The
+/// MistKit Swift wrapper is tracked in #31.
+public struct RereferenceAssetCommand: MistDemoCommand {
+  /// The configuration type.
+  public typealias Config = RereferenceAssetConfig
+  /// The command name.
+  public static let commandName = "rereference-asset"
+  /// The command abstract.
+  public static let abstract = "Re-reference an asset across records (pending #31)"
+  /// The command help text.
+  public static let helpText = """
+    REREFERENCE-ASSET - Re-reference an existing asset across records
+
+    USAGE:
+      mistdemo rereference-asset \\
+        --source-record <name> --asset-field <field> \\
+        --target-record <name> [--target-asset-field <field>]
+
+    OPTIONS:
+      --source-record <name>         Record name whose asset to reuse
+      --asset-field <name>           Field on the source record holding the asset
+      --target-record <name>         Record name receiving the asset reference
+      --target-asset-field <name>    Field on the target record (defaults to --asset-field)
+      --database <type>              Database to target
+      --output-format <format>       Output format (json, table, csv, yaml)
+
+    STATUS:
+      Not yet implemented — pending MistKit support, tracked in #31.
+    """
+
+  private let config: RereferenceAssetConfig
+
+  /// Creates a new instance.
+  public init(config: RereferenceAssetConfig) {
+    self.config = config
+  }
+
+  /// Executes the command.
+  public func execute() async throws {
+    PendingStub.printPending(endpoint: "assets/rereference", trackingIssue: 31)
+  }
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/ResolveCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/ResolveCommand.swift
@@ -1,0 +1,74 @@
+//
+//  ResolveCommand.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+internal import Foundation
+
+/// Stub command for `records/resolve`. Resolves a share URL or record
+/// reference to a CloudKit record. The MistKit Swift wrapper is tracked
+/// in #41; until that lands, this command prints the standard pending
+/// banner and exits 0 so the `--help` shape is discoverable today.
+public struct ResolveCommand: MistDemoCommand {
+  /// The configuration type.
+  public typealias Config = ResolveConfig
+  /// The command name.
+  public static let commandName = "resolve"
+  /// The command abstract.
+  public static let abstract = "Resolve a share URL or record reference (pending #41)"
+  /// The command help text.
+  public static let helpText = """
+    RESOLVE - Resolve a share URL or record reference
+
+    USAGE:
+      mistdemo resolve --share-url <url> [options]
+      mistdemo resolve --record-name <name> [options]
+
+    INPUT (choose one):
+      --share-url <url>          Share URL to resolve
+      --record-name <name>       Record name to resolve
+
+    OPTIONS:
+      --database <type>          Database to target
+      --output-format <format>   Output format (json, table, csv, yaml)
+
+    STATUS:
+      Not yet implemented — pending MistKit support, tracked in #41.
+    """
+
+  private let config: ResolveConfig
+
+  /// Creates a new instance.
+  public init(config: ResolveConfig) {
+    self.config = config
+  }
+
+  /// Executes the command.
+  public func execute() async throws {
+    PendingStub.printPending(endpoint: "records/resolve", trackingIssue: 41)
+  }
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Configuration/CreateTokenConfig.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Configuration/CreateTokenConfig.swift
@@ -1,0 +1,91 @@
+//
+//  CreateTokenConfig.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+public import ConfigKeyKit
+internal import Foundation
+
+/// Configuration for the `create-token` command.
+public struct CreateTokenConfig: Sendable, ConfigurationParseable {
+  /// The configuration reader type.
+  public typealias ConfigReader = MistDemoConfiguration
+  /// The base configuration type.
+  public typealias BaseConfig = MistDemoConfig
+
+  /// The base MistDemo configuration.
+  public let base: MistDemoConfig
+  /// APNs device token (hex string).
+  public let apnsToken: String?
+  /// APNs environment (development, production).
+  public let apnsEnvironment: String?
+  /// The output format.
+  public let output: OutputFormat
+
+  /// Creates a new instance.
+  public init(
+    base: MistDemoConfig,
+    apnsToken: String? = nil,
+    apnsEnvironment: String? = nil,
+    output: OutputFormat = .json
+  ) {
+    self.base = base
+    self.apnsToken = apnsToken
+    self.apnsEnvironment = apnsEnvironment
+    self.output = output
+  }
+
+  /// Parse configuration from command line arguments.
+  public init(
+    configuration: MistDemoConfiguration,
+    base: MistDemoConfig?
+  ) async throws {
+    let baseConfig: MistDemoConfig
+    if let base {
+      baseConfig = base
+    } else {
+      baseConfig = try await MistDemoConfig(
+        configuration: configuration,
+        base: nil
+      )
+    }
+
+    let outputString =
+      configuration.string(
+        forKey: MistDemoConstants.ConfigKeys.outputFormat,
+        default: "json"
+      ) ?? "json"
+    let output = OutputFormat(rawValue: outputString) ?? .json
+
+    self.init(
+      base: baseConfig,
+      apnsToken: configuration.string(forKey: "apns-token"),
+      apnsEnvironment: configuration.string(forKey: "apns-environment"),
+      output: output
+    )
+  }
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Configuration/ListSubscriptionsConfig.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Configuration/ListSubscriptionsConfig.swift
@@ -1,0 +1,78 @@
+//
+//  ListSubscriptionsConfig.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+public import ConfigKeyKit
+internal import Foundation
+
+/// Configuration for the `list-subscriptions` command.
+public struct ListSubscriptionsConfig: Sendable, ConfigurationParseable {
+  /// The configuration reader type.
+  public typealias ConfigReader = MistDemoConfiguration
+  /// The base configuration type.
+  public typealias BaseConfig = MistDemoConfig
+
+  /// The base MistDemo configuration.
+  public let base: MistDemoConfig
+  /// The output format.
+  public let output: OutputFormat
+
+  /// Creates a new instance.
+  public init(
+    base: MistDemoConfig,
+    output: OutputFormat = .table
+  ) {
+    self.base = base
+    self.output = output
+  }
+
+  /// Parse configuration from command line arguments.
+  public init(
+    configuration: MistDemoConfiguration,
+    base: MistDemoConfig?
+  ) async throws {
+    let baseConfig: MistDemoConfig
+    if let base {
+      baseConfig = base
+    } else {
+      baseConfig = try await MistDemoConfig(
+        configuration: configuration,
+        base: nil
+      )
+    }
+
+    let outputString =
+      configuration.string(
+        forKey: MistDemoConstants.ConfigKeys.outputFormat,
+        default: "table"
+      ) ?? "table"
+    let output = OutputFormat(rawValue: outputString) ?? .table
+
+    self.init(base: baseConfig, output: output)
+  }
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Configuration/LookupSubscriptionConfig.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Configuration/LookupSubscriptionConfig.swift
@@ -1,0 +1,93 @@
+//
+//  LookupSubscriptionConfig.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+public import ConfigKeyKit
+internal import Foundation
+
+/// Configuration for the `lookup-subscription` command.
+public struct LookupSubscriptionConfig: Sendable, ConfigurationParseable {
+  /// The configuration reader type.
+  public typealias ConfigReader = MistDemoConfiguration
+  /// The base configuration type.
+  public typealias BaseConfig = MistDemoConfig
+
+  /// The base MistDemo configuration.
+  public let base: MistDemoConfig
+  /// The subscription IDs to look up.
+  public let subscriptionIDs: [String]
+  /// The output format.
+  public let output: OutputFormat
+
+  /// Creates a new instance.
+  public init(
+    base: MistDemoConfig,
+    subscriptionIDs: [String] = [],
+    output: OutputFormat = .json
+  ) {
+    self.base = base
+    self.subscriptionIDs = subscriptionIDs
+    self.output = output
+  }
+
+  /// Parse configuration from command line arguments.
+  public init(
+    configuration: MistDemoConfiguration,
+    base: MistDemoConfig?
+  ) async throws {
+    let baseConfig: MistDemoConfig
+    if let base {
+      baseConfig = base
+    } else {
+      baseConfig = try await MistDemoConfig(
+        configuration: configuration,
+        base: nil
+      )
+    }
+
+    let idsString = configuration.string(forKey: "subscription-ids") ?? ""
+    let subscriptionIDs =
+      idsString
+      .split(separator: ",")
+      .map { String($0).trimmingCharacters(in: .whitespaces) }
+      .filter { !$0.isEmpty }
+
+    let outputString =
+      configuration.string(
+        forKey: MistDemoConstants.ConfigKeys.outputFormat,
+        default: "json"
+      ) ?? "json"
+    let output = OutputFormat(rawValue: outputString) ?? .json
+
+    self.init(
+      base: baseConfig,
+      subscriptionIDs: subscriptionIDs,
+      output: output
+    )
+  }
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Configuration/RegisterTokenConfig.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Configuration/RegisterTokenConfig.swift
@@ -1,0 +1,91 @@
+//
+//  RegisterTokenConfig.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+public import ConfigKeyKit
+internal import Foundation
+
+/// Configuration for the `register-token` command.
+public struct RegisterTokenConfig: Sendable, ConfigurationParseable {
+  /// The configuration reader type.
+  public typealias ConfigReader = MistDemoConfiguration
+  /// The base configuration type.
+  public typealias BaseConfig = MistDemoConfig
+
+  /// The base MistDemo configuration.
+  public let base: MistDemoConfig
+  /// APNs device token (hex string).
+  public let apnsToken: String?
+  /// CloudKit subscription ID to wire the token into.
+  public let subscriptionID: String?
+  /// The output format.
+  public let output: OutputFormat
+
+  /// Creates a new instance.
+  public init(
+    base: MistDemoConfig,
+    apnsToken: String? = nil,
+    subscriptionID: String? = nil,
+    output: OutputFormat = .json
+  ) {
+    self.base = base
+    self.apnsToken = apnsToken
+    self.subscriptionID = subscriptionID
+    self.output = output
+  }
+
+  /// Parse configuration from command line arguments.
+  public init(
+    configuration: MistDemoConfiguration,
+    base: MistDemoConfig?
+  ) async throws {
+    let baseConfig: MistDemoConfig
+    if let base {
+      baseConfig = base
+    } else {
+      baseConfig = try await MistDemoConfig(
+        configuration: configuration,
+        base: nil
+      )
+    }
+
+    let outputString =
+      configuration.string(
+        forKey: MistDemoConstants.ConfigKeys.outputFormat,
+        default: "json"
+      ) ?? "json"
+    let output = OutputFormat(rawValue: outputString) ?? .json
+
+    self.init(
+      base: baseConfig,
+      apnsToken: configuration.string(forKey: "apns-token"),
+      subscriptionID: configuration.string(forKey: "subscription-id"),
+      output: output
+    )
+  }
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Configuration/RereferenceAssetConfig.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Configuration/RereferenceAssetConfig.swift
@@ -1,0 +1,101 @@
+//
+//  RereferenceAssetConfig.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+public import ConfigKeyKit
+internal import Foundation
+
+/// Configuration for the `rereference-asset` command.
+public struct RereferenceAssetConfig: Sendable, ConfigurationParseable {
+  /// The configuration reader type.
+  public typealias ConfigReader = MistDemoConfiguration
+  /// The base configuration type.
+  public typealias BaseConfig = MistDemoConfig
+
+  /// The base MistDemo configuration.
+  public let base: MistDemoConfig
+  /// Source record name whose asset is being reused.
+  public let sourceRecord: String?
+  /// Field on the source record holding the asset.
+  public let assetField: String?
+  /// Target record name receiving the asset reference.
+  public let targetRecord: String?
+  /// Field on the target record (defaults to `assetField`).
+  public let targetAssetField: String?
+  /// The output format.
+  public let output: OutputFormat
+
+  /// Creates a new instance.
+  public init(
+    base: MistDemoConfig,
+    sourceRecord: String? = nil,
+    assetField: String? = nil,
+    targetRecord: String? = nil,
+    targetAssetField: String? = nil,
+    output: OutputFormat = .json
+  ) {
+    self.base = base
+    self.sourceRecord = sourceRecord
+    self.assetField = assetField
+    self.targetRecord = targetRecord
+    self.targetAssetField = targetAssetField
+    self.output = output
+  }
+
+  /// Parse configuration from command line arguments.
+  public init(
+    configuration: MistDemoConfiguration,
+    base: MistDemoConfig?
+  ) async throws {
+    let baseConfig: MistDemoConfig
+    if let base {
+      baseConfig = base
+    } else {
+      baseConfig = try await MistDemoConfig(
+        configuration: configuration,
+        base: nil
+      )
+    }
+
+    let outputString =
+      configuration.string(
+        forKey: MistDemoConstants.ConfigKeys.outputFormat,
+        default: "json"
+      ) ?? "json"
+    let output = OutputFormat(rawValue: outputString) ?? .json
+
+    self.init(
+      base: baseConfig,
+      sourceRecord: configuration.string(forKey: "source-record"),
+      assetField: configuration.string(forKey: "asset-field"),
+      targetRecord: configuration.string(forKey: "target-record"),
+      targetAssetField: configuration.string(forKey: "target-asset-field"),
+      output: output
+    )
+  }
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Configuration/ResolveConfig.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Configuration/ResolveConfig.swift
@@ -1,0 +1,94 @@
+//
+//  ResolveConfig.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+public import ConfigKeyKit
+internal import Foundation
+
+/// Configuration for the `resolve` command. Parses the future argument shape
+/// even though `ResolveCommand.execute()` is currently a `PendingStub`
+/// — the `--help` text and argument names stabilize here so callers can
+/// integrate against the real surface when #41 lands.
+public struct ResolveConfig: Sendable, ConfigurationParseable {
+  /// The configuration reader type.
+  public typealias ConfigReader = MistDemoConfiguration
+  /// The base configuration type.
+  public typealias BaseConfig = MistDemoConfig
+
+  /// The base MistDemo configuration.
+  public let base: MistDemoConfig
+  /// Optional share URL to resolve.
+  public let shareURL: String?
+  /// Optional record name to resolve.
+  public let recordName: String?
+  /// The output format.
+  public let output: OutputFormat
+
+  /// Creates a new instance.
+  public init(
+    base: MistDemoConfig,
+    shareURL: String? = nil,
+    recordName: String? = nil,
+    output: OutputFormat = .json
+  ) {
+    self.base = base
+    self.shareURL = shareURL
+    self.recordName = recordName
+    self.output = output
+  }
+
+  /// Parse configuration from command line arguments.
+  public init(
+    configuration: MistDemoConfiguration,
+    base: MistDemoConfig?
+  ) async throws {
+    let baseConfig: MistDemoConfig
+    if let base {
+      baseConfig = base
+    } else {
+      baseConfig = try await MistDemoConfig(
+        configuration: configuration,
+        base: nil
+      )
+    }
+
+    let outputString =
+      configuration.string(
+        forKey: MistDemoConstants.ConfigKeys.outputFormat,
+        default: "json"
+      ) ?? "json"
+    let output = OutputFormat(rawValue: outputString) ?? .json
+
+    self.init(
+      base: baseConfig,
+      shareURL: configuration.string(forKey: "share-url"),
+      recordName: configuration.string(forKey: "record-name"),
+      output: output
+    )
+  }
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/CreateTokenPhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/CreateTokenPhase.swift
@@ -1,5 +1,5 @@
 //
-//  DetailColumnRoot.swift
+//  CreateTokenPhase.swift
 //  MistDemo
 //
 //  Created by Leo Dion.
@@ -27,38 +27,22 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if canImport(SwiftUI)
-  internal import SwiftUI
+internal import Foundation
 
-  /// Routes the sidebar selection to the appropriate detail view.
-  internal struct DetailColumnRoot: View {
-    internal let selection: SidebarItem?
+/// Stub phase for `tokens/create`. Not wired into the public/private
+/// pipelines yet; `#52` flips this into a real run when the MistKit Swift
+/// wrapper lands.
+internal struct CreateTokenPhase: IntegrationPhase {
+  internal typealias Input = NoState
+  internal typealias Output = NoState
 
-    internal var body: some View {
-      switch selection {
-      case .account:
-        AccountView()
-      case .zones:
-        ZoneListView()
-      case .query:
-        QueryView()
-      case .records:
-        RecordsView()
-      case .subscriptions:
-        SubscriptionsView()
-      case .pushTokens:
-        PushTokensView()
-      case .assets:
-        AssetsView()
-      case .users:
-        UsersView()
-      case nil:
-        ContentUnavailableView(
-          "Pick a section from the sidebar",
-          systemImage: "sidebar.left",
-          description: Text("Account, Zones, Records, Subscriptions, …")
-        )
-      }
-    }
+  internal static let title = "Create token (pending #52)"
+  internal static let emoji = "🎟️"
+  internal static let apiName = "createToken"
+
+  internal func run(input: NoState, context: PhaseContext) async throws -> NoState {
+    print("\n\(Self.emoji) \(Self.title)")
+    PendingStub.printPending(endpoint: "tokens/create", trackingIssue: 52)
+    return NoState()
   }
-#endif
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/ListSubscriptionsPhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/ListSubscriptionsPhase.swift
@@ -1,5 +1,5 @@
 //
-//  DetailColumnRoot.swift
+//  ListSubscriptionsPhase.swift
 //  MistDemo
 //
 //  Created by Leo Dion.
@@ -27,38 +27,22 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if canImport(SwiftUI)
-  internal import SwiftUI
+internal import Foundation
 
-  /// Routes the sidebar selection to the appropriate detail view.
-  internal struct DetailColumnRoot: View {
-    internal let selection: SidebarItem?
+/// Stub phase for `subscriptions/list`. Not wired into the public/private
+/// pipelines yet; `#49` flips this into a real run when the MistKit Swift
+/// wrapper lands.
+internal struct ListSubscriptionsPhase: IntegrationPhase {
+  internal typealias Input = NoState
+  internal typealias Output = NoState
 
-    internal var body: some View {
-      switch selection {
-      case .account:
-        AccountView()
-      case .zones:
-        ZoneListView()
-      case .query:
-        QueryView()
-      case .records:
-        RecordsView()
-      case .subscriptions:
-        SubscriptionsView()
-      case .pushTokens:
-        PushTokensView()
-      case .assets:
-        AssetsView()
-      case .users:
-        UsersView()
-      case nil:
-        ContentUnavailableView(
-          "Pick a section from the sidebar",
-          systemImage: "sidebar.left",
-          description: Text("Account, Zones, Records, Subscriptions, …")
-        )
-      }
-    }
+  internal static let title = "List subscriptions (pending #49)"
+  internal static let emoji = "🔔"
+  internal static let apiName = "listSubscriptions"
+
+  internal func run(input: NoState, context: PhaseContext) async throws -> NoState {
+    print("\n\(Self.emoji) \(Self.title)")
+    PendingStub.printPending(endpoint: "subscriptions/list", trackingIssue: 49)
+    return NoState()
   }
-#endif
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/LookupSubscriptionPhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/LookupSubscriptionPhase.swift
@@ -1,5 +1,5 @@
 //
-//  DetailColumnRoot.swift
+//  LookupSubscriptionPhase.swift
 //  MistDemo
 //
 //  Created by Leo Dion.
@@ -27,38 +27,22 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if canImport(SwiftUI)
-  internal import SwiftUI
+internal import Foundation
 
-  /// Routes the sidebar selection to the appropriate detail view.
-  internal struct DetailColumnRoot: View {
-    internal let selection: SidebarItem?
+/// Stub phase for `subscriptions/lookup`. Not wired into the public/private
+/// pipelines yet; `#50` flips this into a real run when the MistKit Swift
+/// wrapper lands.
+internal struct LookupSubscriptionPhase: IntegrationPhase {
+  internal typealias Input = NoState
+  internal typealias Output = NoState
 
-    internal var body: some View {
-      switch selection {
-      case .account:
-        AccountView()
-      case .zones:
-        ZoneListView()
-      case .query:
-        QueryView()
-      case .records:
-        RecordsView()
-      case .subscriptions:
-        SubscriptionsView()
-      case .pushTokens:
-        PushTokensView()
-      case .assets:
-        AssetsView()
-      case .users:
-        UsersView()
-      case nil:
-        ContentUnavailableView(
-          "Pick a section from the sidebar",
-          systemImage: "sidebar.left",
-          description: Text("Account, Zones, Records, Subscriptions, …")
-        )
-      }
-    }
+  internal static let title = "Lookup subscription (pending #50)"
+  internal static let emoji = "🔍"
+  internal static let apiName = "lookupSubscription"
+
+  internal func run(input: NoState, context: PhaseContext) async throws -> NoState {
+    print("\n\(Self.emoji) \(Self.title)")
+    PendingStub.printPending(endpoint: "subscriptions/lookup", trackingIssue: 50)
+    return NoState()
   }
-#endif
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/RegisterTokenPhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/RegisterTokenPhase.swift
@@ -1,5 +1,5 @@
 //
-//  DetailColumnRoot.swift
+//  RegisterTokenPhase.swift
 //  MistDemo
 //
 //  Created by Leo Dion.
@@ -27,38 +27,22 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if canImport(SwiftUI)
-  internal import SwiftUI
+internal import Foundation
 
-  /// Routes the sidebar selection to the appropriate detail view.
-  internal struct DetailColumnRoot: View {
-    internal let selection: SidebarItem?
+/// Stub phase for `tokens/register`. Not wired into the public/private
+/// pipelines yet; `#53` flips this into a real run when the MistKit Swift
+/// wrapper lands.
+internal struct RegisterTokenPhase: IntegrationPhase {
+  internal typealias Input = NoState
+  internal typealias Output = NoState
 
-    internal var body: some View {
-      switch selection {
-      case .account:
-        AccountView()
-      case .zones:
-        ZoneListView()
-      case .query:
-        QueryView()
-      case .records:
-        RecordsView()
-      case .subscriptions:
-        SubscriptionsView()
-      case .pushTokens:
-        PushTokensView()
-      case .assets:
-        AssetsView()
-      case .users:
-        UsersView()
-      case nil:
-        ContentUnavailableView(
-          "Pick a section from the sidebar",
-          systemImage: "sidebar.left",
-          description: Text("Account, Zones, Records, Subscriptions, …")
-        )
-      }
-    }
+  internal static let title = "Register token (pending #53)"
+  internal static let emoji = "📨"
+  internal static let apiName = "registerToken"
+
+  internal func run(input: NoState, context: PhaseContext) async throws -> NoState {
+    print("\n\(Self.emoji) \(Self.title)")
+    PendingStub.printPending(endpoint: "tokens/register", trackingIssue: 53)
+    return NoState()
   }
-#endif
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/RereferenceAssetPhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/RereferenceAssetPhase.swift
@@ -1,5 +1,5 @@
 //
-//  DetailColumnRoot.swift
+//  RereferenceAssetPhase.swift
 //  MistDemo
 //
 //  Created by Leo Dion.
@@ -27,38 +27,22 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if canImport(SwiftUI)
-  internal import SwiftUI
+internal import Foundation
 
-  /// Routes the sidebar selection to the appropriate detail view.
-  internal struct DetailColumnRoot: View {
-    internal let selection: SidebarItem?
+/// Stub phase for `assets/rereference`. Not wired into the public/private
+/// pipelines yet; `#31` flips this into a real run when the MistKit Swift
+/// wrapper lands.
+internal struct RereferenceAssetPhase: IntegrationPhase {
+  internal typealias Input = NoState
+  internal typealias Output = NoState
 
-    internal var body: some View {
-      switch selection {
-      case .account:
-        AccountView()
-      case .zones:
-        ZoneListView()
-      case .query:
-        QueryView()
-      case .records:
-        RecordsView()
-      case .subscriptions:
-        SubscriptionsView()
-      case .pushTokens:
-        PushTokensView()
-      case .assets:
-        AssetsView()
-      case .users:
-        UsersView()
-      case nil:
-        ContentUnavailableView(
-          "Pick a section from the sidebar",
-          systemImage: "sidebar.left",
-          description: Text("Account, Zones, Records, Subscriptions, …")
-        )
-      }
-    }
+  internal static let title = "Rereference asset (pending #31)"
+  internal static let emoji = "📎"
+  internal static let apiName = "rereferenceAsset"
+
+  internal func run(input: NoState, context: PhaseContext) async throws -> NoState {
+    print("\n\(Self.emoji) \(Self.title)")
+    PendingStub.printPending(endpoint: "assets/rereference", trackingIssue: 31)
+    return NoState()
   }
-#endif
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/ResolveRecordsPhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/ResolveRecordsPhase.swift
@@ -1,5 +1,5 @@
 //
-//  DetailColumnRoot.swift
+//  ResolveRecordsPhase.swift
 //  MistDemo
 //
 //  Created by Leo Dion.
@@ -27,38 +27,22 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if canImport(SwiftUI)
-  internal import SwiftUI
+internal import Foundation
 
-  /// Routes the sidebar selection to the appropriate detail view.
-  internal struct DetailColumnRoot: View {
-    internal let selection: SidebarItem?
+/// Stub phase for `records/resolve`. The pipeline does not wire this phase
+/// into `PublicDatabaseTest` / `PrivateDatabaseTest` yet — it stays available
+/// for `#41` to flip into a real run when the MistKit Swift wrapper lands.
+internal struct ResolveRecordsPhase: IntegrationPhase {
+  internal typealias Input = NoState
+  internal typealias Output = NoState
 
-    internal var body: some View {
-      switch selection {
-      case .account:
-        AccountView()
-      case .zones:
-        ZoneListView()
-      case .query:
-        QueryView()
-      case .records:
-        RecordsView()
-      case .subscriptions:
-        SubscriptionsView()
-      case .pushTokens:
-        PushTokensView()
-      case .assets:
-        AssetsView()
-      case .users:
-        UsersView()
-      case nil:
-        ContentUnavailableView(
-          "Pick a section from the sidebar",
-          systemImage: "sidebar.left",
-          description: Text("Account, Zones, Records, Subscriptions, …")
-        )
-      }
-    }
+  internal static let title = "Resolve records (pending #41)"
+  internal static let emoji = "🔗"
+  internal static let apiName = "resolveRecords"
+
+  internal func run(input: NoState, context: PhaseContext) async throws -> NoState {
+    print("\n\(Self.emoji) \(Self.title)")
+    PendingStub.printPending(endpoint: "records/resolve", trackingIssue: 41)
+    return NoState()
   }
-#endif
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/MistDemoRunner.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/MistDemoRunner.swift
@@ -65,6 +65,15 @@ public enum MistDemoRunner {
     await registry.register(TestPrivateCommand.self)
     await registry.register(DemoErrorsCommand.self)
 
+    // Pending MistKit wrappers — print "pending #N" and exit 0. Each
+    // command flips to a real implementation when its tracking issue lands.
+    await registry.register(ResolveCommand.self)
+    await registry.register(RereferenceAssetCommand.self)
+    await registry.register(ListSubscriptionsCommand.self)
+    await registry.register(LookupSubscriptionCommand.self)
+    await registry.register(CreateTokenCommand.self)
+    await registry.register(RegisterTokenCommand.self)
+
     // Parse command line arguments
     let parser = CommandLineParser()
 

--- a/Examples/MistDemo/Sources/MistDemoKit/PushTokenStatus.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/PushTokenStatus.swift
@@ -1,6 +1,6 @@
 //
-//  MistDemoApp.swift
-//  MistDemoApp
+//  PushTokenStatus.swift
+//  MistDemo
 //
 //  Created by Leo Dion.
 //  Copyright © 2026 BrightDigit.
@@ -27,14 +27,12 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-internal import MistDemoApp
-internal import SwiftUI
-
-@main
-internal struct MistDemoAppMain: AppMain {
-  // SwiftUI owns the AppDelegate's lifecycle via this adaptor; the
-  // delegate's static-weak `receiver` is wired from `CloudKitStore.init`
-  // so the OS-delivered APNs token lands back in the observable store.
-    @PlatformApplicationDelegateAdaptor(PushNotificationDelegate.self)
-    private var pushDelegate
+/// The push-token registration state surfaced to the UI. APNs requires a
+/// signed app + push entitlement; on simulators or unentitled builds the
+/// OS reports an error which the UI renders inline.
+public enum PushTokenStatus: Sendable {
+  case idle
+  case requesting
+  case registered(hexToken: String)
+  case failed(message: String)
 }

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/index.html
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/index.html
@@ -4,220 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MistKit Web Demo</title>
-    <style>
-        :root {
-            --bg: #f5f5f7;
-            --card: #ffffff;
-            --ink: #1d1d1f;
-            --muted: #6e6e73;
-            --accent: #0369a1;
-            --accent-dark: #0c4a6e;
-            --danger: #c00;
-            --danger-bg: #fdd;
-            --success-bg: #d1f5d3;
-            --success-fg: #1d5e20;
-            --border: #d0d7de;
-            --row-hover: #f0f4f8;
-            --row-selected: #dbeafe;
-        }
-        * { box-sizing: border-box; }
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            margin: 0;
-            padding: 24px;
-            background-color: var(--bg);
-            color: var(--ink);
-        }
-        .layout {
-            max-width: 1100px;
-            margin: 0 auto;
-            display: flex;
-            flex-direction: column;
-            gap: 16px;
-        }
-        .card {
-            background: var(--card);
-            border-radius: 12px;
-            padding: 24px;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
-        }
-        h1 { font-size: 24px; margin: 0 0 4px; }
-        h2 { font-size: 18px; margin: 0 0 12px; }
-        h3 { font-size: 15px; margin: 0 0 8px; }
-        p { color: var(--muted); margin: 0 0 16px; line-height: 1.5; }
-        label { display: block; font-size: 13px; font-weight: 600; margin: 12px 0 4px; }
-        input {
-            width: 100%;
-            padding: 8px 10px;
-            border: 1px solid var(--border);
-            border-radius: 6px;
-            font-size: 14px;
-            font-family: inherit;
-        }
-        button {
-            background: var(--accent);
-            color: white;
-            border: none;
-            padding: 8px 16px;
-            border-radius: 6px;
-            cursor: pointer;
-            font-size: 14px;
-            font-weight: 600;
-        }
-        button:hover:not(:disabled) { background: var(--accent-dark); }
-        button:disabled { opacity: 0.45; cursor: not-allowed; }
-        button.secondary {
-            background: transparent;
-            color: var(--ink);
-            border: 1px solid var(--border);
-            font-weight: 500;
-        }
-        button.secondary:hover:not(:disabled) {
-            background: var(--row-hover);
-        }
-        button.danger {
-            background: var(--danger);
-        }
-        button.danger:hover:not(:disabled) {
-            background: #900;
-        }
-        .status {
-            margin-top: 12px;
-            padding: 10px 12px;
-            border-radius: 8px;
-            font-size: 13px;
-            display: none;
-        }
-        .status.success { background: var(--success-bg); color: var(--success-fg); display: block; }
-        .status.error { background: var(--danger-bg); color: var(--danger); display: block; }
-        .status.loading { background: var(--row-hover); color: var(--muted); display: block; }
-        .status.loading::after {
-            content: '…';
-            display: inline-block;
-            margin-left: 4px;
-            animation: status-loading-dots 1.2s steps(4, end) infinite;
-            width: 1ch;
-            overflow: hidden;
-            vertical-align: bottom;
-        }
-        @keyframes status-loading-dots {
-            0% { width: 0; }
-            100% { width: 1ch; }
-        }
-        pre {
-            background: #0d1117;
-            color: #c9d1d9;
-            padding: 12px;
-            border-radius: 6px;
-            font-size: 12px;
-            overflow-x: auto;
-            margin: 8px 0 0;
-            max-height: 240px;
-        }
-        .mode-toggle {
-            display: flex;
-            gap: 8px;
-            margin: 12px 0 4px;
-        }
-        .mode-toggle button {
-            background: transparent;
-            color: var(--ink);
-            border: 1px solid var(--border);
-            font-weight: 500;
-        }
-        .mode-toggle button.active {
-            background: var(--accent);
-            color: white;
-            border-color: var(--accent);
-        }
-        .mode-hint { font-size: 12px; color: var(--muted); margin-top: 4px; }
-        .notes-grid {
-            display: grid;
-            grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
-            gap: 24px;
-            align-items: start;
-        }
-        @media (max-width: 820px) {
-            .notes-grid { grid-template-columns: 1fr; }
-        }
-        .table-toolbar {
-            display: flex;
-            align-items: end;
-            gap: 12px;
-            flex-wrap: wrap;
-            margin-bottom: 12px;
-        }
-        .table-toolbar label { margin: 0 0 4px; }
-        .table-toolbar .limit-field { width: 100px; }
-        .table-wrap {
-            border: 1px solid var(--border);
-            border-radius: 8px;
-            overflow: auto;
-            max-height: 480px;
-        }
-        table { width: 100%; border-collapse: collapse; font-size: 13px; }
-        th, td {
-            text-align: left;
-            padding: 8px 10px;
-            border-bottom: 1px solid var(--border);
-        }
-        th {
-            position: sticky;
-            top: 0;
-            background: var(--row-hover);
-            font-weight: 600;
-            font-size: 12px;
-            text-transform: uppercase;
-            letter-spacing: 0.04em;
-            color: var(--muted);
-        }
-        th.sortable { cursor: pointer; user-select: none; white-space: nowrap; }
-        th.sortable:hover { color: var(--accent); }
-        th.sortable.active { color: var(--accent); }
-        .sort-indicator { display: inline-block; width: 12px; margin-left: 4px; }
-        td.timestamp {
-            font-size: 12px;
-            color: var(--muted);
-            white-space: nowrap;
-        }
-        tbody tr { cursor: pointer; }
-        tbody tr:hover { background: var(--row-hover); }
-        tbody tr.selected { background: var(--row-selected); }
-        td.record-name {
-            font-family: 'SF Mono', Menlo, monospace;
-            font-size: 12px;
-            color: var(--muted);
-            max-width: 180px;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-        }
-        td.actions { width: 1%; white-space: nowrap; }
-        td.actions button { padding: 4px 10px; font-size: 12px; }
-        .empty-state {
-            padding: 24px;
-            text-align: center;
-            color: var(--muted);
-            font-size: 13px;
-        }
-        .form-actions {
-            display: flex;
-            gap: 8px;
-            margin-top: 12px;
-            flex-wrap: wrap;
-        }
-        .form-mode-label {
-            font-size: 12px;
-            color: var(--muted);
-            font-weight: 500;
-        }
-        .pre-auth { opacity: 0.5; pointer-events: none; }
-        #signin-area { margin-top: 8px; }
-        .badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; background: #eef; color: var(--accent); }
-        .badge-you { background: var(--success-bg); color: var(--success-fg); margin-left: 8px; }
-        .raw-response summary { font-size: 12px; color: var(--muted); cursor: pointer; margin-top: 12px; }
-        .raw-response[open] summary { margin-bottom: 4px; }
-    </style>
+    <link rel="stylesheet" href="styles.css">
     <script src="https://cdn.apple-cloudkit.com/ck/2/cloudkit.js" onerror="console.log('Failed to load CloudKit.js')"></script>
 </head>
 <body>
@@ -225,9 +12,9 @@
         <div class="card">
             <h1>MistKit Web Demo</h1>
             <p>
-                Authenticate with your Apple ID, then exercise the same CloudKit
-                operations through MistKit (server) or CloudKit JS (browser) and
-                compare the wire-level behavior.
+                Authenticate with your Apple ID, then exercise the v1.0.0-beta.2 CloudKit
+                surface through MistKit (server) or CloudKit JS (browser) and compare the
+                wire-level behavior side-by-side.
             </p>
 
             <h2>Backend</h2>
@@ -250,8 +37,7 @@
             <div class="mode-hint" id="db-hint">
                 Private uses the captured Apple ID web-auth token; Public uses
                 server-to-server signing on the MistKit side and the API token on
-                the CloudKit JS side. Browsers can't perform S2S signing, so
-                "MistKit + Public" is unique to the server path.
+                the CloudKit JS side.
             </div>
 
             <h2 style="margin-top: 24px;">Auth</h2>
@@ -262,8 +48,11 @@
             <div id="auth-status" class="status"></div>
         </div>
 
+        <!-- Notes CRUD (records/query, records/modify) -->
         <div class="card pre-auth" id="notes-card">
-            <h2>Notes <span class="badge" id="mode-badge">MistKit</span> <span class="badge" id="db-badge">Private</span></h2>
+            <h2>Notes <span class="badge" id="mode-badge">MistKit</span> <span class="badge" id="db-badge">Private</span>
+                <span class="endpoint-label">records/query · records/modify</span>
+            </h2>
             <div class="notes-grid">
                 <section>
                     <div class="table-toolbar">
@@ -324,732 +113,225 @@
                 </section>
             </div>
         </div>
+
+        <!-- Records lookup / changes / resolve -->
+        <div class="card pre-auth">
+            <h2>Records <span class="endpoint-label">records/lookup · records/changes · records/resolve</span></h2>
+            <div class="panel-grid">
+                <section>
+                    <h3>Lookup <span class="endpoint-label">records/lookup</span></h3>
+                    <div class="panel-row">
+                        <input id="records-lookup-input" type="text" placeholder="record name(s), comma-separated">
+                        <button id="records-lookup-btn" type="button">Lookup</button>
+                    </div>
+                    <div id="records-lookup-status" class="status"></div>
+                    <pre id="records-lookup-raw">(none yet)</pre>
+                </section>
+                <section>
+                    <h3>Changes <span class="endpoint-label">records/changes</span></h3>
+                    <div class="panel-row">
+                        <input id="records-changes-zone" type="text" placeholder="zone name (default: _defaultZone)">
+                        <input id="records-changes-token" type="text" placeholder="sync token (optional)">
+                        <button id="records-changes-btn" type="button">Fetch Changes</button>
+                    </div>
+                    <div id="records-changes-status" class="status"></div>
+                    <pre id="records-changes-raw">(none yet)</pre>
+                </section>
+                <section>
+                    <h3>Resolve <span class="endpoint-label">records/resolve <em>(MistKit pending #41 — CloudKit JS composed)</em></span></h3>
+                    <div class="panel-row">
+                        <input id="records-resolve-input" type="text" placeholder="record name or share URL">
+                        <button id="records-resolve-btn" type="button">Resolve</button>
+                    </div>
+                    <div id="records-resolve-status" class="status"></div>
+                    <pre id="records-resolve-raw">(none yet)</pre>
+                    <details class="composition">
+                        <summary>📎 CloudKit JS composition</summary>
+                        <ol>
+                            <li>Share URL → <code>container.fetchShareMetadataWithURL(url)</code></li>
+                            <li>Record name → <code>database.fetchRecords([{ recordName }])</code></li>
+                        </ol>
+                    </details>
+                </section>
+            </div>
+        </div>
+
+        <!-- Zones list / lookup / modify / changes -->
+        <div class="card pre-auth">
+            <h2>Zones <span class="endpoint-label">zones/list · zones/lookup · zones/modify · zones/changes</span></h2>
+            <div class="panel-grid">
+                <section>
+                    <h3>List <span class="endpoint-label">zones/list</span></h3>
+                    <div class="panel-row">
+                        <button id="zones-list-btn" type="button">Fetch Zones</button>
+                    </div>
+                    <div id="zones-list-status" class="status"></div>
+                    <pre id="zones-list-raw">(none yet)</pre>
+                </section>
+                <section>
+                    <h3>Lookup <span class="endpoint-label">zones/lookup</span></h3>
+                    <div class="panel-row">
+                        <input id="zones-lookup-input" type="text" placeholder="zone name(s), comma-separated">
+                        <button id="zones-lookup-btn" type="button">Lookup</button>
+                    </div>
+                    <div id="zones-lookup-status" class="status"></div>
+                    <pre id="zones-lookup-raw">(none yet)</pre>
+                </section>
+                <section>
+                    <h3>Modify <span class="endpoint-label">zones/modify</span></h3>
+                    <div class="panel-row">
+                        <input id="zones-modify-create" type="text" placeholder="create zone name">
+                        <button id="zones-modify-create-btn" type="button">Create Zone</button>
+                        <input id="zones-modify-delete" type="text" placeholder="delete zone name">
+                        <button id="zones-modify-delete-btn" class="danger" type="button">Delete Zone</button>
+                    </div>
+                    <div id="zones-modify-status" class="status"></div>
+                    <pre id="zones-modify-raw">(none yet)</pre>
+                </section>
+                <section>
+                    <h3>Changes <span class="endpoint-label">zones/changes</span></h3>
+                    <div class="panel-row">
+                        <input id="zones-changes-token" type="text" placeholder="sync token (optional)">
+                        <button id="zones-changes-btn" type="button">Fetch Changes</button>
+                    </div>
+                    <div id="zones-changes-status" class="status"></div>
+                    <pre id="zones-changes-raw">(none yet)</pre>
+                </section>
+            </div>
+        </div>
+
+        <!-- Users caller / discover / lookup -->
+        <div class="card pre-auth">
+            <h2>Users <span class="endpoint-label">users/caller · users/discover · users/lookup/email · users/lookup/id</span></h2>
+            <div class="panel-grid">
+                <section>
+                    <h3>Caller <span class="endpoint-label">users/caller</span></h3>
+                    <div class="panel-row">
+                        <button id="users-caller-btn" type="button">Fetch Caller</button>
+                    </div>
+                    <div id="users-caller-status" class="status"></div>
+                    <pre id="users-caller-raw">(none yet)</pre>
+                </section>
+                <section>
+                    <h3>Lookup by Email <span class="endpoint-label">users/lookup/email</span></h3>
+                    <div class="panel-row">
+                        <input id="users-email-input" type="email" placeholder="user@example.com">
+                        <button id="users-email-btn" type="button">Lookup</button>
+                    </div>
+                    <div id="users-email-status" class="status"></div>
+                    <pre id="users-email-raw">(none yet)</pre>
+                </section>
+                <section>
+                    <h3>Lookup by Record Name <span class="endpoint-label">users/lookup/id</span></h3>
+                    <div class="panel-row">
+                        <input id="users-id-input" type="text" placeholder="userRecordName">
+                        <button id="users-id-btn" type="button">Lookup</button>
+                    </div>
+                    <div id="users-id-status" class="status"></div>
+                    <pre id="users-id-raw">(none yet)</pre>
+                </section>
+                <section>
+                    <h3>Discover <span class="endpoint-label">users/discover (POST) <em>(CloudKit JS loops per-email)</em></span></h3>
+                    <div class="panel-row">
+                        <textarea id="users-discover-input" placeholder="one or more emails, comma-separated"></textarea>
+                        <button id="users-discover-btn" type="button">Discover</button>
+                    </div>
+                    <div id="users-discover-status" class="status"></div>
+                    <pre id="users-discover-raw">(none yet)</pre>
+                </section>
+            </div>
+        </div>
+
+        <!-- Subscriptions list / lookup -->
+        <div class="card pre-auth">
+            <h2>Subscriptions <span class="endpoint-label">subscriptions/list · subscriptions/lookup (MistKit pending #49/#50 — CloudKit JS direct)</span></h2>
+            <div class="panel-grid">
+                <section>
+                    <h3>List <span class="endpoint-label">subscriptions/list</span></h3>
+                    <div class="panel-row">
+                        <button id="subs-list-btn" type="button">Fetch All</button>
+                    </div>
+                    <div id="subs-list-status" class="status"></div>
+                    <pre id="subs-list-raw">(none yet)</pre>
+                </section>
+                <section>
+                    <h3>Lookup <span class="endpoint-label">subscriptions/lookup</span></h3>
+                    <div class="panel-row">
+                        <input id="subs-lookup-input" type="text" placeholder="subscription ID(s), comma-separated">
+                        <button id="subs-lookup-btn" type="button">Lookup</button>
+                    </div>
+                    <div id="subs-lookup-status" class="status"></div>
+                    <pre id="subs-lookup-raw">(none yet)</pre>
+                </section>
+            </div>
+        </div>
+
+        <!-- Push tokens -->
+        <div class="card pre-auth">
+            <h2>Push Tokens <span class="endpoint-label">tokens/create · tokens/register (MistKit pending #52/#53 — CloudKit JS combines via registerForNotifications)</span></h2>
+            <div class="panel-grid">
+                <section>
+                    <h3>Register for Notifications <span class="endpoint-label">CloudKit JS: container.registerForNotifications</span></h3>
+                    <div class="panel-row">
+                        <button id="tokens-register-btn" type="button">Register</button>
+                    </div>
+                    <div id="tokens-status" class="status"></div>
+                    <pre id="tokens-raw">(none yet)</pre>
+                    <details class="composition">
+                        <summary>📎 CloudKit JS composition</summary>
+                        <ol>
+                            <li><code>container.registerForNotifications()</code> — combines tokens/create + tokens/register</li>
+                            <li><code>container.addNotificationListener(cb)</code> — surfaces incoming notifications in this panel</li>
+                        </ol>
+                    </details>
+                </section>
+            </div>
+        </div>
+
+        <!-- Assets upload / rereference -->
+        <div class="card pre-auth">
+            <h2>Assets <span class="endpoint-label">assets/upload · assets/rereference (MistKit pending #31 — CloudKit JS composed)</span></h2>
+            <div class="panel-grid">
+                <section>
+                    <h3>Upload <span class="endpoint-label">assets/upload</span></h3>
+                    <p>
+                        Upload via the Notes panel above — set a title, pick a file via the
+                        record's image field. Native CKAsset uploads inline as part of saveRecords.
+                    </p>
+                </section>
+                <section>
+                    <h3>Rereference <span class="endpoint-label">assets/rereference</span></h3>
+                    <div class="panel-row">
+                        <input id="assets-source" type="text" placeholder="source record name">
+                        <input id="assets-field" type="text" placeholder="asset field (e.g. image)">
+                        <input id="assets-target" type="text" placeholder="target record name">
+                        <input id="assets-target-field" type="text" placeholder="target field (optional)">
+                        <button id="assets-rereference-btn" type="button">Rereference</button>
+                    </div>
+                    <div id="assets-status" class="status"></div>
+                    <pre id="assets-raw">(none yet)</pre>
+                    <details class="composition">
+                        <summary>📎 CloudKit JS composition</summary>
+                        <ol>
+                            <li><code>database.fetchRecords([sourceRecordName])</code> — pull source record</li>
+                            <li>Read CloudKit.Asset descriptor from source's asset field</li>
+                            <li><code>database.saveRecords([target])</code> — save target with reused asset</li>
+                        </ol>
+                    </details>
+                </section>
+            </div>
+        </div>
     </div>
 
-    <script>
-        let container = null;
-        let webAuthToken = null;
-        let authenticationInProgress = false;
-        let currentMode = 'mistkit';            // 'mistkit' | 'cloudkitjs'
-        let currentDatabase = 'private';        // 'private' | 'public'
-        // True only when the server reports server-to-server credentials are
-        // configured. CloudKit JS can hit `.public` regardless (it only needs
-        // an API token), so the picker stays usable in cloudkitjs mode even
-        // when this is false — the constraint is "MistKit + public requires
-        // S2S on the server."
-        let publicDatabaseAvailable = false;
-        let notes = [];                          // [{ recordName, title, index, created, modified, createdBy, recordChangeTag, raw }]
-        let selectedRecordName = null;
-        let authComplete = false;
-        let queryInFlight = false;
-        // Captured from the userIdentity returned by setUpAuth() so the table
-        // can flag rows whose creator (created.userRecordName from the
-        // MistKit-mode payload) matches the signed-in user.
-        let currentUserRecordName = null;
-        // Default: latest created first. The third click on the Created header
-        // still clears the sort to null, after which the next click cycles back
-        // through ascending → descending → null.
-        let currentSort = { field: '___createTime', ascending: false };
-        // Pause between a successful Create and the auto-refresh that follows.
-        // CloudKit Web Services is eventually consistent — without this pause
-        // the new record is often missing from the next list, especially on
-        // the public database.
-        const REFRESH_DELAY_MS = 1200;
-
-        const authStatusDiv = document.getElementById('auth-status');
-        const signinButton = document.getElementById('signin-button');
-        const signoutButton = document.getElementById('signout-button');
-        const notesCard = document.getElementById('notes-card');
-        const modeBadge = document.getElementById('mode-badge');
-        const dbBadge = document.getElementById('db-badge');
-        const dbPrivateBtn = document.getElementById('db-private');
-        const dbPublicBtn = document.getElementById('db-public');
-        const dbHint = document.getElementById('db-hint');
-        const tbody = document.getElementById('notes-tbody');
-        const tableStatusEl = document.getElementById('table-status');
-        const formStatusEl = document.getElementById('form-status');
-        const formHeading = document.getElementById('form-heading');
-        const formRecordName = document.getElementById('form-record-name');
-        const titleInput = document.getElementById('form-title');
-        const indexInput = document.getElementById('form-index');
-        const saveBtn = document.getElementById('save-btn');
-        const clearBtn = document.getElementById('clear-btn');
-        const deleteBtn = document.getElementById('delete-btn');
-        const refreshBtn = document.getElementById('refresh-btn');
-        const recordTypeInput = document.getElementById('record-type');
-        const queryLimitInput = document.getElementById('query-limit');
-        const rawResponseEl = document.getElementById('raw-response');
-
-        // ---- shared helpers ----
-
-        function setStatus(el, message, kind) {
-            el.className = `status ${kind || ''}`;
-            el.textContent = message;
-            if (kind) el.style.display = 'block';
-        }
-
-        function clearStatus(el) {
-            el.className = 'status';
-            el.textContent = '';
-            el.style.display = 'none';
-        }
-
-        function showRaw(value) {
-            rawResponseEl.textContent = value == null ? '(none)' : JSON.stringify(value, null, 2);
-        }
-
-        async function postJSON(path, body) {
-            const response = await fetch(path, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(body),
-            });
-            const text = await response.text();
-            let payload;
-            try { payload = text ? JSON.parse(text) : null; } catch { payload = { message: text }; }
-            if (!response.ok) {
-                const msg = (payload && payload.message) || `HTTP ${response.status}`;
-                const err = new Error(msg);
-                err.payload = payload;
-                err.status = response.status;
-                throw err;
-            }
-            return payload;
-        }
-
-        // ---- form state ----
-
-        function selectedNote() {
-            return notes.find(n => n.recordName === selectedRecordName) || null;
-        }
-
-        function refreshFormState() {
-            const note = selectedNote();
-            if (note) {
-                formHeading.textContent = 'Edit note';
-                formRecordName.textContent = `· ${note.recordName}`;
-                saveBtn.textContent = 'Save';
-                deleteBtn.disabled = false;
-            } else {
-                formHeading.textContent = 'New note';
-                formRecordName.textContent = '';
-                saveBtn.textContent = 'Create';
-                deleteBtn.disabled = true;
-            }
-        }
-
-        function clearForm() {
-            selectedRecordName = null;
-            titleInput.value = '';
-            indexInput.value = '';
-            clearStatus(formStatusEl);
-            refreshFormState();
-            renderRows();
-        }
-
-        function loadNoteIntoForm(note) {
-            selectedRecordName = note.recordName;
-            titleInput.value = note.title ?? '';
-            indexInput.value = note.index != null ? String(note.index) : '';
-            clearStatus(formStatusEl);
-            refreshFormState();
-            renderRows();
-        }
-
-        // ---- render ----
-
-        function renderRows() {
-            tbody.innerHTML = '';
-            if (notes.length === 0) {
-                const tr = document.createElement('tr');
-                const td = document.createElement('td');
-                td.colSpan = 5;
-                td.className = 'empty-state';
-                td.textContent = 'No notes — Refresh or Create one.';
-                tr.appendChild(td);
-                tbody.appendChild(tr);
-                return;
-            }
-            for (const note of notes) {
-                const tr = document.createElement('tr');
-                tr.title = note.recordName;
-                if (note.recordName === selectedRecordName) tr.classList.add('selected');
-                tr.addEventListener('click', (e) => {
-                    if (e.target.closest('button')) return;
-                    loadNoteIntoForm(note);
-                });
-
-                const titleTd = document.createElement('td');
-                titleTd.textContent = note.title ?? '';
-                if (note.createdBy && note.createdBy === currentUserRecordName) {
-                    const youBadge = document.createElement('span');
-                    youBadge.className = 'badge badge-you';
-                    youBadge.textContent = 'You';
-                    youBadge.title = `Created by ${note.createdBy}`;
-                    titleTd.appendChild(youBadge);
-                }
-                tr.appendChild(titleTd);
-
-                const indexTd = document.createElement('td');
-                indexTd.textContent = note.index != null ? String(note.index) : '';
-                tr.appendChild(indexTd);
-
-                const createdTd = document.createElement('td');
-                createdTd.className = 'timestamp';
-                createdTd.textContent = formatTimestamp(note.created);
-                if (note.created) createdTd.title = note.created.toISOString();
-                tr.appendChild(createdTd);
-
-                const modifiedTd = document.createElement('td');
-                modifiedTd.className = 'timestamp';
-                modifiedTd.textContent = formatTimestamp(note.modified);
-                if (note.modified) modifiedTd.title = note.modified.toISOString();
-                tr.appendChild(modifiedTd);
-
-                const actionsTd = document.createElement('td');
-                actionsTd.className = 'actions';
-                const delBtn = document.createElement('button');
-                delBtn.className = 'danger';
-                delBtn.type = 'button';
-                delBtn.textContent = 'Delete';
-                // No confirm() — the demo prioritizes hands-on iteration; the
-                // raw response panel below the form shows the wire payload of
-                // every operation so accidents stay visible.
-                delBtn.addEventListener('click', () => deleteNote(note));
-                actionsTd.appendChild(delBtn);
-                tr.appendChild(actionsTd);
-
-                tbody.appendChild(tr);
-            }
-        }
-
-        function refreshSortIndicators() {
-            document.querySelectorAll('th.sortable').forEach(th => {
-                const field = th.dataset.sortField;
-                const isActive = currentSort && currentSort.field === field;
-                th.classList.toggle('active', isActive);
-                const indicator = th.querySelector('.sort-indicator');
-                if (isActive) {
-                    indicator.textContent = currentSort.ascending ? '↑' : '↓';
-                } else {
-                    indicator.textContent = '';
-                }
-            });
-        }
-
-        document.querySelectorAll('th.sortable').forEach(th => {
-            th.addEventListener('click', () => {
-                const field = th.dataset.sortField;
-                if (currentSort && currentSort.field === field) {
-                    if (currentSort.ascending) {
-                        currentSort = { field, ascending: false };
-                    } else {
-                        currentSort = null;            // third click clears
-                    }
-                } else {
-                    currentSort = { field, ascending: true };
-                }
-                refreshSortIndicators();
-                if (authComplete) queryNotes();
-            });
-        });
-
-        // ---- backend normalization ----
-
-        // Project the MistKit-mode `/api/records/query` payload (which mirrors
-        // CloudKit Web Services on the wire) and the CloudKit JS response
-        // into the single shape the table renders from.
-        //
-        // Timestamps:
-        //   - MistKit-mode wire: `created.timestamp` / `modified.timestamp`
-        //     are epoch-millis numbers (encoded with WebJSON's
-        //     .millisecondsSince1970 strategy on the server).
-        //   - CloudKit JS: `created` / `modified` are typed Date objects.
-        // The browser normalizes both into a Date instance.
-        function normalizeRecords(payload) {
-            const list = (payload && payload.records) || [];
-            return list.map(record => {
-                const fields = record.fields || {};
-                const titleField = fields.title;
-                const indexField = fields.index;
-                return {
-                    recordName: record.recordName,
-                    recordType: record.recordType,
-                    recordChangeTag: record.recordChangeTag,
-                    title: titleField && (titleField.value ?? titleField),
-                    index: indexField && Number(indexField.value ?? indexField),
-                    created: toDate(record.created),
-                    modified: toDate(record.modified),
-                    // MistKit-mode wire: `created` is { timestamp, userRecordName }.
-                    // CloudKit JS: `created` is a bare Date object — no creator
-                    // available on the record. Falls back to null in that case;
-                    // the table treats it as "unknown".
-                    createdBy: extractUserRecordName(record.created),
-                    raw: record,
-                };
-            });
-        }
-
-        function extractUserRecordName(value) {
-            if (value == null || typeof value !== 'object' || value instanceof Date) {
-                return null;
-            }
-            return value.userRecordName ?? null;
-        }
-
-        function toDate(value) {
-            if (value == null) return null;
-            // CloudKit JS shape: a Date object directly on record.created/modified,
-            // OR an envelope { timestamp: Date|number, userRecordName }.
-            if (value instanceof Date) return value;
-            if (typeof value === 'number') return new Date(value);
-            if (typeof value === 'object') {
-                const inner = value.timestamp;
-                if (inner == null) return null;
-                if (inner instanceof Date) return inner;
-                if (typeof inner === 'number') return new Date(inner);
-                if (typeof inner === 'string') {
-                    const parsed = Date.parse(inner);
-                    return isNaN(parsed) ? null : new Date(parsed);
-                }
-            }
-            return null;
-        }
-
-        function formatTimestamp(date) {
-            if (!date) return '—';
-            return date.toLocaleString(undefined, {
-                dateStyle: 'short', timeStyle: 'short',
-            });
-        }
-
-        function ckJsDatabase() {
-            return currentDatabase === 'public'
-                ? container.publicCloudDatabase
-                : container.privateCloudDatabase;
-        }
-
-        function buildFields() {
-            const out = {};
-            const title = titleInput.value.trim();
-            if (title.length > 0) out.title = title;
-            const indexRaw = indexInput.value.trim();
-            if (indexRaw.length > 0) {
-                const parsed = Number(indexRaw);
-                if (!isFinite(parsed)) {
-                    throw new Error('Index must be a number.');
-                }
-                out.index = parsed;
-            }
-            return out;
-        }
-
-        function ckJsFields(fields) {
-            const wrapped = {};
-            for (const [k, v] of Object.entries(fields)) {
-                wrapped[k] = { value: v };
-            }
-            return wrapped;
-        }
-
-        // ---- operations ----
-
-        async function queryNotes() {
-            if (queryInFlight) return;
-            const recordType = recordTypeInput.value.trim();
-            const limit = parseInt(queryLimitInput.value, 10);
-            queryInFlight = true;
-            setQueryControlsDisabled(true);
-            const dbLabel = currentDatabase === 'public' ? 'public' : 'private';
-            const modeLabel = currentMode === 'mistkit' ? 'MistKit' : 'CloudKit JS';
-            setStatus(tableStatusEl, `Loading ${dbLabel} via ${modeLabel}`, 'loading');
-            try {
-                let payload;
-                if (currentMode === 'mistkit') {
-                    payload = await postJSON('/api/records/query', {
-                        recordType,
-                        database: currentDatabase,
-                        limit: isFinite(limit) ? limit : undefined,
-                        sortBy: currentSort
-                            ? [{ field: currentSort.field, ascending: currentSort.ascending }]
-                            : undefined,
-                    });
-                } else {
-                    const query = { recordType };
-                    if (currentSort) {
-                        query.sortBy = [{
-                            fieldName: currentSort.field,
-                            ascending: currentSort.ascending,
-                        }];
-                    }
-                    payload = await ckJsDatabase().performQuery(query, {
-                        resultsLimit: isFinite(limit) ? limit : undefined,
-                    });
-                    if (payload && payload.hasErrors && payload.errors.length) {
-                        throw new Error(payload.errors[0].reason || 'CloudKit JS query failed');
-                    }
-                }
-                notes = normalizeRecords(payload);
-                if (selectedRecordName && !notes.some(n => n.recordName === selectedRecordName)) {
-                    clearForm();
-                } else {
-                    refreshFormState();
-                    renderRows();
-                }
-                showRaw(payload);
-                setStatus(tableStatusEl, `Loaded ${notes.length} record${notes.length === 1 ? '' : 's'}.`, 'success');
-            } catch (error) {
-                setStatus(tableStatusEl, `Query failed: ${error.message}`, 'error');
-                showRaw(error.payload || { message: error.message });
-            } finally {
-                queryInFlight = false;
-                setQueryControlsDisabled(false);
-                // Re-evaluate the picker so the public-availability gate
-                // (which writes to the same buttons we just re-enabled) wins.
-                refreshDatabasePicker();
-            }
-        }
-
-        function setQueryControlsDisabled(disabled) {
-            const ids = [
-                'refresh-btn', 'db-private', 'db-public',
-                'mode-mistkit', 'mode-cloudkitjs',
-                'save-btn', 'delete-btn',
-            ];
-            for (const id of ids) {
-                const el = document.getElementById(id);
-                if (el) el.disabled = disabled;
-            }
-        }
-
-        async function saveNote() {
-            let fields;
-            try {
-                fields = buildFields();
-            } catch (error) {
-                setStatus(formStatusEl, error.message, 'error');
-                return;
-            }
-            if (Object.keys(fields).length === 0) {
-                setStatus(formStatusEl, 'Provide a title or index.', 'error');
-                return;
-            }
-            const recordType = recordTypeInput.value.trim();
-            const note = selectedNote();
-            const isUpdate = note != null;
-            const label = isUpdate ? 'Update' : 'Create';
-            clearStatus(formStatusEl);
-            try {
-                let payload;
-                if (currentMode === 'mistkit') {
-                    if (isUpdate) {
-                        payload = await postJSON('/api/records/update', {
-                            recordType,
-                            database: currentDatabase,
-                            recordName: note.recordName,
-                            fields,
-                            recordChangeTag: note.recordChangeTag,
-                        });
-                    } else {
-                        payload = await postJSON('/api/records/create', {
-                            recordType,
-                            database: currentDatabase,
-                            fields,
-                        });
-                    }
-                } else {
-                    const record = { recordType, fields: ckJsFields(fields) };
-                    if (isUpdate) {
-                        record.recordName = note.recordName;
-                        record.recordChangeTag = note.recordChangeTag;
-                    }
-                    payload = await ckJsDatabase().saveRecords([record]);
-                    if (payload && payload.hasErrors && payload.errors.length) {
-                        throw new Error(payload.errors[0].reason || 'CloudKit JS save failed');
-                    }
-                }
-                showRaw(payload);
-                setStatus(formStatusEl, `${label} succeeded.`, 'success');
-                if (!isUpdate) clearForm();
-                if (!isUpdate) {
-                    // Public-DB writes routinely take a beat to show up in the
-                    // next list query. Pause once with a visible status so the
-                    // user understands why the table doesn't refresh instantly.
-                    setStatus(
-                        formStatusEl,
-                        `Created — waiting ${REFRESH_DELAY_MS}ms for CloudKit to settle`,
-                        'loading'
-                    );
-                    await new Promise(r => setTimeout(r, REFRESH_DELAY_MS));
-                }
-                await queryNotes();
-            } catch (error) {
-                setStatus(formStatusEl, `${label} failed: ${error.message}`, 'error');
-                showRaw(error.payload || { message: error.message });
-            }
-        }
-
-        // statusEl defaults to tableStatusEl: per-row Delete buttons live in
-        // the table, so feedback belongs above the table. The form panel's
-        // Delete button passes formStatusEl explicitly to keep its status
-        // alongside the form it acts on.
-        async function deleteNote(note, statusEl = tableStatusEl) {
-            clearStatus(statusEl);
-            try {
-                let payload;
-                if (currentMode === 'mistkit') {
-                    payload = await postJSON('/api/records/delete', {
-                        recordType: note.recordType,
-                        database: currentDatabase,
-                        recordName: note.recordName,
-                        recordChangeTag: note.recordChangeTag,
-                    });
-                } else {
-                    payload = await ckJsDatabase().deleteRecords([{ recordName: note.recordName }]);
-                    if (payload && payload.hasErrors && payload.errors.length) {
-                        throw new Error(payload.errors[0].reason || 'CloudKit JS delete failed');
-                    }
-                }
-                showRaw(payload);
-                setStatus(statusEl, `Deleted ${note.recordName}.`, 'success');
-                if (note.recordName === selectedRecordName) clearForm();
-                await queryNotes();
-            } catch (error) {
-                setStatus(statusEl, `Delete failed: ${error.message}`, 'error');
-                showRaw(error.payload || { message: error.message });
-            }
-        }
-
-        // ---- mode toggle ----
-
-        document.getElementById('mode-mistkit').addEventListener('click', () => setMode('mistkit'));
-        document.getElementById('mode-cloudkitjs').addEventListener('click', () => setMode('cloudkitjs'));
-
-        function setMode(mode) {
-            if (mode === currentMode) return;
-            currentMode = mode;
-            const mistKitBtn = document.getElementById('mode-mistkit');
-            const cloudKitJsBtn = document.getElementById('mode-cloudkitjs');
-            mistKitBtn.classList.toggle('active', mode === 'mistkit');
-            cloudKitJsBtn.classList.toggle('active', mode === 'cloudkitjs');
-            modeBadge.textContent = mode === 'mistkit' ? 'MistKit' : 'CloudKit JS';
-            // Switching to MistKit while sitting on Public is only valid when
-            // the server holds S2S material. If not, drop back to Private so
-            // the user doesn't post requests that will 500 server-side.
-            refreshDatabasePicker();
-            if (authComplete) queryNotes();
-        }
-
-        // ---- database toggle ----
-
-        dbPrivateBtn.addEventListener('click', () => setDatabase('private'));
-        dbPublicBtn.addEventListener('click', () => setDatabase('public'));
-
-        function setDatabase(database) {
-            if (database === currentDatabase) return;
-            if (database === 'public' && !isPublicAllowedForCurrentMode()) {
-                // Defensive — button should already be disabled in this case.
-                return;
-            }
-            currentDatabase = database;
-            refreshDatabasePicker();
-            if (authComplete) queryNotes();
-        }
-
-        function isPublicAllowedForCurrentMode() {
-            // CloudKit JS can talk to public from the browser regardless of
-            // server S2S credentials; MistKit + public requires the server to
-            // hold the key pair.
-            return currentMode === 'cloudkitjs' || publicDatabaseAvailable;
-        }
-
-        function refreshDatabasePicker() {
-            const publicAllowed = isPublicAllowedForCurrentMode();
-            dbPublicBtn.disabled = !publicAllowed;
-            if (!publicAllowed && currentDatabase === 'public') {
-                currentDatabase = 'private';
-            }
-            dbPrivateBtn.classList.toggle('active', currentDatabase === 'private');
-            dbPublicBtn.classList.toggle('active', currentDatabase === 'public');
-            dbBadge.textContent = currentDatabase === 'public' ? 'Public' : 'Private';
-            if (!publicDatabaseAvailable && currentMode === 'mistkit') {
-                dbHint.textContent =
-                    'MistKit + Public requires server-to-server credentials ' +
-                    '(CLOUDKIT_KEY_ID + CLOUDKIT_PRIVATE_KEY[_PATH]). ' +
-                    'Restart the server with those set to enable Public on this side.';
-            } else if (currentMode === 'mistkit' && currentDatabase === 'public') {
-                dbHint.textContent =
-                    'Heads-up: on MistKit + Public, records you write are owned ' +
-                    'by the server-to-server key, not your iCloud user — so they ' +
-                    'won’t carry a "You" badge. The badge tracks your iCloud ' +
-                    'identity, which only appears on records written via ' +
-                    'CloudKit JS or via the web-auth flow on the private database.';
-            } else {
-                dbHint.textContent =
-                    'Private uses the captured Apple ID web-auth token; Public ' +
-                    'uses server-to-server signing on the MistKit side and the ' +
-                    'API token on the CloudKit JS side. Browsers can’t ' +
-                    'perform S2S signing, so "MistKit + Public" is unique to ' +
-                    'the server path.';
-            }
-        }
-
-        // ---- form wiring ----
-
-        saveBtn.addEventListener('click', saveNote);
-        clearBtn.addEventListener('click', clearForm);
-        deleteBtn.addEventListener('click', () => {
-            const note = selectedNote();
-            if (note) deleteNote(note, formStatusEl);
-        });
-        refreshBtn.addEventListener('click', queryNotes);
-
-        // ---- auth flow ----
-
-        function setAuthed(authed) {
-            authComplete = authed;
-            notesCard.classList.toggle('pre-auth', !authed);
-            signoutButton.style.display = authed ? 'inline-block' : 'none';
-        }
-
-        async function loadServerConfig() {
-            const response = await fetch('/api/config');
-            if (!response.ok) throw new Error('Failed to load server config: ' + response.status);
-            return response.json();
-        }
-
-        async function pollWebAuthToken() {
-            const pollIntervalMs = 250;
-            const pollDeadlineMs = 10_000;
-            const pollStart = Date.now();
-            return new Promise((resolve, reject) => {
-                const handle = setInterval(() => {
-                    const token = container?._auth?._ckSession;
-                    if (token) {
-                        clearInterval(handle);
-                        resolve(token);
-                        return;
-                    }
-                    if (Date.now() - pollStart >= pollDeadlineMs) {
-                        clearInterval(handle);
-                        reject(new Error('Timeout waiting for web auth token'));
-                    }
-                }, pollIntervalMs);
-            });
-        }
-
-        async function postAuthenticate(userIdentity, token) {
-            const response = await fetch('/api/authenticate', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    sessionToken: token,
-                    userRecordName: userIdentity.userRecordName,
-                }),
-            });
-            if (!response.ok) {
-                throw new Error(`HTTP ${response.status}`);
-            }
-            return response.status;
-        }
-
-        function renderTokenDisplay(token) {
-            notesCard.style.display = 'none';
-            document.getElementById('signin-area').style.display = 'none';
-            const card = document.createElement('div');
-            card.className = 'card';
-            card.innerHTML = `
-                <h2>Web Auth Token captured</h2>
-                <p>Use this token for command-line CloudKit API access:</p>
-                <pre style="user-select: all; padding: 12px; background: #f6f8fa; border-radius: 6px; word-break: break-all; white-space: pre-wrap;">${token}</pre>
-                <p>The server has shut down — you can close this window.</p>
-            `;
-            document.querySelector('.layout').appendChild(card);
-        }
-
-        async function handleAuthentication(userIdentity) {
-            if (authenticationInProgress) return;
-            authenticationInProgress = true;
-            currentUserRecordName = userIdentity?.userRecordName ?? null;
-            setStatus(authStatusDiv, 'Capturing web auth token...', 'success');
-            try {
-                const token = await pollWebAuthToken();
-                webAuthToken = token;
-                const status = await postAuthenticate(userIdentity, token);
-                if (status === 205) {
-                    setStatus(authStatusDiv, 'Authentication complete.', 'success');
-                    renderTokenDisplay(token);
-                } else {
-                    setStatus(authStatusDiv, `Authenticated as ${userIdentity.userRecordName}.`, 'success');
-                    setAuthed(true);
-                    queryNotes();
-                }
-            } catch (error) {
-                setStatus(authStatusDiv, `Authentication failed: ${error.message}`, 'error');
-            } finally {
-                authenticationInProgress = false;
-            }
-        }
-
-        signoutButton.addEventListener('click', async () => {
-            try {
-                await container.signOut();
-                webAuthToken = null;
-                currentUserRecordName = null;
-                setAuthed(false);
-                notes = [];
-                clearForm();
-                setStatus(authStatusDiv, 'Signed out.', 'success');
-            } catch (error) {
-                setStatus(authStatusDiv, 'Sign out failed: ' + error.message, 'error');
-            }
-        });
-
-        async function initializeCloudKit() {
-            try {
-                if (typeof CloudKit === 'undefined') {
-                    throw new Error('CloudKit.js failed to load');
-                }
-                const serverConfig = await loadServerConfig();
-                publicDatabaseAvailable = !!serverConfig.publicDatabaseAvailable;
-                refreshDatabasePicker();
-                CloudKit.configure({
-                    containers: [{
-                        containerIdentifier: serverConfig.containerIdentifier,
-                        apiTokenAuth: {
-                            apiToken: serverConfig.apiToken,
-                            persist: true,
-                            signInButton: { id: 'signin-button', theme: 'black' },
-                        },
-                        environment: serverConfig.environment || 'development',
-                    }],
-                });
-                container = CloudKit.getDefaultContainer();
-                const userIdentity = await container.setUpAuth();
-                if (userIdentity) {
-                    setStatus(authStatusDiv, 'Already signed in. Capturing token...', 'success');
-                    await handleAuthentication(userIdentity);
-                } else {
-                    setStatus(authStatusDiv, 'Click "Sign In with Apple ID" to authenticate.', 'success');
-                }
-                container.whenUserSignsIn().then((identity) => handleAuthentication(identity));
-                container.whenUserSignsOut().then(() => {
-                    webAuthToken = null;
-                    currentUserRecordName = null;
-                    setAuthed(false);
-                    notes = [];
-                    clearForm();
-                    setStatus(authStatusDiv, 'Signed out.', 'success');
-                });
-            } catch (error) {
-                setStatus(authStatusDiv, 'CloudKit setup failed: ' + error.message, 'error');
-            }
-        }
-
-        refreshFormState();
-        refreshDatabasePicker();
-        refreshSortIndicators();
-        initializeCloudKit();
-    </script>
+    <script src="js/app.js"></script>
+    <script src="js/mode.js"></script>
+    <script src="js/pending.js"></script>
+    <script src="js/auth.js"></script>
+    <script src="js/records.js"></script>
+    <script src="js/zones.js"></script>
+    <script src="js/subscriptions.js"></script>
+    <script src="js/tokens.js"></script>
+    <script src="js/assets.js"></script>
+    <script src="js/users.js"></script>
 </body>
 </html>

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/index.html
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/index.html
@@ -166,7 +166,20 @@
                         <button id="zones-list-btn" type="button">Fetch Zones</button>
                     </div>
                     <div id="zones-list-status" class="status"></div>
-                    <pre id="zones-list-raw">(none yet)</pre>
+                    <div class="table-wrap">
+                        <table>
+                            <thead>
+                                <tr><th>Zone Name</th><th>Owner</th><th>Atomic</th></tr>
+                            </thead>
+                            <tbody id="zones-list-tbody">
+                                <tr><td colspan="3" class="empty-state">No zones loaded — click Fetch Zones.</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <details class="raw-response">
+                        <summary>Last raw response</summary>
+                        <pre id="zones-list-raw">(none yet)</pre>
+                    </details>
                 </section>
                 <section>
                     <h3>Lookup <span class="endpoint-label">zones/lookup</span></h3>
@@ -244,7 +257,7 @@
 
         <!-- Subscriptions list / lookup -->
         <div class="card pre-auth">
-            <h2>Subscriptions <span class="endpoint-label">subscriptions/list · subscriptions/lookup (MistKit pending #49/#50 — CloudKit JS direct)</span></h2>
+            <h2>Subscriptions <span class="endpoint-label">subscriptions/list · subscriptions/lookup · subscriptions/modify (MistKit pending #49/#50/#51 — CloudKit JS direct)</span></h2>
             <div class="panel-grid">
                 <section>
                     <h3>List <span class="endpoint-label">subscriptions/list</span></h3>
@@ -252,7 +265,20 @@
                         <button id="subs-list-btn" type="button">Fetch All</button>
                     </div>
                     <div id="subs-list-status" class="status"></div>
-                    <pre id="subs-list-raw">(none yet)</pre>
+                    <div class="table-wrap">
+                        <table>
+                            <thead>
+                                <tr><th>Subscription ID</th><th>Type</th><th>Record Type</th><th>Zone</th></tr>
+                            </thead>
+                            <tbody id="subs-list-tbody">
+                                <tr><td colspan="4" class="empty-state">No subscriptions loaded — click Fetch All.</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <details class="raw-response">
+                        <summary>Last raw response</summary>
+                        <pre id="subs-list-raw">(none yet)</pre>
+                    </details>
                 </section>
                 <section>
                     <h3>Lookup <span class="endpoint-label">subscriptions/lookup</span></h3>
@@ -262,6 +288,53 @@
                     </div>
                     <div id="subs-lookup-status" class="status"></div>
                     <pre id="subs-lookup-raw">(none yet)</pre>
+                </section>
+                <section>
+                    <h3>Create <span class="endpoint-label">subscriptions/modify <em>(MistKit pending #51 — CloudKit JS direct)</em></span></h3>
+                    <div class="panel-row">
+                        <select id="subs-create-type">
+                            <option value="query">query</option>
+                            <option value="zone">zone</option>
+                        </select>
+                        <input id="subs-create-id" type="text" placeholder="subscription ID (optional)">
+                    </div>
+                    <div class="panel-row" id="subs-create-query-fields">
+                        <label class="field-label">Record type
+                            <select id="subs-create-record-type">
+                                <option value="Note">Note</option>
+                            </select>
+                        </label>
+                        <fieldset class="fires-on">
+                            <legend>Fires on</legend>
+                            <label><input type="checkbox" class="subs-fires-on" value="create" checked> create</label>
+                            <label><input type="checkbox" class="subs-fires-on" value="update" checked> update</label>
+                            <label><input type="checkbox" class="subs-fires-on" value="delete" checked> delete</label>
+                        </fieldset>
+                    </div>
+                    <div class="panel-row" id="subs-create-zone-fields" style="display: none;">
+                        <input id="subs-create-zone" type="text" placeholder="zone name (e.g. Articles)">
+                    </div>
+                    <div class="panel-row">
+                        <button id="subs-create-btn" type="button">Create Subscription</button>
+                    </div>
+                    <div id="subs-create-status" class="status"></div>
+                    <pre id="subs-create-raw">(none yet)</pre>
+                    <details class="composition">
+                        <summary>📎 CloudKit JS shape</summary>
+                        <ol>
+                            <li>query → <code>{ subscriptionType: 'query', firesOn, query: { recordType } }</code></li>
+                            <li>zone → <code>{ subscriptionType: 'zone', zoneID: { zoneName } }</code></li>
+                        </ol>
+                    </details>
+                </section>
+                <section>
+                    <h3>Delete <span class="endpoint-label">subscriptions/modify <em>(MistKit pending #51 — CloudKit JS direct)</em></span></h3>
+                    <div class="panel-row">
+                        <input id="subs-delete-input" type="text" placeholder="subscription ID(s), comma-separated">
+                        <button id="subs-delete-btn" class="danger" type="button">Delete Subscription</button>
+                    </div>
+                    <div id="subs-delete-status" class="status"></div>
+                    <pre id="subs-delete-raw">(none yet)</pre>
                 </section>
             </div>
         </div>

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/js/app.js
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/js/app.js
@@ -60,8 +60,24 @@ function clearStatus(el) {
     el.style.display = 'none';
 }
 
+// JSON.stringify replacer that renders Dates as ISO strings and drops
+// circular references. Some CloudKit JS results (e.g. the value resolved
+// by `registerForNotifications`) hold cyclic structures that would
+// otherwise throw "JSON.stringify cannot serialize cyclic structures".
+function safeReplacer() {
+    const seen = new WeakSet();
+    return (_key, value) => {
+        if (value instanceof Date) return value.toISOString();
+        if (value && typeof value === 'object') {
+            if (seen.has(value)) return '[Circular]';
+            seen.add(value);
+        }
+        return value;
+    };
+}
+
 function showRaw(value) {
-    rawResponseEl.textContent = value == null ? '(none)' : JSON.stringify(value, null, 2);
+    rawResponseEl.textContent = value == null ? '(none)' : JSON.stringify(value, safeReplacer(), 2);
 }
 
 // Render an arbitrary payload to a specific <pre> element (used by all
@@ -71,7 +87,36 @@ function renderRaw(el, value) {
     if (!el) return;
     el.textContent = value == null
         ? '(none)'
-        : JSON.stringify(value, (_k, v) => (v instanceof Date ? v.toISOString() : v), 2);
+        : JSON.stringify(value, safeReplacer(), 2);
+}
+
+// Render a simple read-only table of `items` into `tbody`. `getters` is an
+// array of `item => cellValue` functions, one per column — its length must
+// match the table's column count. Used by the Zones and Subscriptions list
+// panels to present results as a table instead of raw JSON.
+function renderListTable(tbody, getters, items, emptyMessage) {
+    if (!tbody) return;
+    tbody.innerHTML = '';
+    if (!items || items.length === 0) {
+        const tr = document.createElement('tr');
+        const td = document.createElement('td');
+        td.colSpan = getters.length;
+        td.className = 'empty-state';
+        td.textContent = emptyMessage;
+        tr.appendChild(td);
+        tbody.appendChild(tr);
+        return;
+    }
+    for (const item of items) {
+        const tr = document.createElement('tr');
+        for (const get of getters) {
+            const td = document.createElement('td');
+            const value = get(item);
+            td.textContent = (value == null || value === '') ? '—' : String(value);
+            tr.appendChild(td);
+        }
+        tbody.appendChild(tr);
+    }
 }
 
 // Run an operation and pipe its progress through the panel's status div

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/js/app.js
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/js/app.js
@@ -1,0 +1,526 @@
+// Shared globals + helpers for the MistDemo web page.
+//
+// Each operation module (records.js, zones.js, etc.) reads `currentMode` /
+// `currentDatabase` set here, and calls these helpers to render output to
+// per-panel `<div class="status">` and `<pre>` elements. This module also
+// owns the existing Notes CRUD panel — it's the originating shape every
+// new panel mirrors.
+
+let container = null;
+let webAuthToken = null;
+let authenticationInProgress = false;
+let currentMode = 'mistkit';            // 'mistkit' | 'cloudkitjs'
+let currentDatabase = 'private';        // 'private' | 'public'
+let publicDatabaseAvailable = false;
+let notes = [];
+let selectedRecordName = null;
+let authComplete = false;
+let queryInFlight = false;
+let currentUserRecordName = null;
+let currentSort = { field: '___createTime', ascending: false };
+const REFRESH_DELAY_MS = 1200;
+
+const authStatusDiv = document.getElementById('auth-status');
+const signinButton = document.getElementById('signin-button');
+const signoutButton = document.getElementById('signout-button');
+const notesCard = document.getElementById('notes-card');
+const modeBadge = document.getElementById('mode-badge');
+const dbBadge = document.getElementById('db-badge');
+const dbPrivateBtn = document.getElementById('db-private');
+const dbPublicBtn = document.getElementById('db-public');
+const dbHint = document.getElementById('db-hint');
+const tbody = document.getElementById('notes-tbody');
+const tableStatusEl = document.getElementById('table-status');
+const formStatusEl = document.getElementById('form-status');
+const formHeading = document.getElementById('form-heading');
+const formRecordName = document.getElementById('form-record-name');
+const titleInput = document.getElementById('form-title');
+const indexInput = document.getElementById('form-index');
+const saveBtn = document.getElementById('save-btn');
+const clearBtn = document.getElementById('clear-btn');
+const deleteBtn = document.getElementById('delete-btn');
+const refreshBtn = document.getElementById('refresh-btn');
+const recordTypeInput = document.getElementById('record-type');
+const queryLimitInput = document.getElementById('query-limit');
+const rawResponseEl = document.getElementById('raw-response');
+
+// ---- shared helpers ----
+
+function setStatus(el, message, kind) {
+    if (!el) return;
+    el.className = `status ${kind || ''}`;
+    el.textContent = message;
+    if (kind) el.style.display = 'block';
+}
+
+function clearStatus(el) {
+    if (!el) return;
+    el.className = 'status';
+    el.textContent = '';
+    el.style.display = 'none';
+}
+
+function showRaw(value) {
+    rawResponseEl.textContent = value == null ? '(none)' : JSON.stringify(value, null, 2);
+}
+
+// Render an arbitrary payload to a specific <pre> element (used by all
+// new operation panels). Mirrors `showRaw` but takes the target element
+// explicitly.
+function renderRaw(el, value) {
+    if (!el) return;
+    el.textContent = value == null
+        ? '(none)'
+        : JSON.stringify(value, (_k, v) => (v instanceof Date ? v.toISOString() : v), 2);
+}
+
+// Run an operation and pipe its progress through the panel's status div
+// + raw `<pre>`. Common shape across every new panel:
+//   - "loading…" while in-flight
+//   - success body rendered as JSON in the pre
+//   - errors rendered as red banner + payload (or message) in the pre
+async function runPanelOperation({ statusEl, rawEl, label, fn }) {
+    setStatus(statusEl, `${label}…`, 'loading');
+    try {
+        const result = await fn();
+        renderRaw(rawEl, result);
+        setStatus(statusEl, `${label} succeeded.`, 'success');
+        return result;
+    } catch (error) {
+        const payload = error && error.payload ? error.payload : { message: error.message };
+        renderRaw(rawEl, payload);
+        const msg = (error && error.message) || 'Unknown error';
+        setStatus(statusEl, `${label} failed: ${msg}`, 'error');
+        return null;
+    }
+}
+
+async function postJSON(path, body) {
+    const init = { headers: { 'Content-Type': 'application/json' } };
+    if (body !== undefined) {
+        init.method = 'POST';
+        init.body = JSON.stringify(body);
+    }
+    const response = await fetch(path, init);
+    const text = await response.text();
+    let payload;
+    try { payload = text ? JSON.parse(text) : null; } catch { payload = { message: text }; }
+    if (!response.ok) {
+        const msg = (payload && (payload.message || payload.error)) || `HTTP ${response.status}`;
+        const err = new Error(msg);
+        err.payload = payload;
+        err.status = response.status;
+        throw err;
+    }
+    return payload;
+}
+
+async function fetchJSON(path) {
+    const response = await fetch(path);
+    const text = await response.text();
+    let payload;
+    try { payload = text ? JSON.parse(text) : null; } catch { payload = { message: text }; }
+    if (!response.ok) {
+        const msg = (payload && (payload.message || payload.error)) || `HTTP ${response.status}`;
+        const err = new Error(msg);
+        err.payload = payload;
+        err.status = response.status;
+        throw err;
+    }
+    return payload;
+}
+
+function ckJsDatabase() {
+    return currentDatabase === 'public'
+        ? container.publicCloudDatabase
+        : container.privateCloudDatabase;
+}
+
+function ckJsContainer() {
+    return container;
+}
+
+function csv(value) {
+    return (value || '')
+        .split(',')
+        .map(s => s.trim())
+        .filter(s => s.length > 0);
+}
+
+// ---- form state for Notes CRUD ----
+
+function selectedNote() {
+    return notes.find(n => n.recordName === selectedRecordName) || null;
+}
+
+function refreshFormState() {
+    const note = selectedNote();
+    if (note) {
+        formHeading.textContent = 'Edit note';
+        formRecordName.textContent = `· ${note.recordName}`;
+        saveBtn.textContent = 'Save';
+        deleteBtn.disabled = false;
+    } else {
+        formHeading.textContent = 'New note';
+        formRecordName.textContent = '';
+        saveBtn.textContent = 'Create';
+        deleteBtn.disabled = true;
+    }
+}
+
+function clearForm() {
+    selectedRecordName = null;
+    titleInput.value = '';
+    indexInput.value = '';
+    clearStatus(formStatusEl);
+    refreshFormState();
+    renderRows();
+}
+
+function loadNoteIntoForm(note) {
+    selectedRecordName = note.recordName;
+    titleInput.value = note.title ?? '';
+    indexInput.value = note.index != null ? String(note.index) : '';
+    clearStatus(formStatusEl);
+    refreshFormState();
+    renderRows();
+}
+
+// ---- render Notes table ----
+
+function renderRows() {
+    tbody.innerHTML = '';
+    if (notes.length === 0) {
+        const tr = document.createElement('tr');
+        const td = document.createElement('td');
+        td.colSpan = 5;
+        td.className = 'empty-state';
+        td.textContent = 'No notes — Refresh or Create one.';
+        tr.appendChild(td);
+        tbody.appendChild(tr);
+        return;
+    }
+    for (const note of notes) {
+        const tr = document.createElement('tr');
+        tr.title = note.recordName;
+        if (note.recordName === selectedRecordName) tr.classList.add('selected');
+        tr.addEventListener('click', (e) => {
+            if (e.target.closest('button')) return;
+            loadNoteIntoForm(note);
+        });
+
+        const titleTd = document.createElement('td');
+        titleTd.textContent = note.title ?? '';
+        if (note.createdBy && note.createdBy === currentUserRecordName) {
+            const youBadge = document.createElement('span');
+            youBadge.className = 'badge badge-you';
+            youBadge.textContent = 'You';
+            youBadge.title = `Created by ${note.createdBy}`;
+            titleTd.appendChild(youBadge);
+        }
+        tr.appendChild(titleTd);
+
+        const indexTd = document.createElement('td');
+        indexTd.textContent = note.index != null ? String(note.index) : '';
+        tr.appendChild(indexTd);
+
+        const createdTd = document.createElement('td');
+        createdTd.className = 'timestamp';
+        createdTd.textContent = formatTimestamp(note.created);
+        if (note.created) createdTd.title = note.created.toISOString();
+        tr.appendChild(createdTd);
+
+        const modifiedTd = document.createElement('td');
+        modifiedTd.className = 'timestamp';
+        modifiedTd.textContent = formatTimestamp(note.modified);
+        if (note.modified) modifiedTd.title = note.modified.toISOString();
+        tr.appendChild(modifiedTd);
+
+        const actionsTd = document.createElement('td');
+        actionsTd.className = 'actions';
+        const delBtn = document.createElement('button');
+        delBtn.className = 'danger';
+        delBtn.type = 'button';
+        delBtn.textContent = 'Delete';
+        delBtn.addEventListener('click', () => deleteNote(note));
+        actionsTd.appendChild(delBtn);
+        tr.appendChild(actionsTd);
+
+        tbody.appendChild(tr);
+    }
+}
+
+function refreshSortIndicators() {
+    document.querySelectorAll('th.sortable').forEach(th => {
+        const field = th.dataset.sortField;
+        const isActive = currentSort && currentSort.field === field;
+        th.classList.toggle('active', isActive);
+        const indicator = th.querySelector('.sort-indicator');
+        if (isActive) {
+            indicator.textContent = currentSort.ascending ? '↑' : '↓';
+        } else {
+            indicator.textContent = '';
+        }
+    });
+}
+
+document.querySelectorAll('th.sortable').forEach(th => {
+    th.addEventListener('click', () => {
+        const field = th.dataset.sortField;
+        if (currentSort && currentSort.field === field) {
+            currentSort = currentSort.ascending
+                ? { field, ascending: false }
+                : null;
+        } else {
+            currentSort = { field, ascending: true };
+        }
+        refreshSortIndicators();
+        if (authComplete) queryNotes();
+    });
+});
+
+// ---- payload normalization ----
+
+function normalizeRecords(payload) {
+    const list = (payload && payload.records) || [];
+    return list.map(record => {
+        const fields = record.fields || {};
+        const titleField = fields.title;
+        const indexField = fields.index;
+        return {
+            recordName: record.recordName,
+            recordType: record.recordType,
+            recordChangeTag: record.recordChangeTag,
+            title: titleField && (titleField.value ?? titleField),
+            index: indexField && Number(indexField.value ?? indexField),
+            created: toDate(record.created),
+            modified: toDate(record.modified),
+            createdBy: extractUserRecordName(record.created),
+            raw: record,
+        };
+    });
+}
+
+function extractUserRecordName(value) {
+    if (value == null || typeof value !== 'object' || value instanceof Date) {
+        return null;
+    }
+    return value.userRecordName ?? null;
+}
+
+function toDate(value) {
+    if (value == null) return null;
+    if (value instanceof Date) return value;
+    if (typeof value === 'number') return new Date(value);
+    if (typeof value === 'object') {
+        const inner = value.timestamp;
+        if (inner == null) return null;
+        if (inner instanceof Date) return inner;
+        if (typeof inner === 'number') return new Date(inner);
+        if (typeof inner === 'string') {
+            const parsed = Date.parse(inner);
+            return isNaN(parsed) ? null : new Date(parsed);
+        }
+    }
+    return null;
+}
+
+function formatTimestamp(date) {
+    if (!date) return '—';
+    return date.toLocaleString(undefined, {
+        dateStyle: 'short', timeStyle: 'short',
+    });
+}
+
+function buildFields() {
+    const out = {};
+    const title = titleInput.value.trim();
+    if (title.length > 0) out.title = title;
+    const indexRaw = indexInput.value.trim();
+    if (indexRaw.length > 0) {
+        const parsed = Number(indexRaw);
+        if (!isFinite(parsed)) {
+            throw new Error('Index must be a number.');
+        }
+        out.index = parsed;
+    }
+    return out;
+}
+
+function ckJsFields(fields) {
+    const wrapped = {};
+    for (const [k, v] of Object.entries(fields)) {
+        wrapped[k] = { value: v };
+    }
+    return wrapped;
+}
+
+// ---- Notes CRUD operations ----
+
+async function queryNotes() {
+    if (queryInFlight) return;
+    const recordType = recordTypeInput.value.trim();
+    const limit = parseInt(queryLimitInput.value, 10);
+    queryInFlight = true;
+    setQueryControlsDisabled(true);
+    const dbLabel = currentDatabase === 'public' ? 'public' : 'private';
+    const modeLabel = currentMode === 'mistkit' ? 'MistKit' : 'CloudKit JS';
+    setStatus(tableStatusEl, `Loading ${dbLabel} via ${modeLabel}`, 'loading');
+    try {
+        let payload;
+        if (currentMode === 'mistkit') {
+            payload = await postJSON('/api/records/query', {
+                recordType,
+                database: currentDatabase,
+                limit: isFinite(limit) ? limit : undefined,
+                sortBy: currentSort
+                    ? [{ field: currentSort.field, ascending: currentSort.ascending }]
+                    : undefined,
+            });
+        } else {
+            const query = { recordType };
+            if (currentSort) {
+                query.sortBy = [{
+                    fieldName: currentSort.field,
+                    ascending: currentSort.ascending,
+                }];
+            }
+            payload = await ckJsDatabase().performQuery(query, {
+                resultsLimit: isFinite(limit) ? limit : undefined,
+            });
+            if (payload && payload.hasErrors && payload.errors.length) {
+                throw new Error(payload.errors[0].reason || 'CloudKit JS query failed');
+            }
+        }
+        notes = normalizeRecords(payload);
+        if (selectedRecordName && !notes.some(n => n.recordName === selectedRecordName)) {
+            clearForm();
+        } else {
+            refreshFormState();
+            renderRows();
+        }
+        showRaw(payload);
+        setStatus(tableStatusEl, `Loaded ${notes.length} record${notes.length === 1 ? '' : 's'}.`, 'success');
+    } catch (error) {
+        setStatus(tableStatusEl, `Query failed: ${error.message}`, 'error');
+        showRaw(error.payload || { message: error.message });
+    } finally {
+        queryInFlight = false;
+        setQueryControlsDisabled(false);
+        refreshDatabasePicker();
+    }
+}
+
+function setQueryControlsDisabled(disabled) {
+    const ids = [
+        'refresh-btn', 'db-private', 'db-public',
+        'mode-mistkit', 'mode-cloudkitjs',
+        'save-btn', 'delete-btn',
+    ];
+    for (const id of ids) {
+        const el = document.getElementById(id);
+        if (el) el.disabled = disabled;
+    }
+}
+
+async function saveNote() {
+    let fields;
+    try {
+        fields = buildFields();
+    } catch (error) {
+        setStatus(formStatusEl, error.message, 'error');
+        return;
+    }
+    if (Object.keys(fields).length === 0) {
+        setStatus(formStatusEl, 'Provide a title or index.', 'error');
+        return;
+    }
+    const recordType = recordTypeInput.value.trim();
+    const note = selectedNote();
+    const isUpdate = note != null;
+    const label = isUpdate ? 'Update' : 'Create';
+    clearStatus(formStatusEl);
+    try {
+        let payload;
+        if (currentMode === 'mistkit') {
+            if (isUpdate) {
+                payload = await postJSON('/api/records/update', {
+                    recordType,
+                    database: currentDatabase,
+                    recordName: note.recordName,
+                    fields,
+                    recordChangeTag: note.recordChangeTag,
+                });
+            } else {
+                payload = await postJSON('/api/records/create', {
+                    recordType,
+                    database: currentDatabase,
+                    fields,
+                });
+            }
+        } else {
+            const record = { recordType, fields: ckJsFields(fields) };
+            if (isUpdate) {
+                record.recordName = note.recordName;
+                record.recordChangeTag = note.recordChangeTag;
+            }
+            payload = await ckJsDatabase().saveRecords([record]);
+            if (payload && payload.hasErrors && payload.errors.length) {
+                throw new Error(payload.errors[0].reason || 'CloudKit JS save failed');
+            }
+        }
+        showRaw(payload);
+        setStatus(formStatusEl, `${label} succeeded.`, 'success');
+        if (!isUpdate) clearForm();
+        if (!isUpdate) {
+            setStatus(
+                formStatusEl,
+                `Created — waiting ${REFRESH_DELAY_MS}ms for CloudKit to settle`,
+                'loading'
+            );
+            await new Promise(r => setTimeout(r, REFRESH_DELAY_MS));
+        }
+        await queryNotes();
+    } catch (error) {
+        setStatus(formStatusEl, `${label} failed: ${error.message}`, 'error');
+        showRaw(error.payload || { message: error.message });
+    }
+}
+
+async function deleteNote(note, statusEl = tableStatusEl) {
+    clearStatus(statusEl);
+    try {
+        let payload;
+        if (currentMode === 'mistkit') {
+            payload = await postJSON('/api/records/delete', {
+                recordType: note.recordType,
+                database: currentDatabase,
+                recordName: note.recordName,
+                recordChangeTag: note.recordChangeTag,
+            });
+        } else {
+            payload = await ckJsDatabase().deleteRecords([{ recordName: note.recordName }]);
+            if (payload && payload.hasErrors && payload.errors.length) {
+                throw new Error(payload.errors[0].reason || 'CloudKit JS delete failed');
+            }
+        }
+        showRaw(payload);
+        setStatus(statusEl, `Deleted ${note.recordName}.`, 'success');
+        if (note.recordName === selectedRecordName) clearForm();
+        await queryNotes();
+    } catch (error) {
+        setStatus(statusEl, `Delete failed: ${error.message}`, 'error');
+        showRaw(error.payload || { message: error.message });
+    }
+}
+
+saveBtn.addEventListener('click', saveNote);
+clearBtn.addEventListener('click', clearForm);
+deleteBtn.addEventListener('click', () => {
+    const note = selectedNote();
+    if (note) deleteNote(note, formStatusEl);
+});
+refreshBtn.addEventListener('click', queryNotes);
+
+refreshFormState();
+refreshSortIndicators();

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/js/assets.js
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/js/assets.js
@@ -1,0 +1,71 @@
+// assets/rereference panel handler. The MistKit side is pending #31 —
+// the 501 stub renders the pending banner. CloudKit JS composes the
+// rereference as: fetch source → reuse CloudKit.Asset descriptor →
+// save target.
+
+const assetsStatus = document.getElementById('assets-status');
+const assetsRaw = document.getElementById('assets-raw');
+
+document.getElementById('assets-rereference-btn').addEventListener('click', async () => {
+    const source = document.getElementById('assets-source').value.trim();
+    const field = document.getElementById('assets-field').value.trim();
+    const target = document.getElementById('assets-target').value.trim();
+    const targetField = document.getElementById('assets-target-field').value.trim() || field;
+    if (!source || !field || !target) {
+        setStatus(assetsStatus, 'Provide source, asset field, and target.', 'error');
+        return;
+    }
+    if (currentMode === 'mistkit') {
+        setStatus(assetsStatus, 'Rereferencing…', 'loading');
+        try {
+            const payload = await postJSON('/api/assets/rereference', {
+                sourceRecordName: source,
+                assetField: field,
+                targetRecordName: target,
+                targetAssetField: targetField,
+            });
+            renderRaw(assetsRaw, payload);
+            if (isPendingPayload(payload)) {
+                renderPendingBanner(assetsStatus, payload);
+            } else {
+                setStatus(assetsStatus, 'Rereferenced.', 'success');
+            }
+        } catch (error) {
+            const payload = error.payload || { message: error.message };
+            renderRaw(assetsRaw, payload);
+            if (isPendingPayload(payload)) {
+                renderPendingBanner(assetsStatus, payload);
+            } else {
+                setStatus(assetsStatus, `Failed: ${error.message}`, 'error');
+            }
+        }
+        return;
+    }
+    setStatus(assetsStatus, 'Fetching source record…', 'loading');
+    try {
+        const fetchPayload = await ckJsDatabase().fetchRecords([source]);
+        if (fetchPayload.hasErrors && fetchPayload.errors.length) {
+            throw new Error(fetchPayload.errors[0].reason || 'Fetch source failed');
+        }
+        const sourceRecord = (fetchPayload.records || [])[0];
+        if (!sourceRecord) throw new Error(`Source record ${source} not found.`);
+        const assetDescriptor = sourceRecord.fields && sourceRecord.fields[field];
+        if (!assetDescriptor) {
+            throw new Error(`Field ${field} not present on source record.`);
+        }
+        setStatus(assetsStatus, 'Saving target with reused asset…', 'loading');
+        const savePayload = await ckJsDatabase().saveRecords([{
+            recordName: target,
+            recordType: sourceRecord.recordType,
+            fields: { [targetField]: assetDescriptor },
+        }]);
+        if (savePayload.hasErrors && savePayload.errors.length) {
+            throw new Error(savePayload.errors[0].reason || 'Save target failed');
+        }
+        renderRaw(assetsRaw, { fetchSource: fetchPayload, saveTarget: savePayload });
+        setStatus(assetsStatus, 'Rereferenced.', 'success');
+    } catch (error) {
+        renderRaw(assetsRaw, { message: error.message });
+        setStatus(assetsStatus, `Failed: ${error.message}`, 'error');
+    }
+});

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/js/auth.js
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/js/auth.js
@@ -1,0 +1,148 @@
+// CloudKit JS bootstrap + Apple ID auth flow. Polls the internal
+// `_ckSession` token from the CloudKit JS container once the user signs
+// in, then forwards it to `/api/authenticate` so the server can use it
+// for MistKit-mode requests.
+
+function setAuthed(authed) {
+    authComplete = authed;
+    document.querySelectorAll('.pre-auth').forEach(card => {
+        card.classList.toggle('pre-auth', !authed);
+    });
+    signoutButton.style.display = authed ? 'inline-block' : 'none';
+}
+
+async function loadServerConfig() {
+    const response = await fetch('/api/config');
+    if (!response.ok) throw new Error('Failed to load server config: ' + response.status);
+    return response.json();
+}
+
+async function pollWebAuthToken() {
+    const pollIntervalMs = 250;
+    const pollDeadlineMs = 10_000;
+    const pollStart = Date.now();
+    return new Promise((resolve, reject) => {
+        const handle = setInterval(() => {
+            const token = container?._auth?._ckSession;
+            if (token) {
+                clearInterval(handle);
+                resolve(token);
+                return;
+            }
+            if (Date.now() - pollStart >= pollDeadlineMs) {
+                clearInterval(handle);
+                reject(new Error('Timeout waiting for web auth token'));
+            }
+        }, pollIntervalMs);
+    });
+}
+
+async function postAuthenticate(userIdentity, token) {
+    const response = await fetch('/api/authenticate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            sessionToken: token,
+            userRecordName: userIdentity.userRecordName,
+        }),
+    });
+    if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+    }
+    return response.status;
+}
+
+function renderTokenDisplay(token) {
+    notesCard.style.display = 'none';
+    document.getElementById('signin-area').style.display = 'none';
+    const card = document.createElement('div');
+    card.className = 'card';
+    card.innerHTML = `
+        <h2>Web Auth Token captured</h2>
+        <p>Use this token for command-line CloudKit API access:</p>
+        <pre style="user-select: all; padding: 12px; background: #f6f8fa; border-radius: 6px; word-break: break-all; white-space: pre-wrap;">${token}</pre>
+        <p>The server has shut down — you can close this window.</p>
+    `;
+    document.querySelector('.layout').appendChild(card);
+}
+
+async function handleAuthentication(userIdentity) {
+    if (authenticationInProgress) return;
+    authenticationInProgress = true;
+    currentUserRecordName = userIdentity?.userRecordName ?? null;
+    setStatus(authStatusDiv, 'Capturing web auth token...', 'success');
+    try {
+        const token = await pollWebAuthToken();
+        webAuthToken = token;
+        const status = await postAuthenticate(userIdentity, token);
+        if (status === 205) {
+            setStatus(authStatusDiv, 'Authentication complete.', 'success');
+            renderTokenDisplay(token);
+        } else {
+            setStatus(authStatusDiv, `Authenticated as ${userIdentity.userRecordName}.`, 'success');
+            setAuthed(true);
+            queryNotes();
+        }
+    } catch (error) {
+        setStatus(authStatusDiv, `Authentication failed: ${error.message}`, 'error');
+    } finally {
+        authenticationInProgress = false;
+    }
+}
+
+signoutButton.addEventListener('click', async () => {
+    try {
+        await container.signOut();
+        webAuthToken = null;
+        currentUserRecordName = null;
+        setAuthed(false);
+        notes = [];
+        clearForm();
+        setStatus(authStatusDiv, 'Signed out.', 'success');
+    } catch (error) {
+        setStatus(authStatusDiv, 'Sign out failed: ' + error.message, 'error');
+    }
+});
+
+async function initializeCloudKit() {
+    try {
+        if (typeof CloudKit === 'undefined') {
+            throw new Error('CloudKit.js failed to load');
+        }
+        const serverConfig = await loadServerConfig();
+        publicDatabaseAvailable = !!serverConfig.publicDatabaseAvailable;
+        refreshDatabasePicker();
+        CloudKit.configure({
+            containers: [{
+                containerIdentifier: serverConfig.containerIdentifier,
+                apiTokenAuth: {
+                    apiToken: serverConfig.apiToken,
+                    persist: true,
+                    signInButton: { id: 'signin-button', theme: 'black' },
+                },
+                environment: serverConfig.environment || 'development',
+            }],
+        });
+        container = CloudKit.getDefaultContainer();
+        const userIdentity = await container.setUpAuth();
+        if (userIdentity) {
+            setStatus(authStatusDiv, 'Already signed in. Capturing token...', 'success');
+            await handleAuthentication(userIdentity);
+        } else {
+            setStatus(authStatusDiv, 'Click "Sign In with Apple ID" to authenticate.', 'success');
+        }
+        container.whenUserSignsIn().then((identity) => handleAuthentication(identity));
+        container.whenUserSignsOut().then(() => {
+            webAuthToken = null;
+            currentUserRecordName = null;
+            setAuthed(false);
+            notes = [];
+            clearForm();
+            setStatus(authStatusDiv, 'Signed out.', 'success');
+        });
+    } catch (error) {
+        setStatus(authStatusDiv, 'CloudKit setup failed: ' + error.message, 'error');
+    }
+}
+
+initializeCloudKit();

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/js/mode.js
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/js/mode.js
@@ -1,0 +1,62 @@
+// Mode + database toggles. Reads `currentMode` / `currentDatabase` /
+// `publicDatabaseAvailable` set in app.js and updates the picker
+// disabled-state + banner copy.
+
+document.getElementById('mode-mistkit').addEventListener('click', () => setMode('mistkit'));
+document.getElementById('mode-cloudkitjs').addEventListener('click', () => setMode('cloudkitjs'));
+
+function setMode(mode) {
+    if (mode === currentMode) return;
+    currentMode = mode;
+    document.getElementById('mode-mistkit').classList.toggle('active', mode === 'mistkit');
+    document.getElementById('mode-cloudkitjs').classList.toggle('active', mode === 'cloudkitjs');
+    modeBadge.textContent = mode === 'mistkit' ? 'MistKit' : 'CloudKit JS';
+    refreshDatabasePicker();
+    if (authComplete) queryNotes();
+}
+
+dbPrivateBtn.addEventListener('click', () => setDatabase('private'));
+dbPublicBtn.addEventListener('click', () => setDatabase('public'));
+
+function setDatabase(database) {
+    if (database === currentDatabase) return;
+    if (database === 'public' && !isPublicAllowedForCurrentMode()) {
+        return;
+    }
+    currentDatabase = database;
+    refreshDatabasePicker();
+    if (authComplete) queryNotes();
+}
+
+function isPublicAllowedForCurrentMode() {
+    return currentMode === 'cloudkitjs' || publicDatabaseAvailable;
+}
+
+function refreshDatabasePicker() {
+    const publicAllowed = isPublicAllowedForCurrentMode();
+    dbPublicBtn.disabled = !publicAllowed;
+    if (!publicAllowed && currentDatabase === 'public') {
+        currentDatabase = 'private';
+    }
+    dbPrivateBtn.classList.toggle('active', currentDatabase === 'private');
+    dbPublicBtn.classList.toggle('active', currentDatabase === 'public');
+    dbBadge.textContent = currentDatabase === 'public' ? 'Public' : 'Private';
+    if (!publicDatabaseAvailable && currentMode === 'mistkit') {
+        dbHint.textContent =
+            'MistKit + Public requires server-to-server credentials ' +
+            '(CLOUDKIT_KEY_ID + CLOUDKIT_PRIVATE_KEY[_PATH]). ' +
+            'Restart the server with those set to enable Public on this side.';
+    } else if (currentMode === 'mistkit' && currentDatabase === 'public') {
+        dbHint.textContent =
+            'Heads-up: on MistKit + Public, records you write are owned ' +
+            'by the server-to-server key, not your iCloud user — so they ' +
+            'won’t carry a "You" badge.';
+    } else {
+        dbHint.textContent =
+            'Private uses the captured Apple ID web-auth token; Public ' +
+            'uses server-to-server signing on the MistKit side and the ' +
+            'API token on the CloudKit JS side.';
+    }
+}
+
+refreshDatabasePicker();

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/js/pending.js
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/js/pending.js
@@ -1,0 +1,28 @@
+// Render the standard "pending #N" banner. Used by panel modules that
+// hit endpoints whose MistKit Swift wrapper hasn't landed yet — the
+// server returns 501 with a JSON body containing `endpoint` + `tracking`,
+// and this module formats that into a yellow advisory above the raw
+// response area.
+
+function renderPendingBanner(statusEl, payload) {
+    if (!statusEl) return;
+    const endpoint = (payload && payload.endpoint) || 'unknown';
+    const tracking = (payload && payload.tracking) || '#?';
+    const msg =
+        `MistKit support pending for ${endpoint} — tracked in ${tracking}. ` +
+        `Switch to CloudKit JS mode to exercise this endpoint today.`;
+    statusEl.className = 'status error';
+    statusEl.textContent = msg;
+    statusEl.style.display = 'block';
+}
+
+// Treat the structured 501 body as a "pending"  response rather than a
+// hard error so the panel surfaces the asymmetry visibly. Returns true
+// if the payload is a pending-stub body.
+function isPendingPayload(payload) {
+    return payload
+        && typeof payload === 'object'
+        && payload.error === 'not_implemented'
+        && typeof payload.endpoint === 'string'
+        && typeof payload.tracking === 'string';
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/js/records.js
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/js/records.js
@@ -54,10 +54,10 @@ document.getElementById('records-changes-btn').addEventListener('click', async (
                     syncToken,
                 });
             }
-            const payload = await ckJsDatabase().fetchRecordChanges(
-                { zoneName },
-                { previousServerChangeToken: syncToken }
-            );
+            const payload = await ckJsDatabase().fetchRecordZoneChanges({
+                zoneID: { zoneName },
+                syncToken,
+            });
             if (payload && payload.hasErrors && payload.errors.length) {
                 throw new Error(payload.errors[0].reason || 'CloudKit JS changes failed');
             }

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/js/records.js
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/js/records.js
@@ -1,0 +1,120 @@
+// records/lookup · records/changes · records/resolve panel handlers.
+// records/query and records/modify are wired in app.js (Notes CRUD).
+
+const recordsLookupInput = document.getElementById('records-lookup-input');
+const recordsLookupStatus = document.getElementById('records-lookup-status');
+const recordsLookupRaw = document.getElementById('records-lookup-raw');
+
+document.getElementById('records-lookup-btn').addEventListener('click', async () => {
+    const names = csv(recordsLookupInput.value);
+    if (names.length === 0) {
+        setStatus(recordsLookupStatus, 'Provide at least one record name.', 'error');
+        return;
+    }
+    await runPanelOperation({
+        statusEl: recordsLookupStatus,
+        rawEl: recordsLookupRaw,
+        label: 'Lookup',
+        fn: async () => {
+            if (currentMode === 'mistkit') {
+                // records/lookup MistKit wrapper is implemented but isn't
+                // exposed on the demo server yet — surface that asymmetry
+                // by returning a pending banner inline.
+                return await postJSON('/api/records/lookup', {
+                    database: currentDatabase,
+                    recordNames: names,
+                });
+            }
+            const payload = await ckJsDatabase().fetchRecords(names);
+            if (payload && payload.hasErrors && payload.errors.length) {
+                throw new Error(payload.errors[0].reason || 'CloudKit JS lookup failed');
+            }
+            return payload;
+        },
+    });
+});
+
+const recordsChangesZone = document.getElementById('records-changes-zone');
+const recordsChangesToken = document.getElementById('records-changes-token');
+const recordsChangesStatus = document.getElementById('records-changes-status');
+const recordsChangesRaw = document.getElementById('records-changes-raw');
+
+document.getElementById('records-changes-btn').addEventListener('click', async () => {
+    const zoneName = recordsChangesZone.value.trim() || '_defaultZone';
+    const syncToken = recordsChangesToken.value.trim() || undefined;
+    await runPanelOperation({
+        statusEl: recordsChangesStatus,
+        rawEl: recordsChangesRaw,
+        label: 'Fetch changes',
+        fn: async () => {
+            if (currentMode === 'mistkit') {
+                return await postJSON('/api/records/changes', {
+                    database: currentDatabase,
+                    zoneName,
+                    syncToken,
+                });
+            }
+            const payload = await ckJsDatabase().fetchRecordChanges(
+                { zoneName },
+                { previousServerChangeToken: syncToken }
+            );
+            if (payload && payload.hasErrors && payload.errors.length) {
+                throw new Error(payload.errors[0].reason || 'CloudKit JS changes failed');
+            }
+            return payload;
+        },
+    });
+});
+
+const recordsResolveInput = document.getElementById('records-resolve-input');
+const recordsResolveStatus = document.getElementById('records-resolve-status');
+const recordsResolveRaw = document.getElementById('records-resolve-raw');
+
+document.getElementById('records-resolve-btn').addEventListener('click', async () => {
+    const value = recordsResolveInput.value.trim();
+    if (value.length === 0) {
+        setStatus(recordsResolveStatus, 'Provide a record name or share URL.', 'error');
+        return;
+    }
+    const isURL = /^https?:\/\//i.test(value);
+    if (currentMode === 'mistkit') {
+        // records/resolve MistKit wrapper isn't landed yet (#41). Hit the
+        // 501 stub to render the pending banner.
+        setStatus(recordsResolveStatus, 'Resolve…', 'loading');
+        try {
+            const payload = await postJSON('/api/records/resolve', { input: value });
+            renderRaw(recordsResolveRaw, payload);
+            if (isPendingPayload(payload)) {
+                renderPendingBanner(recordsResolveStatus, payload);
+            } else {
+                setStatus(recordsResolveStatus, 'Resolve succeeded.', 'success');
+            }
+        } catch (error) {
+            const payload = error.payload || { message: error.message };
+            renderRaw(recordsResolveRaw, payload);
+            if (isPendingPayload(payload)) {
+                renderPendingBanner(recordsResolveStatus, payload);
+            } else {
+                setStatus(recordsResolveStatus, `Resolve failed: ${error.message}`, 'error');
+            }
+        }
+        return;
+    }
+    // CloudKit JS composed call — branch on input shape.
+    await runPanelOperation({
+        statusEl: recordsResolveStatus,
+        rawEl: recordsResolveRaw,
+        label: isURL ? 'Resolve share URL' : 'Resolve record name',
+        fn: async () => {
+            if (isURL) {
+                const payload = await ckJsContainer().fetchShareMetadataWithURL({ shareURL: value });
+                return { branch: 'shareURL', payload };
+            }
+            const payload = await ckJsDatabase().fetchRecords([value]);
+            if (payload && payload.hasErrors && payload.errors.length) {
+                throw new Error(payload.errors[0].reason || 'CloudKit JS resolve failed');
+            }
+            return { branch: 'recordName', payload };
+        },
+    });
+});

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/js/subscriptions.js
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/js/subscriptions.js
@@ -1,0 +1,77 @@
+// subscriptions/list · subscriptions/lookup panel handlers. MistKit
+// side returns 501 (pending #49 / #50); CloudKit JS side hits the real
+// browser SDK primitives.
+
+const subsListStatus = document.getElementById('subs-list-status');
+const subsListRaw = document.getElementById('subs-list-raw');
+const subsLookupStatus = document.getElementById('subs-lookup-status');
+const subsLookupRaw = document.getElementById('subs-lookup-raw');
+
+document.getElementById('subs-list-btn').addEventListener('click', async () => {
+    setStatus(subsListStatus, 'Fetching…', 'loading');
+    try {
+        if (currentMode === 'mistkit') {
+            try {
+                const payload = await fetchJSON('/api/subscriptions');
+                renderRaw(subsListRaw, payload);
+                if (isPendingPayload(payload)) {
+                    renderPendingBanner(subsListStatus, payload);
+                } else {
+                    setStatus(subsListStatus, 'Loaded.', 'success');
+                }
+            } catch (error) {
+                const payload = error.payload || { message: error.message };
+                renderRaw(subsListRaw, payload);
+                if (isPendingPayload(payload)) {
+                    renderPendingBanner(subsListStatus, payload);
+                } else {
+                    setStatus(subsListStatus, `Failed: ${error.message}`, 'error');
+                }
+            }
+            return;
+        }
+        const payload = await ckJsDatabase().fetchAllSubscriptions();
+        renderRaw(subsListRaw, payload);
+        setStatus(subsListStatus, 'Loaded.', 'success');
+    } catch (error) {
+        renderRaw(subsListRaw, { message: error.message });
+        setStatus(subsListStatus, `Failed: ${error.message}`, 'error');
+    }
+});
+
+document.getElementById('subs-lookup-btn').addEventListener('click', async () => {
+    const ids = csv(document.getElementById('subs-lookup-input').value);
+    if (ids.length === 0) {
+        setStatus(subsLookupStatus, 'Provide at least one subscription ID.', 'error');
+        return;
+    }
+    setStatus(subsLookupStatus, 'Looking up…', 'loading');
+    try {
+        if (currentMode === 'mistkit') {
+            try {
+                const payload = await fetchJSON(`/api/subscriptions/${encodeURIComponent(ids[0])}`);
+                renderRaw(subsLookupRaw, payload);
+                if (isPendingPayload(payload)) {
+                    renderPendingBanner(subsLookupStatus, payload);
+                } else {
+                    setStatus(subsLookupStatus, 'Loaded.', 'success');
+                }
+            } catch (error) {
+                const payload = error.payload || { message: error.message };
+                renderRaw(subsLookupRaw, payload);
+                if (isPendingPayload(payload)) {
+                    renderPendingBanner(subsLookupStatus, payload);
+                } else {
+                    setStatus(subsLookupStatus, `Failed: ${error.message}`, 'error');
+                }
+            }
+            return;
+        }
+        const payload = await ckJsDatabase().fetchSubscriptions(ids);
+        renderRaw(subsLookupRaw, payload);
+        setStatus(subsLookupStatus, 'Loaded.', 'success');
+    } catch (error) {
+        renderRaw(subsLookupRaw, { message: error.message });
+        setStatus(subsLookupStatus, `Failed: ${error.message}`, 'error');
+    }
+});

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/js/subscriptions.js
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/js/subscriptions.js
@@ -4,8 +4,23 @@
 
 const subsListStatus = document.getElementById('subs-list-status');
 const subsListRaw = document.getElementById('subs-list-raw');
+const subsListTbody = document.getElementById('subs-list-tbody');
 const subsLookupStatus = document.getElementById('subs-lookup-status');
 const subsLookupRaw = document.getElementById('subs-lookup-raw');
+
+// CloudKit JS `fetchAllSubscriptions` resolves to `{ subscriptions: [...] }`;
+// the MistKit route (pending #49) will mirror that shape. Each subscription
+// carries `subscriptionID`, `subscriptionType`, and an optional `query`
+// (record-type subscriptions) and `zoneID` (zone subscriptions).
+function renderSubscriptionsTable(payload) {
+    const subs = (payload && payload.subscriptions) || [];
+    renderListTable(subsListTbody, [
+        s => s.subscriptionID ?? s.subscriptionId,
+        s => s.subscriptionType,
+        s => s.query && s.query.recordType,
+        s => s.zoneID && s.zoneID.zoneName,
+    ], Array.isArray(subs) ? subs : [], 'No subscriptions found.');
+}
 
 document.getElementById('subs-list-btn').addEventListener('click', async () => {
     setStatus(subsListStatus, 'Fetching…', 'loading');
@@ -17,6 +32,7 @@ document.getElementById('subs-list-btn').addEventListener('click', async () => {
                 if (isPendingPayload(payload)) {
                     renderPendingBanner(subsListStatus, payload);
                 } else {
+                    renderSubscriptionsTable(payload);
                     setStatus(subsListStatus, 'Loaded.', 'success');
                 }
             } catch (error) {
@@ -32,6 +48,7 @@ document.getElementById('subs-list-btn').addEventListener('click', async () => {
         }
         const payload = await ckJsDatabase().fetchAllSubscriptions();
         renderRaw(subsListRaw, payload);
+        renderSubscriptionsTable(payload);
         setStatus(subsListStatus, 'Loaded.', 'success');
     } catch (error) {
         renderRaw(subsListRaw, { message: error.message });
@@ -73,5 +90,138 @@ document.getElementById('subs-lookup-btn').addEventListener('click', async () =>
     } catch (error) {
         renderRaw(subsLookupRaw, { message: error.message });
         setStatus(subsLookupStatus, `Failed: ${error.message}`, 'error');
+    }
+});
+
+// ---- Create (subscriptions/modify) ----
+
+const subsCreateType = document.getElementById('subs-create-type');
+const subsCreateQueryFields = document.getElementById('subs-create-query-fields');
+const subsCreateZoneFields = document.getElementById('subs-create-zone-fields');
+const subsCreateStatus = document.getElementById('subs-create-status');
+const subsCreateRaw = document.getElementById('subs-create-raw');
+
+// Toggle the type-specific input row to match the selected subscription type.
+function refreshSubsCreateFields() {
+    const isZone = subsCreateType.value === 'zone';
+    subsCreateQueryFields.style.display = isZone ? 'none' : '';
+    subsCreateZoneFields.style.display = isZone ? '' : 'none';
+}
+subsCreateType.addEventListener('change', refreshSubsCreateFields);
+refreshSubsCreateFields();
+
+// Build a CloudKit.Subscription dictionary from the form. Throws with a
+// user-facing message when a required field for the chosen type is missing.
+function buildSubscription() {
+    const type = subsCreateType.value;
+    const id = document.getElementById('subs-create-id').value.trim();
+    const subscription = { subscriptionType: type };
+    if (id) subscription.subscriptionID = id;
+    if (type === 'zone') {
+        const zoneName = document.getElementById('subs-create-zone').value.trim();
+        if (!zoneName) throw new Error('Provide a zone name.');
+        subscription.zoneID = { zoneName };
+    } else {
+        const recordType = document.getElementById('subs-create-record-type').value;
+        const firesOn = Array.from(
+            document.querySelectorAll('.subs-fires-on:checked')
+        ).map(cb => cb.value);
+        if (!firesOn.length) throw new Error('Select at least one "Fires on" operation.');
+        subscription.firesOn = firesOn;
+        subscription.query = { recordType };
+    }
+    return subscription;
+}
+
+document.getElementById('subs-create-btn').addEventListener('click', async () => {
+    let subscription;
+    try {
+        subscription = buildSubscription();
+    } catch (error) {
+        setStatus(subsCreateStatus, error.message, 'error');
+        return;
+    }
+    setStatus(subsCreateStatus, 'Creating…', 'loading');
+    try {
+        if (currentMode === 'mistkit') {
+            // subscriptions/modify MistKit wrapper isn't landed yet (#51) —
+            // hit the 501 stub and render the pending banner inline.
+            try {
+                const payload = await postJSON('/api/subscriptions/modify', subscription);
+                renderRaw(subsCreateRaw, payload);
+                if (isPendingPayload(payload)) {
+                    renderPendingBanner(subsCreateStatus, payload);
+                } else {
+                    setStatus(subsCreateStatus, 'Created.', 'success');
+                }
+            } catch (error) {
+                const payload = error.payload || { message: error.message };
+                renderRaw(subsCreateRaw, payload);
+                if (isPendingPayload(payload)) {
+                    renderPendingBanner(subsCreateStatus, payload);
+                } else {
+                    setStatus(subsCreateStatus, `Failed: ${error.message}`, 'error');
+                }
+            }
+            return;
+        }
+        const payload = await ckJsDatabase().saveSubscriptions(subscription);
+        renderRaw(subsCreateRaw, payload);
+        if (payload && payload.hasErrors && payload.errors.length) {
+            throw new Error(payload.errors[0].reason || 'CloudKit JS save subscription failed');
+        }
+        setStatus(subsCreateStatus, 'Created.', 'success');
+    } catch (error) {
+        renderRaw(subsCreateRaw, error.payload || { message: error.message });
+        setStatus(subsCreateStatus, `Failed: ${error.message}`, 'error');
+    }
+});
+
+// ---- Delete (subscriptions/modify) ----
+
+const subsDeleteStatus = document.getElementById('subs-delete-status');
+const subsDeleteRaw = document.getElementById('subs-delete-raw');
+
+document.getElementById('subs-delete-btn').addEventListener('click', async () => {
+    const ids = csv(document.getElementById('subs-delete-input').value);
+    if (ids.length === 0) {
+        setStatus(subsDeleteStatus, 'Provide at least one subscription ID.', 'error');
+        return;
+    }
+    setStatus(subsDeleteStatus, 'Deleting…', 'loading');
+    try {
+        if (currentMode === 'mistkit') {
+            // CloudKit Web Services models delete as part of subscriptions/modify,
+            // whose MistKit wrapper isn't landed yet (#51) — hit the 501 stub.
+            try {
+                const payload = await postJSON('/api/subscriptions/modify', {
+                    delete: ids.map(id => ({ subscriptionID: id })),
+                });
+                renderRaw(subsDeleteRaw, payload);
+                if (isPendingPayload(payload)) {
+                    renderPendingBanner(subsDeleteStatus, payload);
+                } else {
+                    setStatus(subsDeleteStatus, 'Deleted.', 'success');
+                }
+            } catch (error) {
+                const payload = error.payload || { message: error.message };
+                renderRaw(subsDeleteRaw, payload);
+                if (isPendingPayload(payload)) {
+                    renderPendingBanner(subsDeleteStatus, payload);
+                } else {
+                    setStatus(subsDeleteStatus, `Failed: ${error.message}`, 'error');
+                }
+            }
+            return;
+        }
+        const payload = await ckJsDatabase().deleteSubscriptions(ids);
+        renderRaw(subsDeleteRaw, payload);
+        if (payload && payload.hasErrors && payload.errors.length) {
+            throw new Error(payload.errors[0].reason || 'CloudKit JS delete subscription failed');
+        }
+        setStatus(subsDeleteStatus, 'Deleted.', 'success');
+    } catch (error) {
+        renderRaw(subsDeleteRaw, error.payload || { message: error.message });
+        setStatus(subsDeleteStatus, `Failed: ${error.message}`, 'error');
     }
 });

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/js/tokens.js
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/js/tokens.js
@@ -1,0 +1,50 @@
+// tokens/create + tokens/register panel handler. The CloudKit JS SDK
+// combines token creation and registration into a single
+// `container.registerForNotifications()` call (and surfaces incoming
+// notifications via `addNotificationListener`). MistKit-side is pending
+// #52 (create) and #53 (register) — the 501 stubs render below.
+
+const tokensStatus = document.getElementById('tokens-status');
+const tokensRaw = document.getElementById('tokens-raw');
+
+document.getElementById('tokens-register-btn').addEventListener('click', async () => {
+    if (currentMode === 'mistkit') {
+        // Both create + register are pending. Hit both 501s sequentially and
+        // render the combined response so the asymmetry vs CloudKit JS is
+        // visible on a single panel.
+        setStatus(tokensStatus, 'Registering…', 'loading');
+        const result = { create: null, register: null };
+        try {
+            result.create = await postJSON('/api/tokens', {});
+        } catch (error) { result.create = error.payload || { message: error.message }; }
+        try {
+            result.register = await postJSON('/api/tokens/register', {});
+        } catch (error) { result.register = error.payload || { message: error.message }; }
+        renderRaw(tokensRaw, result);
+        if (isPendingPayload(result.create) || isPendingPayload(result.register)) {
+            renderPendingBanner(tokensStatus, result.create || result.register);
+        } else {
+            setStatus(tokensStatus, 'Registered.', 'success');
+        }
+        return;
+    }
+
+    setStatus(tokensStatus, 'Registering for notifications…', 'loading');
+    try {
+        const result = await ckJsContainer().registerForNotifications();
+        renderRaw(tokensRaw, result);
+        setStatus(tokensStatus, 'Registered.', 'success');
+        try {
+            ckJsContainer().addNotificationListener((notification) => {
+                renderRaw(tokensRaw, { lastNotification: notification });
+            });
+        } catch (_listenerError) {
+            // addNotificationListener is best-effort; older CloudKit JS
+            // versions don't expose it. Don't fail the panel if the
+            // listener wire-up fails.
+        }
+    } catch (error) {
+        renderRaw(tokensRaw, { message: error.message });
+        setStatus(tokensStatus, `Failed: ${error.message}`, 'error');
+    }
+});

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/js/users.js
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/js/users.js
@@ -21,7 +21,7 @@ document.getElementById('users-caller-btn').addEventListener('click', async () =
             if (currentMode === 'mistkit') {
                 return await fetchJSON('/api/users/caller');
             }
-            return await ckJsContainer().fetchUserIdentityMe();
+            return await ckJsContainer().fetchCurrentUserIdentity();
         },
     });
 });
@@ -40,7 +40,7 @@ document.getElementById('users-email-btn').addEventListener('click', async () =>
             if (currentMode === 'mistkit') {
                 return await postJSON('/api/users/lookup/email', { emails: [email] });
             }
-            return await ckJsContainer().discoverUserIdentity({ emailAddress: email });
+            return await ckJsContainer().discoverUserIdentityWithEmailAddress(email);
         },
     });
 });
@@ -59,7 +59,7 @@ document.getElementById('users-id-btn').addEventListener('click', async () => {
             if (currentMode === 'mistkit') {
                 return await postJSON('/api/users/lookup/id', { userRecordNames: [recordName] });
             }
-            return await ckJsContainer().discoverUserIdentity({ userRecordName: recordName });
+            return await ckJsContainer().discoverUserIdentityWithUserRecordName(recordName);
         },
     });
 });
@@ -83,7 +83,7 @@ document.getElementById('users-discover-btn').addEventListener('click', async ()
             const results = [];
             for (const email of emails) {
                 try {
-                    const identity = await ckJsContainer().discoverUserIdentity({ emailAddress: email });
+                    const identity = await ckJsContainer().discoverUserIdentityWithEmailAddress(email);
                     results.push({ email, identity });
                 } catch (error) {
                     results.push({ email, error: error.message });

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/js/users.js
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/js/users.js
@@ -1,0 +1,95 @@
+// users/caller · users/discover · users/lookup/email · users/lookup/id
+// panel handlers. All four MistKit wrappers landed in #215 but aren't
+// exposed on the demo server yet; CloudKit JS fully exercises every
+// endpoint today.
+
+const usersCallerStatus = document.getElementById('users-caller-status');
+const usersCallerRaw = document.getElementById('users-caller-raw');
+const usersEmailStatus = document.getElementById('users-email-status');
+const usersEmailRaw = document.getElementById('users-email-raw');
+const usersIdStatus = document.getElementById('users-id-status');
+const usersIdRaw = document.getElementById('users-id-raw');
+const usersDiscoverStatus = document.getElementById('users-discover-status');
+const usersDiscoverRaw = document.getElementById('users-discover-raw');
+
+document.getElementById('users-caller-btn').addEventListener('click', async () => {
+    await runPanelOperation({
+        statusEl: usersCallerStatus,
+        rawEl: usersCallerRaw,
+        label: 'Fetch caller',
+        fn: async () => {
+            if (currentMode === 'mistkit') {
+                return await fetchJSON('/api/users/caller');
+            }
+            return await ckJsContainer().fetchUserIdentityMe();
+        },
+    });
+});
+
+document.getElementById('users-email-btn').addEventListener('click', async () => {
+    const email = document.getElementById('users-email-input').value.trim();
+    if (!email) {
+        setStatus(usersEmailStatus, 'Provide an email address.', 'error');
+        return;
+    }
+    await runPanelOperation({
+        statusEl: usersEmailStatus,
+        rawEl: usersEmailRaw,
+        label: 'Lookup by email',
+        fn: async () => {
+            if (currentMode === 'mistkit') {
+                return await postJSON('/api/users/lookup/email', { emails: [email] });
+            }
+            return await ckJsContainer().discoverUserIdentity({ emailAddress: email });
+        },
+    });
+});
+
+document.getElementById('users-id-btn').addEventListener('click', async () => {
+    const recordName = document.getElementById('users-id-input').value.trim();
+    if (!recordName) {
+        setStatus(usersIdStatus, 'Provide a user record name.', 'error');
+        return;
+    }
+    await runPanelOperation({
+        statusEl: usersIdStatus,
+        rawEl: usersIdRaw,
+        label: 'Lookup by record name',
+        fn: async () => {
+            if (currentMode === 'mistkit') {
+                return await postJSON('/api/users/lookup/id', { userRecordNames: [recordName] });
+            }
+            return await ckJsContainer().discoverUserIdentity({ userRecordName: recordName });
+        },
+    });
+});
+
+document.getElementById('users-discover-btn').addEventListener('click', async () => {
+    const emails = csv(document.getElementById('users-discover-input').value);
+    if (emails.length === 0) {
+        setStatus(usersDiscoverStatus, 'Provide at least one email.', 'error');
+        return;
+    }
+    await runPanelOperation({
+        statusEl: usersDiscoverStatus,
+        rawEl: usersDiscoverRaw,
+        label: 'Discover users',
+        fn: async () => {
+            if (currentMode === 'mistkit') {
+                return await postJSON('/api/users/discover', { emails });
+            }
+            // CloudKit JS exposes a per-email primitive — loop and aggregate
+            // to match the REST endpoint's batch shape.
+            const results = [];
+            for (const email of emails) {
+                try {
+                    const identity = await ckJsContainer().discoverUserIdentity({ emailAddress: email });
+                    results.push({ email, identity });
+                } catch (error) {
+                    results.push({ email, error: error.message });
+                }
+            }
+            return { discovered: results };
+        },
+    });
+});

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/js/zones.js
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/js/zones.js
@@ -1,0 +1,119 @@
+// zones/list · zones/lookup · zones/modify · zones/changes panel handlers.
+// All four endpoints have landed MistKit wrappers (#215, #45, #48, #367)
+// but aren't yet exposed on the demo server; calls to the MistKit side
+// hit 404 from the server until the corresponding /api/* routes wire in.
+// CloudKit JS calls are fully exercisable today.
+
+const zonesListStatus = document.getElementById('zones-list-status');
+const zonesListRaw = document.getElementById('zones-list-raw');
+const zonesLookupStatus = document.getElementById('zones-lookup-status');
+const zonesLookupRaw = document.getElementById('zones-lookup-raw');
+const zonesModifyStatus = document.getElementById('zones-modify-status');
+const zonesModifyRaw = document.getElementById('zones-modify-raw');
+const zonesChangesStatus = document.getElementById('zones-changes-status');
+const zonesChangesRaw = document.getElementById('zones-changes-raw');
+
+document.getElementById('zones-list-btn').addEventListener('click', async () => {
+    await runPanelOperation({
+        statusEl: zonesListStatus,
+        rawEl: zonesListRaw,
+        label: 'List zones',
+        fn: async () => {
+            if (currentMode === 'mistkit') {
+                return await postJSON('/api/zones/list', { database: currentDatabase });
+            }
+            return await ckJsDatabase().fetchAllRecordZones();
+        },
+    });
+});
+
+document.getElementById('zones-lookup-btn').addEventListener('click', async () => {
+    const zoneNames = csv(document.getElementById('zones-lookup-input').value);
+    if (zoneNames.length === 0) {
+        setStatus(zonesLookupStatus, 'Provide at least one zone name.', 'error');
+        return;
+    }
+    await runPanelOperation({
+        statusEl: zonesLookupStatus,
+        rawEl: zonesLookupRaw,
+        label: 'Lookup zones',
+        fn: async () => {
+            if (currentMode === 'mistkit') {
+                return await postJSON('/api/zones/lookup', {
+                    database: currentDatabase,
+                    zoneNames,
+                });
+            }
+            const zoneIDs = zoneNames.map(name => ({ zoneName: name }));
+            return await ckJsDatabase().fetchRecordZones(zoneIDs);
+        },
+    });
+});
+
+document.getElementById('zones-modify-create-btn').addEventListener('click', async () => {
+    const zoneName = document.getElementById('zones-modify-create').value.trim();
+    if (zoneName.length === 0) {
+        setStatus(zonesModifyStatus, 'Provide a zone name to create.', 'error');
+        return;
+    }
+    await runPanelOperation({
+        statusEl: zonesModifyStatus,
+        rawEl: zonesModifyRaw,
+        label: 'Create zone',
+        fn: async () => {
+            if (currentMode === 'mistkit') {
+                return await postJSON('/api/zones/modify', {
+                    database: currentDatabase,
+                    create: [{ zoneName }],
+                });
+            }
+            return await ckJsDatabase().saveRecordZones([{ zoneName }]);
+        },
+    });
+});
+
+document.getElementById('zones-modify-delete-btn').addEventListener('click', async () => {
+    const zoneName = document.getElementById('zones-modify-delete').value.trim();
+    if (zoneName.length === 0) {
+        setStatus(zonesModifyStatus, 'Provide a zone name to delete.', 'error');
+        return;
+    }
+    await runPanelOperation({
+        statusEl: zonesModifyStatus,
+        rawEl: zonesModifyRaw,
+        label: 'Delete zone',
+        fn: async () => {
+            if (currentMode === 'mistkit') {
+                return await postJSON('/api/zones/modify', {
+                    database: currentDatabase,
+                    delete: [{ zoneName }],
+                });
+            }
+            return await ckJsDatabase().deleteRecordZones([{ zoneName }]);
+        },
+    });
+});
+
+document.getElementById('zones-changes-btn').addEventListener('click', async () => {
+    const token = document.getElementById('zones-changes-token').value.trim() || undefined;
+    await runPanelOperation({
+        statusEl: zonesChangesStatus,
+        rawEl: zonesChangesRaw,
+        label: 'Zone changes',
+        fn: async () => {
+            if (currentMode === 'mistkit') {
+                return await postJSON('/api/zones/changes', {
+                    database: currentDatabase,
+                    syncToken: token,
+                });
+            }
+            // CloudKit JS doesn't expose a direct zones/changes — the
+            // equivalent is composed per-zone via fetchRecordChanges, so
+            // surface that pedagogical asymmetry inline.
+            return {
+                note: 'CloudKit JS exposes per-zone records/changes only — there is no direct zones/changes browser primitive.',
+                composedFrom: 'database.fetchRecordChanges(zoneID, { previousServerChangeToken })',
+            };
+        },
+    });
+});

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/js/zones.js
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/js/zones.js
@@ -1,11 +1,13 @@
 // zones/list · zones/lookup · zones/modify · zones/changes panel handlers.
-// All four endpoints have landed MistKit wrappers (#215, #45, #48, #367)
-// but aren't yet exposed on the demo server; calls to the MistKit side
-// hit 404 from the server until the corresponding /api/* routes wire in.
-// CloudKit JS calls are fully exercisable today.
+// zones/modify is wired on the demo server (POST /api/zones/modify), so the
+// MistKit-mode Create/Delete buttons hit the real CloudKitService. The other
+// three (list/lookup/changes) have landed MistKit wrappers (#215, #45, #48,
+// #367) but aren't yet exposed on the server, so MistKit-mode calls to them
+// still 404. CloudKit JS calls are fully exercisable today.
 
 const zonesListStatus = document.getElementById('zones-list-status');
 const zonesListRaw = document.getElementById('zones-list-raw');
+const zonesListTbody = document.getElementById('zones-list-tbody');
 const zonesLookupStatus = document.getElementById('zones-lookup-status');
 const zonesLookupRaw = document.getElementById('zones-lookup-raw');
 const zonesModifyStatus = document.getElementById('zones-modify-status');
@@ -13,8 +15,21 @@ const zonesModifyRaw = document.getElementById('zones-modify-raw');
 const zonesChangesStatus = document.getElementById('zones-changes-status');
 const zonesChangesRaw = document.getElementById('zones-changes-raw');
 
+// Both the MistKit (`/api/zones/list`) and CloudKit JS
+// (`fetchAllRecordZones`) responses wrap the zone array under `zones`;
+// CloudKit JS nests the name under `zoneID.zoneName`, MistKit returns a
+// flat `zoneName`, so read both.
+function renderZonesTable(payload) {
+    const zones = (payload && payload.zones) || [];
+    renderListTable(zonesListTbody, [
+        z => (z.zoneID && z.zoneID.zoneName) ?? z.zoneName,
+        z => z.zoneID && z.zoneID.ownerRecordName,
+        z => (z.atomic != null ? String(z.atomic) : ''),
+    ], Array.isArray(zones) ? zones : [], 'No zones found.');
+}
+
 document.getElementById('zones-list-btn').addEventListener('click', async () => {
-    await runPanelOperation({
+    const payload = await runPanelOperation({
         statusEl: zonesListStatus,
         rawEl: zonesListRaw,
         label: 'List zones',
@@ -25,6 +40,7 @@ document.getElementById('zones-list-btn').addEventListener('click', async () => 
             return await ckJsDatabase().fetchAllRecordZones();
         },
     });
+    if (payload) renderZonesTable(payload);
 });
 
 document.getElementById('zones-lookup-btn').addEventListener('click', async () => {
@@ -67,7 +83,7 @@ document.getElementById('zones-modify-create-btn').addEventListener('click', asy
                     create: [{ zoneName }],
                 });
             }
-            return await ckJsDatabase().saveRecordZones([{ zoneName }]);
+            return await ckJsDatabase().saveRecordZones([{ zoneID: { zoneName } }]);
         },
     });
 });
@@ -110,10 +126,10 @@ document.getElementById('zones-changes-btn').addEventListener('click', async () 
             // CloudKit JS doesn't expose a direct zones/changes — the
             // equivalent is composed per-zone via fetchRecordChanges, so
             // surface that pedagogical asymmetry inline.
-            return {
-                note: 'CloudKit JS exposes per-zone records/changes only — there is no direct zones/changes browser primitive.',
-                composedFrom: 'database.fetchRecordChanges(zoneID, { previousServerChangeToken })',
-            };
+            // CloudKit JS does expose a database-level changes primitive
+            // (`fetchDatabaseChanges`, returning changed record zones), which
+            // is the closest analog to the REST zones/changes endpoint.
+            return await ckJsDatabase().fetchDatabaseChanges({ syncToken: token });
         },
     });
 });

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/styles.css
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/styles.css
@@ -1,0 +1,253 @@
+:root {
+  --bg: #f5f5f7;
+  --card: #ffffff;
+  --ink: #1d1d1f;
+  --muted: #6e6e73;
+  --accent: #0369a1;
+  --accent-dark: #0c4a6e;
+  --danger: #c00;
+  --danger-bg: #fdd;
+  --success-bg: #d1f5d3;
+  --success-fg: #1d5e20;
+  --border: #d0d7de;
+  --row-hover: #f0f4f8;
+  --row-selected: #dbeafe;
+}
+* { box-sizing: border-box; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  margin: 0;
+  padding: 24px;
+  background-color: var(--bg);
+  color: var(--ink);
+}
+.layout {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.card {
+  background: var(--card);
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+}
+h1 { font-size: 24px; margin: 0 0 4px; }
+h2 { font-size: 18px; margin: 0 0 12px; }
+h3 { font-size: 15px; margin: 0 0 8px; }
+p { color: var(--muted); margin: 0 0 16px; line-height: 1.5; }
+label { display: block; font-size: 13px; font-weight: 600; margin: 12px 0 4px; }
+input, textarea {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 14px;
+  font-family: inherit;
+}
+textarea { font-family: 'SF Mono', Menlo, monospace; font-size: 13px; resize: vertical; min-height: 60px; }
+button {
+  background: var(--accent);
+  color: white;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+}
+button:hover:not(:disabled) { background: var(--accent-dark); }
+button:disabled { opacity: 0.45; cursor: not-allowed; }
+button.secondary {
+  background: transparent;
+  color: var(--ink);
+  border: 1px solid var(--border);
+  font-weight: 500;
+}
+button.secondary:hover:not(:disabled) { background: var(--row-hover); }
+button.danger { background: var(--danger); }
+button.danger:hover:not(:disabled) { background: #900; }
+.status {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  display: none;
+}
+.status.success { background: var(--success-bg); color: var(--success-fg); display: block; }
+.status.error { background: var(--danger-bg); color: var(--danger); display: block; }
+.status.loading { background: var(--row-hover); color: var(--muted); display: block; }
+.status.loading::after {
+  content: '…';
+  display: inline-block;
+  margin-left: 4px;
+  animation: status-loading-dots 1.2s steps(4, end) infinite;
+  width: 1ch;
+  overflow: hidden;
+  vertical-align: bottom;
+}
+@keyframes status-loading-dots {
+  0% { width: 0; }
+  100% { width: 1ch; }
+}
+pre {
+  background: #0d1117;
+  color: #c9d1d9;
+  padding: 12px;
+  border-radius: 6px;
+  font-size: 12px;
+  overflow-x: auto;
+  margin: 8px 0 0;
+  max-height: 240px;
+}
+.mode-toggle {
+  display: flex;
+  gap: 8px;
+  margin: 12px 0 4px;
+}
+.mode-toggle button {
+  background: transparent;
+  color: var(--ink);
+  border: 1px solid var(--border);
+  font-weight: 500;
+}
+.mode-toggle button.active {
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}
+.mode-hint { font-size: 12px; color: var(--muted); margin-top: 4px; }
+.notes-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+  gap: 24px;
+  align-items: start;
+}
+@media (max-width: 820px) {
+  .notes-grid { grid-template-columns: 1fr; }
+}
+.table-toolbar {
+  display: flex;
+  align-items: end;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+.table-toolbar label { margin: 0 0 4px; }
+.table-toolbar .limit-field { width: 100px; }
+.table-wrap {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: auto;
+  max-height: 480px;
+}
+table { width: 100%; border-collapse: collapse; font-size: 13px; }
+th, td {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+}
+th {
+  position: sticky;
+  top: 0;
+  background: var(--row-hover);
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+th.sortable { cursor: pointer; user-select: none; white-space: nowrap; }
+th.sortable:hover { color: var(--accent); }
+th.sortable.active { color: var(--accent); }
+.sort-indicator { display: inline-block; width: 12px; margin-left: 4px; }
+td.timestamp {
+  font-size: 12px;
+  color: var(--muted);
+  white-space: nowrap;
+}
+tbody tr { cursor: pointer; }
+tbody tr:hover { background: var(--row-hover); }
+tbody tr.selected { background: var(--row-selected); }
+td.record-name {
+  font-family: 'SF Mono', Menlo, monospace;
+  font-size: 12px;
+  color: var(--muted);
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+td.actions { width: 1%; white-space: nowrap; }
+td.actions button { padding: 4px 10px; font-size: 12px; }
+.empty-state {
+  padding: 24px;
+  text-align: center;
+  color: var(--muted);
+  font-size: 13px;
+}
+.form-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+  flex-wrap: wrap;
+}
+.form-mode-label {
+  font-size: 12px;
+  color: var(--muted);
+  font-weight: 500;
+}
+.pre-auth { opacity: 0.5; pointer-events: none; }
+#signin-area { margin-top: 8px; }
+.badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; background: #eef; color: var(--accent); }
+.badge-you { background: var(--success-bg); color: var(--success-fg); margin-left: 8px; }
+.raw-response summary { font-size: 12px; color: var(--muted); cursor: pointer; margin-top: 12px; }
+.raw-response[open] summary { margin-bottom: 4px; }
+
+/* New panel styles for v1.0.0-beta.2 surface */
+.panel-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+}
+.panel-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: end;
+}
+.panel-row > input,
+.panel-row > textarea { flex: 1; min-width: 180px; }
+.composition {
+  border-left: 3px solid var(--accent);
+  padding: 8px 12px;
+  margin-top: 12px;
+  background: var(--row-hover);
+  border-radius: 4px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.composition summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--ink);
+}
+.composition ol { margin: 6px 0 0 18px; padding: 0; }
+.composition li { margin-bottom: 2px; font-family: 'SF Mono', Menlo, monospace; }
+.endpoint-label {
+  font-family: 'SF Mono', Menlo, monospace;
+  font-size: 11px;
+  color: var(--muted);
+  margin-left: 6px;
+}
+.pending-banner {
+  background: #fffbe6;
+  border: 1px solid #ffe58f;
+  color: #ad8b00;
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 12px;
+  margin-top: 8px;
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/styles.css
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/styles.css
@@ -48,6 +48,28 @@ input, textarea {
   font-family: inherit;
 }
 textarea { font-family: 'SF Mono', Menlo, monospace; font-size: 13px; resize: vertical; min-height: 60px; }
+select {
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 14px;
+  font-family: inherit;
+  background: #fff;
+}
+/* Checkboxes/radios must not inherit the full-width `input` rule above. */
+input[type="checkbox"], input[type="radio"] { width: auto; }
+.field-label { display: inline-flex; flex-direction: column; gap: 4px; font-size: 12px; color: var(--muted); }
+.fires-on {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 12px;
+  margin: 0;
+}
+.fires-on legend { font-size: 12px; color: var(--muted); padding: 0 4px; }
+.fires-on label { display: inline-flex; align-items: center; gap: 5px; font-size: 13px; color: var(--ink); }
 button {
   background: var(--accent);
   color: white;
@@ -98,9 +120,14 @@ pre {
   padding: 12px;
   border-radius: 6px;
   font-size: 12px;
-  overflow-x: auto;
+  overflow: auto;
   margin: 8px 0 0;
   max-height: 240px;
+  max-width: 100%;
+  /* Wrap long unbreakable strings (e.g. single-line JSON error payloads)
+     so the block never pushes past its card. */
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 .mode-toggle {
   display: flex;
@@ -212,6 +239,9 @@ td.actions button { padding: 4px 10px; font-size: 12px; }
   grid-template-columns: 1fr;
   gap: 12px;
 }
+/* Allow grid tracks to shrink below their content's intrinsic width so a
+   long line inside a child (e.g. a <pre>) can't widen the whole card. */
+.panel-grid > section { min-width: 0; }
 .panel-row {
   display: flex;
   gap: 8px;

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebBackend.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebBackend.swift
@@ -66,6 +66,12 @@ internal protocol WebBackend: Sendable {
     recordChangeTag: String?,
     database: MistKit.Database
   ) async throws
+
+  func webModifyZones(
+    create: [String],
+    delete: [String],
+    database: MistKit.Database
+  ) async throws -> [ZoneInfo]
 }
 
 extension CloudKitService: WebBackend {
@@ -130,5 +136,16 @@ extension CloudKitService: WebBackend {
       recordChangeTag: recordChangeTag,
       database: database
     )
+  }
+
+  internal func webModifyZones(
+    create: [String],
+    delete: [String],
+    database: MistKit.Database
+  ) async throws -> [ZoneInfo] {
+    let operations =
+      create.map { ZoneOperation.create(ZoneID(zoneName: $0)) }
+      + delete.map { ZoneOperation.delete(ZoneID(zoneName: $0)) }
+    return try await modifyZones(operations, database: database)
   }
 }

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebIndexHTML.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebIndexHTML.swift
@@ -32,26 +32,63 @@
 
   /// Loader for the web command's interactive page served by `WebServer`.
   ///
-  /// The HTML+JS lives in `Resources/index.html` and is read from
-  /// `Bundle.module` on first access. The mode toggle in this page lets
-  /// users compare MistKit (server-side) and CloudKit JS (browser-side)
-  /// against the same CloudKit container; the CloudKit JS side is wired
-  /// in by #329.
+  /// The HTML, CSS, and JS modules live under `Resources/` and are read
+  /// from `Bundle.module` on first access, then cached in memory so each
+  /// request serves the same `ByteBuffer`. The mode toggle in `index.html`
+  /// lets users compare MistKit (server-side) and CloudKit JS (browser-
+  /// side) against the same CloudKit container.
   internal enum WebIndexHTML {
     internal static let content: String = loadContent()
+    /// Cached extracted CSS file body served at `GET /styles.css`.
+    internal static let stylesheet: String = loadResource(
+      name: "styles", extension: "css"
+    )
+
+    /// Cached JS module bodies, keyed by the path the browser requests
+    /// (e.g. `"app.js"`). Populated once from the bundled `js/`
+    /// subdirectory; missing files surface as a preconditionFailure on
+    /// boot so a typo'd `<script src>` doesn't masquerade as a 404 in
+    /// production.
+    internal static let jsModules: [String: String] = loadJSModules()
 
     private static func loadContent() -> String {
+      loadResource(name: "index", extension: "html")
+    }
+
+    private static func loadResource(name: String, extension ext: String) -> String {
       guard
-        let url = Bundle.module.url(
-          forResource: "index", withExtension: "html"
-        ),
-        let html = try? String(contentsOf: url, encoding: .utf8)
+        let url = Bundle.module.url(forResource: name, withExtension: ext),
+        let content = try? String(contentsOf: url, encoding: .utf8)
       else {
         preconditionFailure(
-          "Resources/index.html missing from MistDemoKit bundle"
+          "Resources/\(name).\(ext) missing from MistDemoKit bundle"
         )
       }
-      return html
+      return content
+    }
+
+    private static func loadJSModules() -> [String: String] {
+      let names = [
+        "app", "mode", "pending", "auth",
+        "records", "zones", "subscriptions",
+        "tokens", "assets", "users",
+      ]
+      var modules: [String: String] = [:]
+      modules.reserveCapacity(names.count)
+      for name in names {
+        guard
+          let url = Bundle.module.url(
+            forResource: name, withExtension: "js", subdirectory: "js"
+          ),
+          let body = try? String(contentsOf: url, encoding: .utf8)
+        else {
+          preconditionFailure(
+            "Resources/js/\(name).js missing from MistDemoKit bundle"
+          )
+        }
+        modules["\(name).js"] = body
+      }
+      return modules
     }
   }
 #endif

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebRequests+Zones.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebRequests+Zones.swift
@@ -1,0 +1,69 @@
+//
+//  WebRequests+Zones.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+internal import Foundation
+internal import MistKit
+
+extension WebRequests {
+  /// `POST /api/zones/modify`
+  ///
+  /// Mirrors CloudKit Web Services `zones/modify`: a batch of create and/or
+  /// delete operations against the target database. The browser sends each
+  /// zone as `{ "zoneName": "X" }` (matching the CloudKit JS `RecordZone`
+  /// shape), so both arrays decode through `ZoneRef`.
+  ///
+  /// `zones/modify` is unsupported on `.public` (it has only `_defaultZone`);
+  /// the MistKit wrapper rejects that case, surfacing as a `500` error body.
+  internal struct ModifyZones: Decodable {
+    internal struct ZoneRef: Decodable, Sendable {
+      internal let zoneName: String
+    }
+
+    private enum CodingKeys: String, CodingKey {
+      case create
+      case delete
+      case database
+    }
+
+    internal let create: [ZoneRef]
+    internal let delete: [ZoneRef]
+    internal let database: MistKit.Database
+
+    internal init(from decoder: any Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      self.create =
+        try container.decodeIfPresent([ZoneRef].self, forKey: .create) ?? []
+      self.delete =
+        try container.decodeIfPresent([ZoneRef].self, forKey: .delete) ?? []
+      self.database = try WebRequests.decodeDatabase(
+        from: container, forKey: .database
+      )
+    }
+  }
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebRequests.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebRequests.swift
@@ -169,6 +169,42 @@ internal enum WebRequests {
     }
   }
 
+  /// `POST /api/zones/modify`
+  ///
+  /// Mirrors CloudKit Web Services `zones/modify`: a batch of create and/or
+  /// delete operations against the target database. The browser sends each
+  /// zone as `{ "zoneName": "X" }` (matching the CloudKit JS `RecordZone`
+  /// shape), so both arrays decode through `ZoneRef`.
+  ///
+  /// `zones/modify` is unsupported on `.public` (it has only `_defaultZone`);
+  /// the MistKit wrapper rejects that case, surfacing as a `500` error body.
+  internal struct ModifyZones: Decodable {
+    internal struct ZoneRef: Decodable, Sendable {
+      internal let zoneName: String
+    }
+
+    private enum CodingKeys: String, CodingKey {
+      case create
+      case delete
+      case database
+    }
+
+    internal let create: [ZoneRef]
+    internal let delete: [ZoneRef]
+    internal let database: MistKit.Database
+
+    internal init(from decoder: any Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      self.create =
+        try container.decodeIfPresent([ZoneRef].self, forKey: .create) ?? []
+      self.delete =
+        try container.decodeIfPresent([ZoneRef].self, forKey: .delete) ?? []
+      self.database = try WebRequests.decodeDatabase(
+        from: container, forKey: .database
+      )
+    }
+  }
+
   /// CloudKit database targeted by a request. Defaults to `.private` when
   /// the field is omitted so legacy clients (pre-database-picker) keep
   /// working.

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebRequests.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebRequests.swift
@@ -169,42 +169,6 @@ internal enum WebRequests {
     }
   }
 
-  /// `POST /api/zones/modify`
-  ///
-  /// Mirrors CloudKit Web Services `zones/modify`: a batch of create and/or
-  /// delete operations against the target database. The browser sends each
-  /// zone as `{ "zoneName": "X" }` (matching the CloudKit JS `RecordZone`
-  /// shape), so both arrays decode through `ZoneRef`.
-  ///
-  /// `zones/modify` is unsupported on `.public` (it has only `_defaultZone`);
-  /// the MistKit wrapper rejects that case, surfacing as a `500` error body.
-  internal struct ModifyZones: Decodable {
-    internal struct ZoneRef: Decodable, Sendable {
-      internal let zoneName: String
-    }
-
-    private enum CodingKeys: String, CodingKey {
-      case create
-      case delete
-      case database
-    }
-
-    internal let create: [ZoneRef]
-    internal let delete: [ZoneRef]
-    internal let database: MistKit.Database
-
-    internal init(from decoder: any Decoder) throws {
-      let container = try decoder.container(keyedBy: CodingKeys.self)
-      self.create =
-        try container.decodeIfPresent([ZoneRef].self, forKey: .create) ?? []
-      self.delete =
-        try container.decodeIfPresent([ZoneRef].self, forKey: .delete) ?? []
-      self.database = try WebRequests.decodeDatabase(
-        from: container, forKey: .database
-      )
-    }
-  }
-
   /// CloudKit database targeted by a request. Defaults to `.private` when
   /// the field is omitted so legacy clients (pre-database-picker) keep
   /// working.
@@ -213,7 +177,7 @@ internal enum WebRequests {
   /// Decode `database` (string raw-value) from a keyed container. Falls back
   /// to `defaultDatabase` when the key is absent and throws when present but
   /// unrecognized so a typo surfaces as a `400` rather than a silent default.
-  fileprivate static func decodeDatabase<Key: CodingKey>(
+  internal static func decodeDatabase<Key: CodingKey>(
     from container: KeyedDecodingContainer<Key>,
     forKey key: Key
   ) throws -> MistKit.Database {

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebResponse.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebResponse.swift
@@ -43,6 +43,13 @@ internal enum WebResponse {
     internal let deleted: Bool
   }
 
+  /// Body returned by zone routes (`zones/modify`). `ZoneInfo` encodes to
+  /// `{ zoneName, ownerRecordName, capabilities }`, which the browser's
+  /// zone table reads directly.
+  internal struct Zones: Encodable {
+    internal let zones: [ZoneInfo]
+  }
+
   /// Body returned for any handled CloudKit/MistKit error so the UI can
   /// surface the message without parsing transport-level failures.
   internal struct Error: Encodable {

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer+Pending.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer+Pending.swift
@@ -39,6 +39,38 @@
       case post
     }
 
+    private static func registerPending(
+      api: RouterGroup<BasicRequestContext>,
+      verb: PendingVerb,
+      path: String,
+      endpoint: String,
+      trackingIssue: Int
+    ) {
+      let bytes: Data
+      do {
+        bytes = try PendingStub.responseJSON(
+          endpoint: endpoint, trackingIssue: trackingIssue
+        )
+      } catch {
+        // PendingStub.responseJSON encodes a fixed shape; failure here would
+        // be a programmer error, not a runtime failure. Crash early so a
+        // broken stub doesn't masquerade as a working route.
+        preconditionFailure(
+          "Failed to encode pending-stub body for \(endpoint): \(error)"
+        )
+      }
+      let handler: @Sendable (Request, BasicRequestContext) async throws -> Response = {
+        _, _ -> Response in
+        Self.jsonResponse(status: .notImplemented, bytes: bytes)
+      }
+      switch verb {
+      case .get:
+        api.get(RouterPath(path), use: handler)
+      case .post:
+        api.post(RouterPath(path), use: handler)
+      }
+    }
+
     /// Register 501 stubs for every CloudKit Web Services endpoint whose
     /// MistKit Swift wrapper hasn't landed yet. Each route returns the
     /// shared `PendingStub.responseJSON` payload so the browser-side panel
@@ -79,6 +111,13 @@
       Self.registerPending(
         api: api,
         verb: .post,
+        path: "subscriptions/modify",
+        endpoint: "subscriptions/modify",
+        trackingIssue: 51
+      )
+      Self.registerPending(
+        api: api,
+        verb: .post,
         path: "tokens",
         endpoint: "tokens/create",
         trackingIssue: 52
@@ -90,38 +129,6 @@
         endpoint: "tokens/register",
         trackingIssue: 53
       )
-    }
-
-    private static func registerPending(
-      api: RouterGroup<BasicRequestContext>,
-      verb: PendingVerb,
-      path: String,
-      endpoint: String,
-      trackingIssue: Int
-    ) {
-      let bytes: Data
-      do {
-        bytes = try PendingStub.responseJSON(
-          endpoint: endpoint, trackingIssue: trackingIssue
-        )
-      } catch {
-        // PendingStub.responseJSON encodes a fixed shape; failure here would
-        // be a programmer error, not a runtime failure. Crash early so a
-        // broken stub doesn't masquerade as a working route.
-        preconditionFailure(
-          "Failed to encode pending-stub body for \(endpoint): \(error)"
-        )
-      }
-      let handler: @Sendable (Request, BasicRequestContext) async throws -> Response = {
-        _, _ -> Response in
-        Self.jsonResponse(status: .notImplemented, bytes: bytes)
-      }
-      switch verb {
-      case .get:
-        api.get(RouterPath(path), use: handler)
-      case .post:
-        api.post(RouterPath(path), use: handler)
-      }
     }
   }
 #endif

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer+Pending.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer+Pending.swift
@@ -146,69 +146,28 @@
       api: RouterGroup<BasicRequestContext>
     ) {
       let routeWiringIssue = 370
-      Self.registerPending(
-        api: api,
-        verb: .post,
-        path: "records/lookup",
-        endpoint: "records/lookup",
-        trackingIssue: routeWiringIssue
-      )
-      Self.registerPending(
-        api: api,
-        verb: .post,
-        path: "records/changes",
-        endpoint: "records/changes",
-        trackingIssue: routeWiringIssue
-      )
-      Self.registerPending(
-        api: api,
-        verb: .post,
-        path: "zones/list",
-        endpoint: "zones/list",
-        trackingIssue: routeWiringIssue
-      )
-      Self.registerPending(
-        api: api,
-        verb: .post,
-        path: "zones/lookup",
-        endpoint: "zones/lookup",
-        trackingIssue: routeWiringIssue
-      )
-      Self.registerPending(
-        api: api,
-        verb: .post,
-        path: "zones/changes",
-        endpoint: "zones/changes",
-        trackingIssue: routeWiringIssue
-      )
-      Self.registerPending(
-        api: api,
-        verb: .get,
-        path: "users/caller",
-        endpoint: "users/caller",
-        trackingIssue: routeWiringIssue
-      )
-      Self.registerPending(
-        api: api,
-        verb: .post,
-        path: "users/discover",
-        endpoint: "users/discover",
-        trackingIssue: routeWiringIssue
-      )
-      Self.registerPending(
-        api: api,
-        verb: .post,
-        path: "users/lookup/email",
-        endpoint: "users/lookup/email",
-        trackingIssue: routeWiringIssue
-      )
-      Self.registerPending(
-        api: api,
-        verb: .post,
-        path: "users/lookup/id",
-        endpoint: "users/lookup/id",
-        trackingIssue: routeWiringIssue
-      )
+      // Each route's `endpoint` label equals its path here, so a flat list of
+      // (verb, path) pairs drives registration without per-route boilerplate.
+      let routes: [(verb: PendingVerb, path: String)] = [
+        (.post, "records/lookup"),
+        (.post, "records/changes"),
+        (.post, "zones/list"),
+        (.post, "zones/lookup"),
+        (.post, "zones/changes"),
+        (.get, "users/caller"),
+        (.post, "users/discover"),
+        (.post, "users/lookup/email"),
+        (.post, "users/lookup/id"),
+      ]
+      for route in routes {
+        Self.registerPending(
+          api: api,
+          verb: route.verb,
+          path: route.path,
+          endpoint: route.path,
+          trackingIssue: routeWiringIssue
+        )
+      }
     }
   }
 #endif

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer+Pending.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer+Pending.swift
@@ -1,0 +1,127 @@
+//
+//  WebServer+Pending.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if canImport(Hummingbird)
+  internal import Foundation
+  internal import HTTPTypes
+  internal import Hummingbird
+
+  extension WebServer {
+    /// HTTP verbs the pending registrar supports — only the ones we need.
+    internal enum PendingVerb {
+      case get
+      case post
+    }
+
+    /// Register 501 stubs for every CloudKit Web Services endpoint whose
+    /// MistKit Swift wrapper hasn't landed yet. Each route returns the
+    /// shared `PendingStub.responseJSON` payload so the browser-side panel
+    /// renders a structured "pending #N" body. When a tracking issue lands,
+    /// flip the corresponding `api.<verb>(...)` registration here to the
+    /// real handler (or move it into a dedicated extension file).
+    internal func addPendingEndpoints(
+      api: RouterGroup<BasicRequestContext>
+    ) {
+      Self.registerPending(
+        api: api,
+        verb: .post,
+        path: "records/resolve",
+        endpoint: "records/resolve",
+        trackingIssue: 41
+      )
+      Self.registerPending(
+        api: api,
+        verb: .post,
+        path: "assets/rereference",
+        endpoint: "assets/rereference",
+        trackingIssue: 31
+      )
+      Self.registerPending(
+        api: api,
+        verb: .get,
+        path: "subscriptions",
+        endpoint: "subscriptions/list",
+        trackingIssue: 49
+      )
+      Self.registerPending(
+        api: api,
+        verb: .get,
+        path: "subscriptions/:id",
+        endpoint: "subscriptions/lookup",
+        trackingIssue: 50
+      )
+      Self.registerPending(
+        api: api,
+        verb: .post,
+        path: "tokens",
+        endpoint: "tokens/create",
+        trackingIssue: 52
+      )
+      Self.registerPending(
+        api: api,
+        verb: .post,
+        path: "tokens/register",
+        endpoint: "tokens/register",
+        trackingIssue: 53
+      )
+    }
+
+    private static func registerPending(
+      api: RouterGroup<BasicRequestContext>,
+      verb: PendingVerb,
+      path: String,
+      endpoint: String,
+      trackingIssue: Int
+    ) {
+      let bytes: Data
+      do {
+        bytes = try PendingStub.responseJSON(
+          endpoint: endpoint, trackingIssue: trackingIssue
+        )
+      } catch {
+        // PendingStub.responseJSON encodes a fixed shape; failure here would
+        // be a programmer error, not a runtime failure. Crash early so a
+        // broken stub doesn't masquerade as a working route.
+        preconditionFailure(
+          "Failed to encode pending-stub body for \(endpoint): \(error)"
+        )
+      }
+      let handler: @Sendable (Request, BasicRequestContext) async throws -> Response = {
+        _, _ -> Response in
+        Self.jsonResponse(status: .notImplemented, bytes: bytes)
+      }
+      switch verb {
+      case .get:
+        api.get(RouterPath(path), use: handler)
+      case .post:
+        api.post(RouterPath(path), use: handler)
+      }
+    }
+  }
+#endif

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer+Pending.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer+Pending.swift
@@ -129,6 +129,86 @@
         endpoint: "tokens/register",
         trackingIssue: 53
       )
+
+      addUnwiredLandedEndpoints(api: api)
+    }
+
+    /// Register 501 stubs for endpoints whose MistKit Swift wrapper *has*
+    /// already landed but isn't exposed on the demo server yet — only the
+    /// `/api/*` route wiring is outstanding, tracked by #370. These return
+    /// the same structured pending body as `addPendingEndpoints`; replacing a
+    /// stub here with a real handler (mirroring `WebServer+Zones`) is the
+    /// remaining work for #370's "exercisable in both modes" criterion.
+    ///
+    /// Note: #370 is the tracking issue for the *route wiring*, not for the
+    /// wrapper (which shipped under #215/#45/#47/#48/#367).
+    internal func addUnwiredLandedEndpoints(
+      api: RouterGroup<BasicRequestContext>
+    ) {
+      let routeWiringIssue = 370
+      Self.registerPending(
+        api: api,
+        verb: .post,
+        path: "records/lookup",
+        endpoint: "records/lookup",
+        trackingIssue: routeWiringIssue
+      )
+      Self.registerPending(
+        api: api,
+        verb: .post,
+        path: "records/changes",
+        endpoint: "records/changes",
+        trackingIssue: routeWiringIssue
+      )
+      Self.registerPending(
+        api: api,
+        verb: .post,
+        path: "zones/list",
+        endpoint: "zones/list",
+        trackingIssue: routeWiringIssue
+      )
+      Self.registerPending(
+        api: api,
+        verb: .post,
+        path: "zones/lookup",
+        endpoint: "zones/lookup",
+        trackingIssue: routeWiringIssue
+      )
+      Self.registerPending(
+        api: api,
+        verb: .post,
+        path: "zones/changes",
+        endpoint: "zones/changes",
+        trackingIssue: routeWiringIssue
+      )
+      Self.registerPending(
+        api: api,
+        verb: .get,
+        path: "users/caller",
+        endpoint: "users/caller",
+        trackingIssue: routeWiringIssue
+      )
+      Self.registerPending(
+        api: api,
+        verb: .post,
+        path: "users/discover",
+        endpoint: "users/discover",
+        trackingIssue: routeWiringIssue
+      )
+      Self.registerPending(
+        api: api,
+        verb: .post,
+        path: "users/lookup/email",
+        endpoint: "users/lookup/email",
+        trackingIssue: routeWiringIssue
+      )
+      Self.registerPending(
+        api: api,
+        verb: .post,
+        path: "users/lookup/id",
+        endpoint: "users/lookup/id",
+        trackingIssue: routeWiringIssue
+      )
     }
   }
 #endif

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer+Zones.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer+Zones.swift
@@ -1,0 +1,66 @@
+//
+//  WebServer+Zones.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if canImport(Hummingbird)
+  internal import Foundation
+  internal import Hummingbird
+  internal import MistKit
+
+  extension WebServer {
+    /// `POST /api/zones/modify` — create and/or delete zones in one batch,
+    /// backing the demo's MistKit-mode "Create Zone" / "Delete Zone" buttons.
+    /// CloudKit JS mode hits the browser SDK directly; this is the
+    /// server-side counterpart.
+    internal func addZonesModifyEndpoint(
+      api: RouterGroup<BasicRequestContext>
+    ) {
+      let tokenStore = self.tokenStore
+      let backendFactory = self.backendFactory
+      api.post("zones/modify") { request, context -> Response in
+        guard let token = await tokenStore.currentToken else {
+          return Response(status: .unauthorized)
+        }
+        let body = try await request.decode(
+          as: WebRequests.ModifyZones.self, context: context
+        )
+        return try await Self.runOperation { () -> Data in
+          let backend = try backendFactory.make(token)
+          let zones = try await backend.webModifyZones(
+            create: body.create.map(\.zoneName),
+            delete: body.delete.map(\.zoneName),
+            database: body.database
+          )
+          return try WebJSON.encoder().encode(
+            WebResponse.Zones(zones: zones)
+          )
+        }
+      }
+    }
+  }
+#endif

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer.swift
@@ -127,6 +127,7 @@
       addCreateEndpoint(api: api)
       addUpdateEndpoint(api: api)
       addDeleteEndpoint(api: api)
+      addZonesModifyEndpoint(api: api)
       addPendingEndpoints(api: api)
 
       return router

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer.swift
@@ -109,6 +109,7 @@
       router.middlewares.add(LogRequestsMiddleware(.info))
 
       addIndexEndpoint(router: router)
+      addStaticAssetEndpoints(router: router)
 
       let api = router.group("api")
         .add(middleware: LoopbackOnlyMiddleware<BasicRequestContext>())
@@ -126,6 +127,7 @@
       addCreateEndpoint(api: api)
       addUpdateEndpoint(api: api)
       addDeleteEndpoint(api: api)
+      addPendingEndpoints(api: api)
 
       return router
     }
@@ -147,6 +149,43 @@
       router.get("/") { _, _ -> Response in indexResponseBuilder() }
       router.get("/index.html") { _, _ -> Response in
         indexResponseBuilder()
+      }
+    }
+
+    /// Serve the extracted `styles.css` and `js/*.js` modules referenced
+    /// from `index.html`. Each file's bytes are read once at startup
+    /// (see `WebIndexHTML.stylesheet` / `.jsModules`) and re-served from
+    /// memory on every request — same pattern as the cached index page.
+    private func addStaticAssetEndpoints(
+      router: Router<BasicRequestContext>
+    ) {
+      let cssBytes = ByteBuffer(string: WebIndexHTML.stylesheet)
+      router.get("/styles.css") { _, _ -> Response in
+        Response(
+          status: .ok,
+          headers: [.contentType: "text/css; charset=utf-8"],
+          body: ResponseBody { writer in
+            try await writer.write(cssBytes)
+            try await writer.finish(nil)
+          }
+        )
+      }
+
+      // Register one route per known JS module rather than a wildcard
+      // handler, so unknown `js/*` requests return 404 — and we don't
+      // accidentally serve future-added files we haven't reviewed.
+      for (filename, body) in WebIndexHTML.jsModules {
+        let bytes = ByteBuffer(string: body)
+        router.get(RouterPath("/js/\(filename)")) { _, _ -> Response in
+          Response(
+            status: .ok,
+            headers: [.contentType: "application/javascript; charset=utf-8"],
+            body: ResponseBody { writer in
+              try await writer.write(bytes)
+              try await writer.finish(nil)
+            }
+          )
+        }
       }
     }
 

--- a/Examples/MistDemo/Sources/MistDemoKit/Utilities/PendingStub.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Utilities/PendingStub.swift
@@ -1,0 +1,66 @@
+//
+//  PendingStub.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+public import Foundation
+
+/// Shared messaging for CloudKit Web Services endpoints whose MistKit Swift
+/// wrapper hasn't landed yet. Used by CLI commands, integration phases, and
+/// `mistdemo web` 501 responses so the "pending #N" banner stays consistent
+/// and grep-able. When the underlying MistKit API lands, callers flip from
+/// this helper to the real implementation.
+public enum PendingStub {
+  private struct Body: Encodable {
+    let error: String
+    let endpoint: String
+    let tracking: String
+
+    init(endpoint: String, tracking: String) {
+      self.error = "not_implemented"
+      self.endpoint = endpoint
+      self.tracking = tracking
+    }
+  }
+
+  /// Print the standard "not yet implemented" banner for `endpoint`, citing
+  /// the GitHub issue tracking the underlying MistKit wrapper.
+  public static func printPending(endpoint: String, trackingIssue: Int) {
+    print(
+      "⚠️  \(endpoint) — not yet implemented "
+        + "(pending MistKit support, tracked in #\(trackingIssue))"
+    )
+  }
+
+  /// Encode the standard 501 response body — `{"error":"not_implemented",
+  /// "endpoint":"…","tracking":"#N"}` — for the web server stubs.
+  public static func responseJSON(endpoint: String, trackingIssue: Int) throws -> Data {
+    try JSONEncoder().encode(
+      Body(endpoint: endpoint, tracking: "#\(trackingIssue)")
+    )
+  }
+}

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend+Calls.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend+Calls.swift
@@ -1,0 +1,75 @@
+//
+//  MockBackend+Calls.swift
+//  MistDemoTests
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if canImport(Hummingbird)
+  internal import MistKit
+
+  @testable import MistDemoKit
+
+  extension MockBackend {
+    /// Captured arguments from the most recent `webQuery` call.
+    internal struct QueryCall: Sendable {
+      internal let recordType: String
+      internal let limit: Int?
+      internal let sortBy: [WebRequests.QuerySortField]?
+      internal let database: MistKit.Database
+    }
+
+    /// Captured arguments from the most recent `webCreate` call.
+    internal struct CreateCall: Sendable {
+      internal let recordType: String
+      internal let fields: [String: String]
+      internal let database: MistKit.Database
+    }
+
+    /// Captured arguments from the most recent `webUpdate` call.
+    internal struct UpdateCall: Sendable {
+      internal let recordType: String
+      internal let recordName: String
+      internal let fields: [String: String]
+      internal let recordChangeTag: String?
+      internal let database: MistKit.Database
+    }
+
+    /// Captured arguments from the most recent `webDelete` call.
+    internal struct DeleteCall: Sendable {
+      internal let recordType: String
+      internal let recordName: String
+      internal let recordChangeTag: String?
+      internal let database: MistKit.Database
+    }
+
+    /// Captured arguments from the most recent `webModifyZones` call.
+    internal struct ModifyZonesCall: Sendable {
+      internal let create: [String]
+      internal let delete: [String]
+      internal let database: MistKit.Database
+    }
+  }
+#endif

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend.swift
@@ -36,40 +36,6 @@
   /// In-memory `WebBackend` for routing-level tests. Records the last
   /// call to each operation and returns deterministic stub records.
   internal final actor MockBackend: WebBackend {
-    internal struct QueryCall: Sendable {
-      internal let recordType: String
-      internal let limit: Int?
-      internal let sortBy: [WebRequests.QuerySortField]?
-      internal let database: MistKit.Database
-    }
-
-    internal struct CreateCall: Sendable {
-      internal let recordType: String
-      internal let fields: [String: String]
-      internal let database: MistKit.Database
-    }
-
-    internal struct UpdateCall: Sendable {
-      internal let recordType: String
-      internal let recordName: String
-      internal let fields: [String: String]
-      internal let recordChangeTag: String?
-      internal let database: MistKit.Database
-    }
-
-    internal struct DeleteCall: Sendable {
-      internal let recordType: String
-      internal let recordName: String
-      internal let recordChangeTag: String?
-      internal let database: MistKit.Database
-    }
-
-    internal struct ModifyZonesCall: Sendable {
-      internal let create: [String]
-      internal let delete: [String]
-      internal let database: MistKit.Database
-    }
-
     internal private(set) var lastQuery: QueryCall?
     internal private(set) var lastCreate: CreateCall?
     internal private(set) var lastUpdate: UpdateCall?

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend.swift
@@ -64,10 +64,17 @@
       internal let database: MistKit.Database
     }
 
+    internal struct ModifyZonesCall: Sendable {
+      internal let create: [String]
+      internal let delete: [String]
+      internal let database: MistKit.Database
+    }
+
     internal private(set) var lastQuery: QueryCall?
     internal private(set) var lastCreate: CreateCall?
     internal private(set) var lastUpdate: UpdateCall?
     internal private(set) var lastDelete: DeleteCall?
+    internal private(set) var lastModifyZones: ModifyZonesCall?
     private var pendingError: String?
 
     private static func stubRecord(
@@ -194,6 +201,22 @@
         database: database
       )
       try consumePendingError()
+    }
+
+    internal func webModifyZones(
+      create: [String],
+      delete: [String],
+      database: MistKit.Database
+    ) async throws -> [ZoneInfo] {
+      lastModifyZones = ModifyZonesCall(
+        create: create,
+        delete: delete,
+        database: database
+      )
+      try consumePendingError()
+      return create.map { name in
+        ZoneInfo(zoneName: name, ownerRecordName: nil, capabilities: [])
+      }
     }
 
     private func consumePendingError() throws {

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+Index.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+Index.swift
@@ -38,84 +38,74 @@
   @testable import MistDemoKit
 
   extension WebServerTests {
-    @Test("GET / returns the web demo HTML")
-    internal func indexReturnsHtml() async throws {
-      let fixture = Self.makeFixture()
-      let app = Application(router: try fixture.server.makeRouter())
-
-      try await app.test(.router) { client in
-        try await client.execute(uri: "/", method: .get) { response in
+    /// Fetch a served document body as a string, asserting a 200.
+    ///
+    /// The web demo's CSS and JS were extracted out of `index.html` into
+    /// `/styles.css` and `/js/*.js` static assets, so the structural HTML,
+    /// behavior (JS), and styling (CSS) each live at a distinct URI now.
+    private func body(at uri: String) async throws -> String {
+      let app = Application(router: try Self.makeFixture().server.makeRouter())
+      return try await app.test(.router) { client in
+        try await client.execute(uri: uri, method: .get) { response in
           #expect(response.status == .ok)
-          let body = String(buffer: response.body)
-          #expect(body.contains("MistKit Web Demo"))
+          return String(buffer: response.body)
         }
       }
+    }
+
+    @Test("GET / returns the web demo HTML")
+    internal func indexReturnsHtml() async throws {
+      let html = try await body(at: "/")
+      #expect(html.contains("MistKit Web Demo"))
     }
 
     @Test("Index HTML wires CloudKit JS as an alternate backend")
     internal func indexExposesCloudKitJsHandlers() async throws {
-      let fixture = Self.makeFixture()
-      let app = Application(router: try fixture.server.makeRouter())
+      let html = try await body(at: "/")
+      #expect(html.contains("cdn.apple-cloudkit.com/ck/2/cloudkit.js"))
+      #expect(!html.contains("id=\"mode-cloudkitjs\" type=\"button\" disabled"))
 
-      try await app.test(.router) { client in
-        try await client.execute(uri: "/", method: .get) { response in
-          #expect(response.status == .ok)
-          let body = String(buffer: response.body)
-          #expect(body.contains("cdn.apple-cloudkit.com/ck/2/cloudkit.js"))
-          #expect(!body.contains("id=\"mode-cloudkitjs\" type=\"button\" disabled"))
-          #expect(body.contains("performQuery"))
-          #expect(body.contains("saveRecords"))
-          #expect(body.contains("deleteRecords"))
-          #expect(!body.contains("cloudKitJsNotWired"))
-        }
-      }
+      // CloudKit JS primitives now live in the extracted app module.
+      let appJs = try await body(at: "/js/app.js")
+      #expect(appJs.contains("performQuery"))
+      #expect(appJs.contains("saveRecords"))
+      #expect(appJs.contains("deleteRecords"))
+      #expect(!appJs.contains("cloudKitJsNotWired"))
     }
 
     @Test("Index HTML exposes a public/private database picker")
     internal func indexExposesDatabasePicker() async throws {
-      let fixture = Self.makeFixture()
-      let app = Application(router: try fixture.server.makeRouter())
+      let html = try await body(at: "/")
+      #expect(html.contains(#"id="db-private""#))
+      #expect(html.contains(#"id="db-public""#))
 
-      try await app.test(.router) { client in
-        try await client.execute(uri: "/", method: .get) { response in
-          #expect(response.status == .ok)
-          let body = String(buffer: response.body)
-          #expect(body.contains(#"id="db-private""#))
-          #expect(body.contains(#"id="db-public""#))
-          #expect(body.contains("publicCloudDatabase"))
-          #expect(body.contains("privateCloudDatabase"))
-        }
-      }
+      // The picker's wiring to the CloudKit JS database handles is in app.js.
+      let appJs = try await body(at: "/js/app.js")
+      #expect(appJs.contains("publicCloudDatabase"))
+      #expect(appJs.contains("privateCloudDatabase"))
     }
 
-    @Test("Index HTML carries the post-database-picker UX additions")
+    @Test("Web demo carries the post-database-picker UX additions")
     internal func indexCarriesUxPolish() async throws {
-      let fixture = Self.makeFixture()
-      let app = Application(router: try fixture.server.makeRouter())
-
-      try await app.test(.router) { client in
-        try await client.execute(uri: "/", method: .get) { response in
-          #expect(response.status == .ok)
-          let body = String(buffer: response.body)
-          // 1. Loading state
-          #expect(body.contains(".status.loading"))
-          #expect(body.contains("queryInFlight"))
-          #expect(body.contains("setQueryControlsDisabled"))
-          // 2. Post-create delay
-          #expect(body.contains("REFRESH_DELAY_MS"))
-          #expect(body.contains("waiting"))
-          // 3. "You" badge wired to the captured user identity
-          #expect(body.contains("currentUserRecordName"))
-          #expect(body.contains("badge-you"))
-          #expect(body.contains("extractUserRecordName"))
-          // 4. Default sort = ___createTime descending
-          #expect(
-            body.contains(
-              "currentSort = { field: '___createTime', ascending: false }"
-            )
-          )
-        }
-      }
+      let css = try await body(at: "/styles.css")
+      let appJs = try await body(at: "/js/app.js")
+      // 1. Loading state
+      #expect(css.contains(".status.loading"))
+      #expect(appJs.contains("queryInFlight"))
+      #expect(appJs.contains("setQueryControlsDisabled"))
+      // 2. Post-create delay
+      #expect(appJs.contains("REFRESH_DELAY_MS"))
+      #expect(appJs.contains("waiting"))
+      // 3. "You" badge wired to the captured user identity
+      #expect(appJs.contains("currentUserRecordName"))
+      #expect(css.contains("badge-you"))
+      #expect(appJs.contains("extractUserRecordName"))
+      // 4. Default sort = ___createTime descending
+      #expect(
+        appJs.contains(
+          "currentSort = { field: '___createTime', ascending: false }"
+        )
+      )
     }
   }
 #endif

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+Zones.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+Zones.swift
@@ -1,0 +1,112 @@
+//
+//  WebServerTests+Zones.swift
+//  MistDemoTests
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if canImport(Hummingbird)
+  internal import Foundation
+  internal import HTTPTypes
+  internal import Hummingbird
+  internal import HummingbirdTesting
+  internal import MistKit
+  internal import Testing
+
+  @testable import MistDemoKit
+
+  extension WebServerTests {
+    private struct ZonesPayload: Decodable {
+      let zones: [ZoneInfo]
+    }
+
+    @Test("POST /api/zones/modify forwards a create operation to the backend")
+    internal func zonesModifyCreateForwards() async throws {
+      let fixture = Self.makeFixture(authenticated: true)
+      let app = Application(router: try fixture.server.makeRouter())
+      let jsonBody = #"{"database":"private","create":[{"zoneName":"Articles"}]}"#
+
+      try await app.test(.router) { client in
+        try await client.execute(
+          uri: "/api/zones/modify",
+          method: .post,
+          headers: [.contentType: "application/json"],
+          body: ByteBuffer(string: jsonBody)
+        ) { response in
+          #expect(response.status == .ok)
+          let payload = try JSONDecoder().decode(
+            ZonesPayload.self,
+            from: Data(response.body.readableBytesView)
+          )
+          #expect(payload.zones.first?.zoneName == "Articles")
+        }
+      }
+
+      let captured = await fixture.backend.lastModifyZones
+      #expect(captured?.create == ["Articles"])
+      #expect(captured?.delete == [])
+      #expect(captured?.database == .private)
+    }
+
+    @Test("POST /api/zones/modify forwards a delete operation to the backend")
+    internal func zonesModifyDeleteForwards() async throws {
+      let fixture = Self.makeFixture(authenticated: true)
+      let app = Application(router: try fixture.server.makeRouter())
+      let jsonBody = #"{"database":"private","delete":[{"zoneName":"Archive"}]}"#
+
+      try await app.test(.router) { client in
+        try await client.execute(
+          uri: "/api/zones/modify",
+          method: .post,
+          headers: [.contentType: "application/json"],
+          body: ByteBuffer(string: jsonBody)
+        ) { response in
+          #expect(response.status == .ok)
+        }
+      }
+
+      let captured = await fixture.backend.lastModifyZones
+      #expect(captured?.create == [])
+      #expect(captured?.delete == ["Archive"])
+    }
+
+    @Test("POST /api/zones/modify returns 401 without a captured auth token")
+    internal func zonesModifyRequiresAuth() async throws {
+      let fixture = Self.makeFixture(authenticated: false)
+      let app = Application(router: try fixture.server.makeRouter())
+
+      try await app.test(.router) { client in
+        try await client.execute(
+          uri: "/api/zones/modify",
+          method: .post,
+          headers: [.contentType: "application/json"],
+          body: ByteBuffer(string: #"{"create":[{"zoneName":"Z"}]}"#)
+        ) { response in
+          #expect(response.status == .unauthorized)
+        }
+      }
+    }
+  }
+#endif

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+Zones.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+Zones.swift
@@ -66,7 +66,7 @@
 
       let captured = await fixture.backend.lastModifyZones
       #expect(captured?.create == ["Articles"])
-      #expect(captured?.delete == [])
+      #expect(captured?.delete.isEmpty == true)
       #expect(captured?.database == .private)
     }
 
@@ -88,7 +88,7 @@
       }
 
       let captured = await fixture.backend.lastModifyZones
-      #expect(captured?.create == [])
+      #expect(captured?.create.isEmpty == true)
       #expect(captured?.delete == ["Archive"])
     }
 

--- a/Examples/MistDemo/Tests/MistDemoTests/Utilities/TestPlatform.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Utilities/TestPlatform.swift
@@ -46,16 +46,11 @@ internal enum TestPlatform {
 
   /// True when running inside CI on a simulator whose cooperative executor can
   /// starve the polling timeout task in `withTimeout` — see #334. The race is
-  /// bounded to iOS / visionOS / watchOS simulators under CI load; local sim
-  /// runs (CI env unset) stay strict to surface real regressions in the helper.
-  ///
-  /// The `CI` flag is delivered into the simulator's test-runner process via the
-  /// `TEST_RUNNER_CI` job-level env in the workflow — `xcodebuild test`
-  /// re-exports `TEST_RUNNER_`-prefixed host vars to the runner with the prefix
-  /// stripped, so it arrives as `CI`. (The earlier `SIMCTL_CHILD_CI` approach
-  /// never reached the xctest runner; an env dump confirmed it.)
+  /// bounded to Apple simulators (iOS / tvOS / visionOS / watchOS) under CI
+  /// load; local sim runs (CI env unset) stay strict to surface real
+  /// regressions in the helper.
   internal static let isFlakyTimeoutSimulator: Bool = {
-    #if (os(iOS) || os(visionOS) || os(watchOS)) && targetEnvironment(simulator)
+    #if (os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)) && targetEnvironment(simulator)
       return ProcessInfo.processInfo.environment["CI"] != nil
     #else
       return false


### PR DESCRIPTION
Part of #370 — scaffolds the **MistDemo CLI**, **MistDemoApp** (SwiftUI/native CloudKit), and **Web app** (Hummingbird) so every CloudKit Web Services endpoint in the v1.0.0-beta.2 milestone has a visible surface, with the MistKit-vs-CloudKit-JS asymmetry made explicit in the web app.

## What's included

**CLI** — 6 pending stub commands registered in `MistDemoRunner` (`resolve`, `rereference-asset`, `list-subscriptions`, `lookup-subscription`, `create-token`, `register-token`); each prints "pending #N" and exits 0. Shared `PendingStub` helper.

**Integration phases** — 6 stub `IntegrationPhase` files (not wired into `test-public`/`test-private`, kept green).

**MistDemoApp (native CloudKit)** — sidebar extended from 3 → 8 items; new `Records`, `Subscriptions`, `PushTokens`, `Assets`, `Users` views + `CompositionDisclosure`.

**Web app** — `index.html` refactored into `styles.css` + per-area `js/*.js` modules. Both-mode panels (MistKit server vs CloudKit JS browser) across the milestone surface.
- Real `POST /api/zones/modify` route (create/delete) via `CloudKitService.modifyZones` + tests.
- CloudKit JS calls corrected against the bundled reference (`fetchRecordZoneChanges`, `fetchCurrentUserIdentity`, `discoverUserIdentityWith{EmailAddress,UserRecordName}`, `saveRecordZones` zone shape, `fetchDatabaseChanges`, cycle-safe JSON serializer).
- Zones/Subscriptions rendered as tables; Subscriptions Create (query/zone) + Delete.
- 501 pending stubs for the 6 unlanded endpoints, plus 501 stubs for landed-but-unwired endpoints (`records/lookup`, `records/changes`, `zones/{list,lookup,changes}`, `users/*`).

## Status vs acceptance criteria

Done: CLI commands + registration, integration phases, app sidebar/views, HTML/JS/CSS refactor, web pending stubs, real `zones/modify`, CloudKit JS coverage.

**Remaining (why this is still a draft):**
- [ ] Wire the 9 landed-but-unwired MistKit server routes for real (currently 501) so they're exercisable in both modes: `records/lookup`, `records/changes`, `zones/{list,lookup,changes}` (mirror `WebServer+Zones`), and `users/{caller,discover,lookup/email,lookup/id}` (needs the public+web-auth `userContextService` in `WebBackendFactory`).
- [ ] Confirm the 5 new app views drive real native CloudKit calls and composed views carry the "📎 Composition" disclosure.
- [ ] Repo-root gates: `./Scripts/lint.sh` (build + swiftlint + header.sh + periphery) and full `swift test` clean.

Implementing the underlying MistKit wrappers for #31/#41/#49/#50/#52/#53 stays out of scope (each lands in its own PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)