### PR TITLE
setup-mistkit: pin to resolved revision

### DIFF
--- a/.github/actions/setup-mistkit/action.yml
+++ b/.github/actions/setup-mistkit/action.yml
@@ -1,5 +1,5 @@
 name: Setup MistKit
-description: Replaces the local MistKit path dependency with a remote branch reference
+description: Replaces the local MistKit path dependency with a remote reference, pinned to the branch's current commit
 
 inputs:
   branch:
@@ -8,19 +8,43 @@ inputs:
 runs:
   using: composite
   steps:
+    # Resolve the branch to its current HEAD commit and pin the dependency by
+    # `revision:` rather than `branch:`. This makes the dependency content-addressed,
+    # so `swift package dump-package` (which swift-build@v1 hashes for its cache key)
+    # changes whenever the MistKit branch advances — otherwise a new MistKit commit on
+    # the same branch yields a stale cache hit and is never rebuilt. Falls back to a
+    # `branch:` pin if the ref can't be resolved (e.g. offline).
     - name: Update Package.swift (Unix)
       if: inputs.branch != '' && runner.os != 'Windows'
       shell: bash
       run: |
-        if [ "$RUNNER_OS" = "macOS" ]; then
-          sed -i '' 's|\.package(name: "MistKit", path: "\.\./\.\.")|.package(url: "https://github.com/brightdigit/MistKit.git", branch: "'"${{ inputs.branch }}"'")|g' Package.swift
+        BRANCH='${{ inputs.branch }}'
+        REF=$(git ls-remote https://github.com/brightdigit/MistKit.git "$BRANCH" | head -n1 | cut -f1)
+        if [ -n "$REF" ]; then
+          REQ='revision: "'"$REF"'"'
+          echo "Pinning MistKit to $BRANCH @ $REF"
         else
-          sed -i 's|\.package(name: "MistKit", path: "\.\./\.\.")|.package(url: "https://github.com/brightdigit/MistKit.git", branch: "'"${{ inputs.branch }}"'")|g' Package.swift
+          REQ='branch: "'"$BRANCH"'"'
+          echo "Could not resolve $BRANCH to a commit; pinning by branch"
+        fi
+        if [ "$RUNNER_OS" = "macOS" ]; then
+          sed -i '' 's|\.package(name: "MistKit", path: "\.\./\.\.")|.package(url: "https://github.com/brightdigit/MistKit.git", '"$REQ"')|g' Package.swift
+        else
+          sed -i 's|\.package(name: "MistKit", path: "\.\./\.\.")|.package(url: "https://github.com/brightdigit/MistKit.git", '"$REQ"')|g' Package.swift
         fi
         rm -f Package.resolved
     - name: Update Package.swift (Windows)
       if: inputs.branch != '' && runner.os == 'Windows'
       shell: pwsh
       run: |
-        (Get-Content Package.swift) -replace '\.package\(name: "MistKit", path: "\.\./\.\."\)', ".package(url: `"https://github.com/brightdigit/MistKit.git`", branch: `"${{ inputs.branch }}`")" | Set-Content Package.swift
+        $branch = '${{ inputs.branch }}'
+        $ref = (git ls-remote https://github.com/brightdigit/MistKit.git $branch | Select-Object -First 1) -split "`t" | Select-Object -First 1
+        if ($ref) {
+          $req = "revision: `"$ref`""
+          Write-Host "Pinning MistKit to $branch @ $ref"
+        } else {
+          $req = "branch: `"$branch`""
+          Write-Host "Could not resolve $branch to a commit; pinning by branch"
+        }
+        (Get-Content Package.swift) -replace '\.package\(name: "MistKit", path: "\.\./\.\."\)', ".package(url: `"https://github.com/brightdigit/MistKit.git`", $req)" | Set-Content Package.swift
         Remove-Item -Path Package.resolved -Force -ErrorAction SilentlyContinue

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Maintainability](https://qlty.sh/badges/55637213-d307-477e-a710-f9dba332d955/maintainability.svg)](https://qlty.sh/gh/brightdigit/projects/MistKit)
 [![Documentation](https://img.shields.io/badge/docc-read_documentation-blue)](https://swiftpackageindex.com/brightdigit/MistKit/documentation)
 
-A Swift Package for Server-Side and Command-Line Access to [CloudKit Web Services](https://developer.apple.com/documentation/cloudkitwebservices)
+A Swift Package for Server-Side and Command-Line Access to [CloudKit Web Services](https://developer.apple.com/library/archive/documentation/DataManagement/Conceptual/CloudKitWebServicesReference/index.html)
 
 ## Table of Contents
 - [Overview](#overview)
@@ -330,7 +330,7 @@ Check out the `Examples/` directory for complete working examples:
 
 ### Apple References
 
-- **[CloudKit Web Services](https://developer.apple.com/documentation/cloudkitwebservices)**: Official CloudKit Web Services REST API documentation
+- **[CloudKit Web Services](https://developer.apple.com/library/archive/documentation/DataManagement/Conceptual/CloudKitWebServicesReference/index.html)**: Official CloudKit Web Services REST API documentation
 - **[CloudKit framework](https://developer.apple.com/documentation/cloudkit)**: On-device CloudKit framework (iOS/macOS)
 - **[CloudKit JS](https://developer.apple.com/documentation/cloudkitjs)**: Browser-based CloudKit access used for web auth token capture
 - **[CKFetchWebAuthTokenOperation](https://developer.apple.com/documentation/cloudkit/ckfetchwebauthtokenoperation)**: iOS/macOS API for exchanging an iCloud session for a web auth token


### PR DESCRIPTION
## Summary

- `setup-mistkit` writes `revision: "<sha>"` into Package.swift instead of `branch: "<name>"` so swift-build@v1's package-hash invalidates when MistKit advances.
- Resolves the input branch via `git ls-remote`; falls back to `branch:` if resolution fails.
- Already shipped on `v1.0.0-beta.2` (#377); this lands the same change on `main` so consumers referencing `@main` (BushelCloud, CelestraCloud) pick it up.

## Why

CelestraCloud PR brightdigit/CelestraCloud#36 was failing on every Linux/Windows job with errors like `value of type 'RecordInfo' has no member 'get'` and `type '_ErrorCodeProtocol' has no member 'recordOperationFailed'`. Root cause: swift-build@v1 hashes `swift package dump-package` for the SPM cache key. With `branch:` pinning, that JSON is constant for a given branch name, so a stale `.build/` from before #372 (`RecordResult`) landed kept being restored. Macros macOS passes because Xcode DerivedData cache also keys on `github.sha`.

## Test plan

- [ ] CelestraCloud PR #36 Ubuntu/Windows jobs pass on re-run after this PR merges
- [ ] Stale-cache scenario (push a no-op commit to a feature branch of MistKit, re-run a consumer workflow) — verify cache miss happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions setup workflow to provide more precise dependency pinning with automatic fallback mechanisms, improving build consistency and reliability across development platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/brightdigit/MistKit/pull/380?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->