### PR TITLE
Fix test-private integration: subscription dedup + notification name collision (v1.0.0-beta.2)

### DIFF
--- a/.codefactor.yml
+++ b/.codefactor.yml
@@ -1,2 +1,3 @@
 exclude:
   - "Scripts/mermaid-to-pptx.py"
+  - "Examples/MistDemo/Sources/MistDemoKit/Resources/js/**"

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/NotificationRoundtripPhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/NotificationRoundtripPhase.swift
@@ -133,11 +133,15 @@ internal struct NotificationRoundtripPhase: IntegrationPhase {
     }
 
     /// Create a record that matches the subscription — the change that should
-    /// fire the push.
+    /// fire the push. The record name is deliberately distinct from the
+    /// subscription ID (`mistkit-notif-<suffix>`): CloudKit provisions an
+    /// internal `_sub_trigger_sub_<hash>` backing record named after the
+    /// subscription ID, so reusing that name here collides with it
+    /// (`invalid attempt to update record from type '_sub_trigger_sub_…'`).
     private func trigger(suffix: String, context: PhaseContext) async throws -> RecordInfo {
       let record = try await context.service.createRecord(
         recordType: IntegrationTestData.recordType,
-        recordName: "mistkit-notif-\(suffix)",
+        recordName: "mistkit-notif-rec-\(suffix)",
         fields: ["title": .string("notification probe \(suffix)")],
         database: context.database
       )

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/SubscriptionRoundtripPhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/SubscriptionRoundtripPhase.swift
@@ -45,6 +45,13 @@ internal struct SubscriptionRoundtripPhase: IntegrationPhase {
   internal func run(input: NoState, context: PhaseContext) async throws -> NoState {
     print("\n\(Self.emoji) \(Self.title)")
 
+    // CloudKit dedupes query subscriptions by their query + firesOn signature,
+    // not by subscriptionID, so a leftover subscription from an interrupted or
+    // failed prior run (same recordType + firesOn) makes `createSubscription`
+    // fail with `subscriptionLikelyDuplicate`. Sweep any stale test
+    // subscriptions first so this phase is self-healing across runs.
+    try await sweepStaleSubscriptions(context: context)
+
     let subscriptionID = "mistkit-itest-\(UUID().uuidString.lowercased())"
 
     let created = try await context.service.createSubscription(
@@ -80,6 +87,28 @@ internal struct SubscriptionRoundtripPhase: IntegrationPhase {
     print("✅ Roundtrip succeeded for subscription '\(subscriptionID)'")
 
     return NoState()
+  }
+
+  /// Delete leftover test subscriptions so a fresh create won't collide with
+  /// CloudKit's query-signature dedup. Matches both the `mistkit-itest-` ID
+  /// convention and the test's query signature (`recordType`), so the blocking
+  /// subscription is cleared even if its ID differs from the current prefix.
+  /// Best-effort: a failed delete shouldn't fail the phase.
+  private func sweepStaleSubscriptions(context: PhaseContext) async throws {
+    let existing = try await context.service.listSubscriptions(database: context.database)
+    let stale = existing.filter {
+      $0.subscriptionID.hasPrefix("mistkit-itest-")
+        || $0.query?.recordType == IntegrationTestData.recordType
+    }
+    for subscription in stale {
+      try? await context.service.deleteSubscription(
+        id: subscription.subscriptionID,
+        database: context.database
+      )
+      if context.verbose {
+        print("   🧹 Swept stale subscription: \(subscription.subscriptionID)")
+      }
+    }
   }
 
   /// Confirm the created subscription is visible via both `list` and `lookup`.


### PR DESCRIPTION
## Context

CI run [26439176787](https://github.com/brightdigit/MistKit/actions/runs/26439176787) (v1.0.0-beta.2 MistDemo Integration) failed in the **Live CloudKit Integration → test-private** job with an illegal-instruction crash (exit 132). Root cause was two bugs in the MistDemo integration phases — one masking the other.

## Bug 1 — Phase 15 subscription duplicate (the reported crash)

CloudKit deduplicates query subscriptions by their **query + `firesOn` signature, not by `subscriptionID`** (see `Sources/MistKit/Models/SubscriptionTarget.swift`). `SubscriptionRoundtripPhase` always creates a query subscription on recordType `Note` firing on create/update/delete; the ID is a fresh UUID but the signature is identical every run. A subscription left over from an interrupted/failed prior run blocked the create, which throws `subscriptionLikelyDuplicate` **outside** the phase's `do/catch` (it only wrapped `verify`), so it propagated to the top level and crashed.

**Fix:** `SubscriptionRoundtripPhase` now pre-sweeps stale test subscriptions (matching the `mistkit-itest-` ID convention and the test's query signature) before creating — self-healing across runs, leaving the container clean. MistKit's `subscriptionLikelyDuplicate` behavior is unchanged (correct by design).

## Bug 2 — Phase 17 notification name collision (newly reached)

With Phase 15 no longer crashing, Phase 17 (`NotificationRoundtripPhase`) ran for the first time and failed deterministically: it named the trigger record identically to the subscription ID (`mistkit-notif-<suffix>`), colliding with the internal `_sub_trigger_sub_<hash>` record CloudKit provisions for the subscription — `invalid attempt to update record from type '_sub_trigger_sub_…' to 'Note'`.

**Fix:** the trigger record now uses a distinct name (`mistkit-notif-rec-<suffix>`).

## Verification

Run live against `iCloud.com.brightdigit.MistDemo` (private DB) via `swift run mistdemo test-private --record-count 5 --asset-size 50`:

- All 18 phases pass, **twice back-to-back** (confirming the Phase 15 pre-sweep self-heals).
- Phase 17 receives the actual push (`reason recordCreated`).
- `swift build`, `swift-format`, and `swiftlint` all clean.

Scope: MistDemo integration phases only — no MistKit library changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)