### PR TITLE
Update integration test CloudKit record type to "Note"

### DIFF
--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/IntegrationTestData.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/IntegrationTestData.swift
@@ -32,7 +32,7 @@ internal import Foundation
 /// Test data generation utilities for integration tests.
 internal enum IntegrationTestData {
   /// CloudKit record type for integration tests.
-  internal static let recordType = "MistKitIntegrationTest"
+  internal static let recordType = "Note"
 
   /// Generate minimal PNG-like binary data for upload testing.
   ///


### PR DESCRIPTION
## Summary
Updates the CloudKit record type used in integration tests from a generic test identifier to the standard "Note" record type.

## Changes
- Changed `IntegrationTestData.recordType` from `"MistKitIntegrationTest"` to `"Note"` in `Examples/MistDemo/Sources/MistDemoKit/Integration/IntegrationTestData.swift`

## Details
This change aligns the integration test data with a more realistic CloudKit schema by using the standard "Note" record type instead of a custom test-specific identifier. This allows integration tests to work with actual CloudKit record types and better reflects real-world usage patterns in the MistDemo application.

https://claude.ai/code/session_01EvLrWZwcSs1MjiCrUx8KjU