### PR TITLE
Enable MistDemo integration workflow on claude/** branches

### DIFF
--- a/.github/workflows/MistDemo-Integration.yml
+++ b/.github/workflows/MistDemo-Integration.yml
@@ -31,6 +31,7 @@ on:
     branches:
       - main
       - 'v*.*.*'
+      - 'claude/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/MistDemo-Integration.yml
+++ b/.github/workflows/MistDemo-Integration.yml
@@ -31,7 +31,6 @@ on:
     branches:
       - main
       - 'v*.*.*'
-      - 'claude/**'
   workflow_dispatch:
 
 concurrency:

--- a/Examples/BushelCloud/Sources/BushelCloudCLI/Commands/ExportCommand.swift
+++ b/Examples/BushelCloud/Sources/BushelCloudCLI/Commands/ExportCommand.swift
@@ -43,7 +43,7 @@ internal enum ExportCommand {
 
   private struct RecordExport: Codable {
     let recordName: String
-    let recordType: String
+    let recordType: String?
     let fields: [String: String]
 
     init(from recordInfo: RecordInfo) {

--- a/Examples/BushelCloud/Sources/BushelCloudKit/DataSources/IPSWFetcher.swift
+++ b/Examples/BushelCloud/Sources/BushelCloudKit/DataSources/IPSWFetcher.swift
@@ -31,8 +31,8 @@ internal import BushelFoundation
 internal import BushelUtilities
 internal import Foundation
 internal import IPSWDownloads
-internal import OSVer
 internal import OpenAPIURLSession
+internal import OSVer
 
 #if canImport(FoundationNetworking)
   internal import FoundationNetworking

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformAliases.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformAliases.swift
@@ -27,13 +27,6 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-// The per-platform aliases live together (rather than one type per file)
-// because each is a thin, `#if`-selected typealias. The file is deliberately
-// not named after any one alias — in project-mode lint SwiftLint parses every
-// `#if` branch, so a filename-matching typealias ladder would be misread as a
-// `main_type` sitting amongst `supporting_type`s (`file_types_order`). Naming
-// the file neutrally keeps every alias a plain supporting type; the resulting
-// `file_name` mismatch is waived for this file in `.swiftlint.yml`.
 #if canImport(SwiftUI)
   public import SwiftUI
 

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplicationDelegate+RemoteNotifications.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplicationDelegate+RemoteNotifications.swift
@@ -27,11 +27,6 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-// The `application(_:didRegister…)` / `didFail…` selectors are identical on
-// AppKit and UIKit (both take the unified ``PlatformApplication``), so they
-// share one extension here. watchOS's `WKApplicationDelegate` uses
-// parameter-less selectors, so its variants live in
-// `PlatformApplicationDelegate+WKApplicationDelegate.swift` instead.
 #if (canImport(AppKit) && !targetEnvironment(macCatalyst)) || (canImport(UIKit) && !os(watchOS))
   public import Foundation
 

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplicationDelegate.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PlatformApplicationDelegate.swift
@@ -27,9 +27,6 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-// `@objc` requires the Objective-C runtime, which is absent on
-// Linux/Windows. This delegate protocol exists only to bridge APNs callbacks
-// on Apple platforms, so gate it on Objective-C interop availability.
 #if canImport(ObjectiveC)
   // `@objc` requires the Objective-C runtime, surfaced here via Foundation.
   internal import Foundation

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PushNotificationDelegate.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PushNotificationDelegate.swift
@@ -27,9 +27,6 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-// Conforms to the SwiftUI-defined ``ApplicationDelegate`` typealias and uses
-// `NSObject`/`@objc` machinery, so gate on SwiftUI (which implies an Apple
-// platform with Objective-C interop) to keep Linux/Windows builds clean.
 #if canImport(SwiftUI)
   public import Foundation
 

--- a/Examples/MistDemo/Sources/MistDemoApp/Services/PushTokenReceiver.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Services/PushTokenReceiver.swift
@@ -27,9 +27,6 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-// `@objc` requires the Objective-C runtime, which is absent on
-// Linux/Windows. The push-notification bridge is Apple-only, so gate the
-// whole protocol on Objective-C interop availability.
 #if canImport(ObjectiveC)
   public import Foundation
 

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/FetchChangesCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/FetchChangesCommand.swift
@@ -145,7 +145,7 @@ public struct FetchChangesCommand: MistDemoCommand, OutputFormatting {
   private func displayRecords(_ records: [RecordInfo], limit: Int) {
     let displayed = records.prefix(limit)
     for record in displayed {
-      print("   📝 \(record.recordType) - \(record.recordName)")
+      print("   📝 \(record.recordType ?? "(deleted)") - \(record.recordName)")
       if !record.fields.isEmpty {
         print("      Fields: \(record.fields.keys.joined(separator: ", "))")
       }

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/ModifyResultRow.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/ModifyResultRow.swift
@@ -40,8 +40,8 @@ public struct ModifyResultRow: Encodable, Sendable {
 
   /// The operation type applied.
   public let operation: String
-  /// The record type.
-  public let recordType: String
+  /// The record type, or `nil` for a deleted (typeless) record.
+  public let recordType: String?
   /// The record name.
   public let recordName: String?
   /// The record change tag.
@@ -50,7 +50,7 @@ public struct ModifyResultRow: Encodable, Sendable {
   /// Creates a new instance.
   public init(
     operation: String,
-    recordType: String,
+    recordType: String?,
     recordName: String?,
     recordChangeTag: String?
   ) {

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/IntegrationTestData.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/IntegrationTestData.swift
@@ -32,7 +32,7 @@ internal import Foundation
 /// Test data generation utilities for integration tests.
 internal enum IntegrationTestData {
   /// CloudKit record type for integration tests.
-  internal static let recordType = "MistKitIntegrationTest"
+  internal static let recordType = "Note"
 
   /// Generate minimal PNG-like binary data for upload testing.
   ///

--- a/Examples/MistDemo/Sources/MistDemoKit/Output/Formatters/CSVFormatter.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Output/Formatters/CSVFormatter.swift
@@ -65,7 +65,7 @@ public struct CSVFormatter: OutputFormatter {
 
     // Basic fields
     output += "recordName,\(escaper.escape(record.recordName))\n"
-    output += "recordType,\(escaper.escape(record.recordType))\n"
+    output += "recordType,\(escaper.escape(record.recordType ?? ""))\n"
 
     // Custom fields
     for (fieldName, fieldValue) in record.fields.sorted(by: { $0.key < $1.key }) {

--- a/Examples/MistDemo/Sources/MistDemoKit/Output/Formatters/TableFormatter.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Output/Formatters/TableFormatter.swift
@@ -61,7 +61,7 @@ public struct TableFormatter: OutputFormatter {
     var output = ""
 
     output += "Record Name: \(escaper.escape(record.recordName))\n"
-    output += "Record Type: \(escaper.escape(record.recordType))\n"
+    output += "Record Type: \(escaper.escape(record.recordType ?? ""))\n"
 
     if !record.fields.isEmpty {
       output += "Fields:\n"

--- a/Examples/MistDemo/Sources/MistDemoKit/Output/Formatters/YAMLFormatter.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Output/Formatters/YAMLFormatter.swift
@@ -61,7 +61,7 @@ public struct YAMLFormatter: OutputFormatter {
     var output = ""
 
     output += "recordName: \(escaper.escape(record.recordName))\n"
-    output += "recordType: \(escaper.escape(record.recordType))\n"
+    output += "recordType: \(escaper.escape(record.recordType ?? ""))\n"
 
     if !record.fields.isEmpty {
       output += "fields:\n"

--- a/Examples/MistDemo/Sources/MistDemoKit/Protocols/OutputFormatting+Records.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Protocols/OutputFormatting+Records.swift
@@ -46,7 +46,7 @@ extension OutputFormatting {
       let record = records[0]
       print(MistDemoConstants.Messages.recordCreated)
       print("├─ Name: \(record.recordName)")
-      print("├─ Type: \(record.recordType)")
+      print("├─ Type: \(record.recordType ?? "")")
       if let changeTag = record.recordChangeTag {
         print("├─ Change Tag: \(changeTag)")
       }
@@ -64,7 +64,7 @@ extension OutputFormatting {
 
       for (index, record) in records.enumerated() {
         print("\n[\(index + 1)] Record: \(record.recordName)")
-        print("    Type: \(record.recordType)")
+        print("    Type: \(record.recordType ?? "")")
         if let changeTag = record.recordChangeTag {
           print("    Change Tag: \(changeTag)")
         }
@@ -110,7 +110,7 @@ extension OutputFormatting {
         case MistDemoConstants.FieldNames.recordName:
           values.append(csvEscaper.escape(record.recordName))
         case MistDemoConstants.FieldNames.recordType:
-          values.append(csvEscaper.escape(record.recordType))
+          values.append(csvEscaper.escape(record.recordType ?? ""))
         case MistDemoConstants.FieldNames.recordChangeTag:
           values.append(csvEscaper.escape(record.recordChangeTag ?? ""))
         default:
@@ -139,7 +139,7 @@ extension OutputFormatting {
       print("record:")
       let name = yamlEscaper.escape(record.recordName)
       print("  \(recordNameKey): \(name)")
-      let rtype = yamlEscaper.escape(record.recordType)
+      let rtype = yamlEscaper.escape(record.recordType ?? "")
       print("  \(recordTypeKey): \(rtype)")
       if let changeTag = record.recordChangeTag {
         let tag = yamlEscaper.escape(changeTag)
@@ -157,7 +157,7 @@ extension OutputFormatting {
       for record in records {
         let name = yamlEscaper.escape(record.recordName)
         print("  - \(recordNameKey): \(name)")
-        let rtype = yamlEscaper.escape(record.recordType)
+        let rtype = yamlEscaper.escape(record.recordType ?? "")
         print("    \(recordTypeKey): \(rtype)")
         if let changeTag = record.recordChangeTag {
           let tag = yamlEscaper.escape(changeTag)

--- a/Sources/MistKit/Models/ConversionError.swift
+++ b/Sources/MistKit/Models/ConversionError.swift
@@ -48,8 +48,12 @@ public enum ConversionError: LocalizedError, Sendable, Equatable {
   case unmappableNestedListItem(fieldName: String, item: String)
   /// A record timestamp was negative.
   case negativeTimestamp(milliseconds: Double)
-  /// A record response was missing `recordName` and/or `recordType`.
-  case recordMissingIdentifier(recordName: String?, recordType: String?)
+  /// A record response was missing its `recordName`.
+  ///
+  /// `recordType` is intentionally *not* required: CloudKit's Record Dictionary
+  /// only guarantees `recordName` in a response, and omits `recordType` for
+  /// tombstones (deleted records) and other typeless results.
+  case recordMissingRecordName
   /// A zone response was missing its `zoneID`.
   case zoneMissingID
   /// A zone response was missing its `zoneName`.
@@ -75,9 +79,8 @@ public enum ConversionError: LocalizedError, Sendable, Equatable {
       return "Unmappable nested list item for field '\(fieldName)' (\(item))"
     case .negativeTimestamp(let milliseconds):
       return "Invalid negative timestamp (\(milliseconds) ms)"
-    case .recordMissingIdentifier(let recordName, let recordType):
-      return "RecordResponse missing required identifier(s) "
-        + "(recordName: \(recordName ?? "nil"), recordType: \(recordType ?? "nil"))"
+    case .recordMissingRecordName:
+      return "RecordResponse missing required recordName"
     case .zoneMissingID:
       return "Zone entry missing zoneID"
     case .zoneMissingName:

--- a/Sources/MistKit/Models/ConversionError.swift
+++ b/Sources/MistKit/Models/ConversionError.swift
@@ -42,10 +42,6 @@ public import Foundation
 public enum ConversionError: LocalizedError, Sendable, Equatable {
   /// A field value's structure matched no known `FieldValue` case.
   case unmappableFieldValue(fieldName: String, value: String, type: String?)
-  /// A location field was missing its latitude and/or longitude.
-  case locationMissingCoordinates(fieldName: String)
-  /// A reference field was missing its `recordName`.
-  case referenceMissingRecordName(fieldName: String)
   /// A list element matched no known `FieldValue` case.
   case unmappableListItem(fieldName: String, item: String)
   /// A nested-list element was not one of the supported basic types.
@@ -73,10 +69,6 @@ public enum ConversionError: LocalizedError, Sendable, Equatable {
     case .unmappableFieldValue(let fieldName, let value, let type):
       return "Unmappable FieldValue for field '\(fieldName)' "
         + "(value: \(value), type: \(type ?? "nil"))"
-    case .locationMissingCoordinates(let fieldName):
-      return "Location field '\(fieldName)' missing latitude/longitude"
-    case .referenceMissingRecordName(let fieldName):
-      return "Reference field '\(fieldName)' missing recordName"
     case .unmappableListItem(let fieldName, let item):
       return "Unmappable list item for field '\(fieldName)' (\(item))"
     case .unmappableNestedListItem(let fieldName, let item):

--- a/Sources/MistKit/Models/FieldValues/FieldValue+Components+List.swift
+++ b/Sources/MistKit/Models/FieldValues/FieldValue+Components+List.swift
@@ -121,10 +121,10 @@ extension FieldValue {
     fieldName: String
   ) throws(ConversionError) -> FieldValue? {
     if case .LocationValue(let locationValue) = listItem {
-      return try Self(locationValue: locationValue, fieldName: fieldName)
+      return Self(locationValue: locationValue)
     }
     if case .ReferenceValue(let referenceValue) = listItem {
-      return try Self(referenceValue: referenceValue, fieldName: fieldName)
+      return Self(referenceValue: referenceValue)
     }
     if case .AssetValue(let assetValue) = listItem {
       return Self(assetValue: assetValue)

--- a/Sources/MistKit/Models/FieldValues/FieldValue+Components.swift
+++ b/Sources/MistKit/Models/FieldValues/FieldValue+Components.swift
@@ -70,18 +70,11 @@ extension FieldValue {
 
   /// Initialize from location field value
   internal init(
-    locationValue: Components.Schemas.LocationValue,
-    fieldName: String
-  ) throws(ConversionError) {
-    guard let latitude = locationValue.latitude,
-      let longitude = locationValue.longitude
-    else {
-      try ConversionError.locationMissingCoordinates(fieldName: fieldName).reportAndThrow()
-    }
-
+    locationValue: Components.Schemas.LocationValue
+  ) {
     let location = Location(
-      latitude: latitude,
-      longitude: longitude,
+      latitude: locationValue.latitude,
+      longitude: locationValue.longitude,
       horizontalAccuracy: locationValue.horizontalAccuracy,
       verticalAccuracy: locationValue.verticalAccuracy,
       altitude: locationValue.altitude,
@@ -94,12 +87,9 @@ extension FieldValue {
 
   /// Initialize from reference field value
   internal init(
-    referenceValue: Components.Schemas.ReferenceValue,
-    fieldName: String
-  ) throws(ConversionError) {
-    guard let recordName = referenceValue.recordName else {
-      try ConversionError.referenceMissingRecordName(fieldName: fieldName).reportAndThrow()
-    }
+    referenceValue: Components.Schemas.ReferenceValue
+  ) {
+    let recordName = referenceValue.recordName
     let action: Reference.Action?
     switch referenceValue.action {
     case .DELETE_SELF:
@@ -158,10 +148,10 @@ extension FieldValue {
     fieldName: String
   ) throws(ConversionError) -> FieldValue? {
     if case .LocationValue(let locationValue) = value {
-      return try Self(locationValue: locationValue, fieldName: fieldName)
+      return Self(locationValue: locationValue)
     }
     if case .ReferenceValue(let referenceValue) = value {
-      return try Self(referenceValue: referenceValue, fieldName: fieldName)
+      return Self(referenceValue: referenceValue)
     }
     if case .AssetValue(let assetValue) = value {
       return Self(assetValue: assetValue)

--- a/Sources/MistKit/Models/RecordInfo.swift
+++ b/Sources/MistKit/Models/RecordInfo.swift
@@ -32,17 +32,19 @@ internal import MistKitOpenAPI
 
 /// Record information from CloudKit.
 ///
-/// A `RecordInfo` always represents a successfully-returned record: it carries a
-/// non-optional `recordName` and `recordType`. Per-record failures from
-/// `modifyRecords` / `lookupRecords` are surfaced separately as
+/// A `RecordInfo` always carries a non-optional `recordName` (CloudKit's Record
+/// Dictionary guarantees it in every response). `recordType`, by contrast, is
+/// *optional*: CloudKit omits it for tombstones (deleted records, `deleted ==
+/// true`) and other typeless results, so it is `nil` in those cases. Per-record
+/// failures from `modifyRecords` / `lookupRecords` are surfaced separately as
 /// ``RecordResult/failure(_:)`` (a ``RecordOperationFailure``) and never become a
-/// `RecordInfo`. A response record missing its identifiers is treated as a
+/// `RecordInfo`. A response record missing its `recordName` is treated as a
 /// conversion failure (logged, asserted in DEBUG, and thrown).
 public struct RecordInfo: Codable, Sendable {
   /// The record name
   public let recordName: String
-  /// The record type
-  public let recordType: String
+  /// The record type, or `nil` for tombstones and other typeless responses
+  public let recordType: String?
   /// The record change tag for optimistic locking
   public let recordChangeTag: String?
   /// The record fields
@@ -56,15 +58,11 @@ public struct RecordInfo: Codable, Sendable {
   public let deleted: Bool
 
   internal init(from record: Components.Schemas.RecordResponse) throws(ConversionError) {
-    guard let recordName = record.recordName, let recordType = record.recordType else {
-      let failure = ConversionError.recordMissingIdentifier(
-        recordName: record.recordName,
-        recordType: record.recordType
-      )
-      try failure.reportAndThrow()
+    guard let recordName = record.recordName else {
+      try ConversionError.recordMissingRecordName.reportAndThrow()
     }
     self.recordName = recordName
-    self.recordType = recordType
+    self.recordType = record.recordType
     self.recordChangeTag = record.recordChangeTag
     if let created = record.created {
       self.created = try RecordTimestamp(from: created)
@@ -97,7 +95,7 @@ public struct RecordInfo: Codable, Sendable {
   ///
   /// - Parameters:
   ///   - recordName: The unique record name
-  ///   - recordType: The CloudKit record type
+  ///   - recordType: The CloudKit record type, or `nil` for a tombstone
   ///   - recordChangeTag: Optional change tag for optimistic locking
   ///   - fields: Dictionary of field names to their values
   ///   - created: Optional timestamp when the record was created
@@ -105,7 +103,7 @@ public struct RecordInfo: Codable, Sendable {
   ///   - deleted: Whether the record has been deleted
   public init(
     recordName: String,
-    recordType: String,
+    recordType: String?,
     recordChangeTag: String? = nil,
     fields: [String: FieldValue],
     created: RecordTimestamp? = nil,

--- a/Sources/MistKitOpenAPI/Types.swift
+++ b/Sources/MistKitOpenAPI/Types.swift
@@ -1157,11 +1157,11 @@ public enum Components {
             /// Latitude in degrees
             ///
             /// - Remark: Generated from `#/components/schemas/LocationValue/latitude`.
-            public var latitude: Swift.Double?
+            public var latitude: Swift.Double
             /// Longitude in degrees
             ///
             /// - Remark: Generated from `#/components/schemas/LocationValue/longitude`.
-            public var longitude: Swift.Double?
+            public var longitude: Swift.Double
             /// Horizontal accuracy in meters
             ///
             /// - Remark: Generated from `#/components/schemas/LocationValue/horizontalAccuracy`.
@@ -1198,8 +1198,8 @@ public enum Components {
             ///   - course: Course in degrees
             ///   - timestamp: Timestamp in milliseconds since epoch
             public init(
-                latitude: Swift.Double? = nil,
-                longitude: Swift.Double? = nil,
+                latitude: Swift.Double,
+                longitude: Swift.Double,
                 horizontalAccuracy: Swift.Double? = nil,
                 verticalAccuracy: Swift.Double? = nil,
                 altitude: Swift.Double? = nil,
@@ -1234,7 +1234,7 @@ public enum Components {
             /// The record name being referenced
             ///
             /// - Remark: Generated from `#/components/schemas/ReferenceValue/recordName`.
-            public var recordName: Swift.String?
+            public var recordName: Swift.String
             /// Action to perform on the referenced record
             ///
             /// - Remark: Generated from `#/components/schemas/ReferenceValue/action`.
@@ -1252,7 +1252,7 @@ public enum Components {
             ///   - recordName: The record name being referenced
             ///   - action: Action to perform on the referenced record
             public init(
-                recordName: Swift.String? = nil,
+                recordName: Swift.String,
                 action: Components.Schemas.ReferenceValue.actionPayload? = nil
             ) {
                 self.recordName = recordName

--- a/Tests/MistKitTests/Models/ConversionFailureTests.swift
+++ b/Tests/MistKitTests/Models/ConversionFailureTests.swift
@@ -53,28 +53,27 @@ internal struct ConversionFailureTests {
     )
   }
 
-  @Test("FieldValue throws on a reference field missing recordName")
-  internal func referenceMissingRecordNameThrows() {
-    let response = Components.Schemas.FieldValueResponse(
-      value: .ReferenceValue(.init(recordName: nil))
+  @Test("An asset field value converts to .asset rather than a mis-typed location")
+  internal func assetFieldValueConvertsToAsset() throws {
+    // Regression: an asset value object carries no latitude/longitude, but while
+    // LocationValue's coordinates were optional the oneOf decoder greedily
+    // matched assets as locations, so conversion failed on a missing coordinate.
+    let json = Data(
+      #"{"value":{"fileChecksum":"chk","size":51200,"downloadURL":"https://example.com/a.bin"}}"#
+        .utf8
     )
-    expectConversionThrow {
-      _ = try FieldValue(response, fieldName: "owner")
-    }
-  }
+    let response = try JSONDecoder().decode(
+      Components.Schemas.FieldValueResponse.self,
+      from: json
+    )
 
-  @Test("RecordInfo throws on a field that cannot be mapped")
-  internal func recordInfoThrowsOnReferenceWithoutRecordName() {
-    let record = Components.Schemas.RecordResponse(
-      recordName: "rec-1",
-      recordType: "Article",
-      fields: .init(additionalProperties: [
-        "owner": .init(value: .ReferenceValue(.init(recordName: nil)))
-      ])
-    )
-    expectConversionThrow {
-      _ = try RecordInfo(from: record)
+    let field = try FieldValue(response, fieldName: "image")
+
+    guard case .asset(let asset) = field else {
+      Issue.record("Expected .asset, got \(field)")
+      return
     }
+    #expect(asset.fileChecksum == "chk")
   }
 
   @Test("UserIdentity faithfully converts a non-discoverable user (nil userRecordName)")

--- a/Tests/MistKitTests/Models/RecordInfoTests.swift
+++ b/Tests/MistKitTests/Models/RecordInfoTests.swift
@@ -7,10 +7,10 @@ internal import Testing
 @Suite("Record Info")
 /// Tests for RecordInfo functionality
 internal struct RecordInfoTests {
-  /// A response with no identifiers is a conversion failure, not an "Unknown"
+  /// A response with no `recordName` is a conversion failure, not an "Unknown"
   /// record. The assertion handler is suppressed so the throw is observable in
   /// DEBUG instead of trapping the test process.
-  @Test("RecordInfo throws when the response is missing identifiers")
+  @Test("RecordInfo throws when the response is missing its recordName")
   internal func recordInfoMissingIdentifiersThrows() {
     let mockRecord = Components.Schemas.RecordResponse()
     ConversionFailureReporter.$assertionHandler.withValue(
@@ -35,5 +35,22 @@ internal struct RecordInfoTests {
     #expect(recordInfo.recordName == "rec-1")
     #expect(recordInfo.recordType == "Article")
     #expect(recordInfo.fields.isEmpty)
+  }
+
+  /// CloudKit omits `recordType` for tombstones (deleted records) and other
+  /// typeless responses. Such a record must convert to a `RecordInfo` with a
+  /// `nil` recordType rather than trapping — this is the regression that crashed
+  /// the delete/cleanup and `fetchRecordChanges` paths.
+  @Test("RecordInfo converts a typeless (deleted) response without a recordType")
+  internal func recordInfoFromTypelessRecord() throws {
+    let mockRecord = Components.Schemas.RecordResponse(
+      recordName: "rec-deleted",
+      deleted: true
+    )
+    let recordInfo = try RecordInfo(from: mockRecord)
+
+    #expect(recordInfo.recordName == "rec-deleted")
+    #expect(recordInfo.recordType == nil)
+    #expect(recordInfo.deleted)
   }
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1079,6 +1079,9 @@ components:
     LocationValue:
       type: object
       description: Location dictionary as defined in CloudKit Web Services
+      required:
+        - latitude
+        - longitude
       properties:
         latitude:
           type: number
@@ -1116,6 +1119,8 @@ components:
     ReferenceValue:
       type: object
       description: Reference dictionary as defined in CloudKit Web Services
+      required:
+        - recordName
       properties:
         recordName:
           type: string


### PR DESCRIPTION
## Summary
- Adds `claude/**` to the `push` trigger of `.github/workflows/MistDemo-Integration.yml` so the live CloudKit integration workflow runs on working branches, letting us watch it pass while iterating.
- Branch is synced to the latest `v1.0.0-beta.2` (scaffold #371 + the `Note` record-type fix).

## Status
The integration workflow already ran green on this branch — run [26251422359](https://github.com/brightdigit/MistKit/actions/runs/26251422359) (Success): live query/create/modify/cleanup against the `Note` type, `demo-errors` (401/404/409), and `demo-in-filter` all passed.

## Note
The `claude/**` trigger is a temporary enablement for iteration and should be dropped before this merges back into `v1.0.0-beta.2`.

https://claude.ai/code/session_01EvLrWZwcSs1MjiCrUx8KjU

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvLrWZwcSs1MjiCrUx8KjU)_