### PR TITLE
Auto-chunking conveniences for batch operations (#307)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,7 @@ MistKit/
 | `CloudKitService+ZoneOperations.swift` | `listZones`, `lookupZones(zoneIDs:)`, `fetchZoneChanges(syncToken:)` |
 | `CloudKitService+ModifyZones.swift` | `modifyZones(_:database:)` |
 | `CloudKitService+SyncOperations.swift` | `fetchRecordChanges(recordType:syncToken:)`, `fetchAllRecordChanges(recordType:syncToken:)` |
-| `CloudKitService+UserOperations.swift` | `fetchCaller()`, `discoverUserIdentities(lookupInfos:)`, `discoverAllUserIdentities()` *(unavailable — pending #28)*, `lookupUsersByEmail(_:)`, `lookupUsersByRecordName(_:)`, `fetchCurrentUser()` (deprecated, forwards to `fetchCaller`) |
+| `CloudKitService+UserOperations.swift` | `fetchCaller()`, `discoverUserIdentities(lookupInfos:)`, `discoverAllUserIdentities()` *(no-arg address-book form — unavailable, pending #28; distinct from the available `discoverAllUserIdentities(lookupInfos:batchSize:)` chunking overload below)*, `lookupUsersByEmail(_:)`, `lookupUsersByRecordName(_:)`, `fetchCurrentUser()` (deprecated, forwards to `fetchCaller`) |
 | `CloudKitService+LookupAllRecords.swift` | `lookupAllRecords(recordNames:desiredKeys:database:batchSize:)` — auto-chunking convenience over `lookupRecords` |
 | `CloudKitService+UserIdentityChunking.swift` | `discoverAllUserIdentities(lookupInfos:batchSize:)` — auto-chunking convenience over `discoverUserIdentities` |
 | `CloudKitService+BatchChunking.swift` | internal `chunkedBatches` helper backing the auto-chunking conveniences |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,9 @@ MistKit/
 | `CloudKitService+ModifyZones.swift` | `modifyZones(_:database:)` |
 | `CloudKitService+SyncOperations.swift` | `fetchRecordChanges(recordType:syncToken:)`, `fetchAllRecordChanges(recordType:syncToken:)` |
 | `CloudKitService+UserOperations.swift` | `fetchCaller()`, `discoverUserIdentities(lookupInfos:)`, `discoverAllUserIdentities()` *(unavailable — pending #28)*, `lookupUsersByEmail(_:)`, `lookupUsersByRecordName(_:)`, `fetchCurrentUser()` (deprecated, forwards to `fetchCaller`) |
+| `CloudKitService+LookupAllRecords.swift` | `lookupAllRecords(recordNames:desiredKeys:database:batchSize:)` — auto-chunking convenience over `lookupRecords` |
+| `CloudKitService+UserIdentityChunking.swift` | `discoverAllUserIdentities(lookupInfos:batchSize:)` — auto-chunking convenience over `discoverUserIdentities` |
+| `CloudKitService+BatchChunking.swift` | internal `chunkedBatches` helper backing the auto-chunking conveniences |
 | `CloudKitService+AssetOperations.swift` | `uploadAssets`, `requestAssetUploadURL` |
 | `CloudKitService+AssetUpload.swift` | `uploadAssetData` |
 | `CloudKitService+RecordManaging.swift` | record-managing convenience surface |
@@ -209,6 +212,17 @@ MistKit/
 - `discoverAllUserIdentities()` → GET `/users/discover` — returns `[UserIdentity]` for every discoverable user in the caller's address book.
 - `lookupUsersByEmail(_:)` → POST `/users/lookup/email` — returns `[UserIdentity]`.
 - `lookupUsersByRecordName(_:)` → POST `/users/lookup/id` — returns `[UserIdentity]`.
+
+**Batch chunking (issue #307):** the two non-deprecated operations capped at CloudKit's 200-item-per-request limit (`CloudKitService.maxRecordsPerRequest`) each pair a single-request primitive with an auto-chunking convenience that splits the input into ≤`batchSize` batches, calls the primitive per batch, and concatenates results in input order. This mirrors the `queryRecords`/`queryAllRecords` page-primitive + auto-paginating-extension pattern. Because chunk count is `ceil(input.count / batchSize)` — deterministic and finite — there is **no** `maxPages`-style throwing ceiling; `batchSize` (default `maxRecordsPerRequest`, clamped to `1...maxRecordsPerRequest`) is the only knob. The shared engine is `chunkedBatches` (`CloudKitService+BatchChunking.swift`).
+
+| Primitive (single request) | Auto-chunking convenience |
+|----------------------------|---------------------------|
+| `lookupRecords(recordNames:desiredKeys:database:)` | `lookupAllRecords(recordNames:desiredKeys:database:batchSize:)` |
+| `discoverUserIdentities(lookupInfos:)` | `discoverAllUserIdentities(lookupInfos:batchSize:)` *(overloads the no-arg address-book form)* |
+
+The `users/lookup/email` and `users/lookup/id` primitives (`lookupUsersByEmail` / `lookupUsersByRecordName`) are **deprecated by Apple** in favor of POST `users/discover` (verified against Apple's archived CloudKit Web Services reference), so they intentionally get **no** chunking convenience — callers needing >200 should use `discoverAllUserIdentities(lookupInfos:)`. `users/lookup/contacts` is likewise deprecated and unwrapped.
+
+`listZones` is **not** a pagination candidate — `zones/list` (GET) returns every zone in one response with no continuation marker. `modifyRecords`/`sync<T>` already chunk by 200 internally. The `fetchAllRecordChanges` / `fetchAllZoneChanges` paginators already implement the page-primitive pattern with `maxPages` + stuck-token detection.
 
 In MistDemo, integration runs targeting these endpoints use `PhaseContext.userContextService` (a public+web-auth `CloudKitService`) which is built from `CLOUDKIT_API_TOKEN` + `CLOUDKIT_WEB_AUTH_TOKEN` regardless of the primary `--database` selection. The `DatabaseConfiguration` / `AuthenticationCredentials` types in `Examples/MistDemo/Sources/MistDemoKit/Configuration/` enforce valid database+auth combinations at construction time.
 

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/DiscoverAllUserIdentitiesCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/DiscoverAllUserIdentitiesCommand.swift
@@ -1,0 +1,98 @@
+//
+//  DiscoverAllUserIdentitiesCommand.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+internal import Foundation
+internal import MistKit
+
+/// Command that discovers user identities for a set of email addresses using
+/// the auto-chunking `discoverAllUserIdentities(lookupInfos:)` convenience
+/// (issue #307).
+public struct DiscoverAllUserIdentitiesCommand: MistDemoCommand, OutputFormatting {
+  /// The configuration type.
+  public typealias Config = DiscoverConfig
+  /// The command name.
+  public static let commandName = "discover-all"
+  /// The command abstract.
+  public static let abstract =
+    "Discover user identities, auto-chunking large inputs (discoverAllUserIdentities)"
+  /// The command help text.
+  public static let helpText = """
+    DISCOVER-ALL - Discover user identities, auto-chunking past CloudKit's 200/request cap
+
+    USAGE:
+      mistdemo discover-all --discover-emails <list> [options]
+
+    INPUT (choose one):
+      --discover-emails <list>       Comma-separated email addresses
+      --stdin                        Read one email per line from stdin
+
+    OPTIONS:
+      --batch-size <n>               Items per request (default 200, clamped 1...200).
+                                     Set small (e.g. 1) to force multiple requests.
+      --output-format <format>       Output format (json, table, csv, yaml)
+
+    NOTES:
+      - Requires API + web-auth credentials; the endpoint is pinned to the
+        public database, so the --database flag does not apply.
+      - Each email is sent as a lookup info; CloudKit only returns identities
+        for accounts discoverable to the caller.
+    """
+
+  private let config: DiscoverConfig
+
+  /// Creates a new instance.
+  public init(config: DiscoverConfig) {
+    self.config = config
+  }
+
+  /// Executes the command.
+  public func execute() async throws {
+    guard !config.emails.isEmpty else {
+      throw DiscoverError.emailsRequired
+    }
+    guard config.base.hasUserContextCredentials else {
+      throw DiscoverError.webAuthRequired
+    }
+
+    let service = try MistKitClientFactory.create(for: config.base)
+
+    let batches = (config.emails.count + config.batchSize - 1) / config.batchSize
+    let note =
+      "discover-all: \(config.emails.count) lookup(s), batchSize \(config.batchSize) "
+      + "→ \(batches) request(s)\n"
+    FileHandle.standardError.write(Data(note.utf8))
+
+    let lookupInfos = config.emails.map { UserIdentityLookupInfo(emailAddress: $0) }
+    let identities = try await service.discoverAllUserIdentities(
+      lookupInfos: lookupInfos,
+      batchSize: config.batchSize
+    )
+    try await outputResults(identities, format: config.output)
+  }
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/DiscoverAllUserIdentitiesCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/DiscoverAllUserIdentitiesCommand.swift
@@ -82,7 +82,11 @@ public struct DiscoverAllUserIdentitiesCommand: MistDemoCommand, OutputFormattin
 
     let service = try MistKitClientFactory.create(for: config.base)
 
-    let batches = (config.emails.count + config.batchSize - 1) / config.batchSize
+    let effectiveBatchSize = min(
+      max(config.batchSize, 1),
+      CloudKitService.maxRecordsPerRequest
+    )
+    let batches = (config.emails.count + effectiveBatchSize - 1) / effectiveBatchSize
     let note =
       "discover-all: \(config.emails.count) lookup(s), batchSize \(config.batchSize) "
       + "→ \(batches) request(s)\n"

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/LookupAllRecordsCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/LookupAllRecordsCommand.swift
@@ -1,0 +1,100 @@
+//
+//  LookupAllRecordsCommand.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+internal import Foundation
+internal import MistKit
+
+/// Command to look up records by name using the auto-chunking
+/// `lookupAllRecords` convenience (issue #307).
+public struct LookupAllRecordsCommand: MistDemoCommand, OutputFormatting {
+  /// The configuration type.
+  public typealias Config = LookupConfig
+  /// The command name.
+  public static let commandName = "lookup-all"
+  /// The command abstract.
+  public static let abstract =
+    "Look up records by name, auto-chunking large inputs (lookupAllRecords)"
+  /// The command help text.
+  public static let helpText = """
+    LOOKUP-ALL - Fetch records by name, auto-chunking past CloudKit's 200/request cap
+
+    USAGE:
+      mistdemo lookup-all --record-names <names> [options]
+
+    REQUIRED:
+      --api-token <token>          CloudKit API token
+      --web-auth-token <token>     Web authentication token
+      --record-names <names>       Comma-separated record names
+
+    OPTIONS:
+      --fields <field1,field2,...> Restrict returned fields
+      --batch-size <n>             Items per request (default 200, clamped 1...200).
+                                   Set small (e.g. 1) to force multiple requests.
+      --output-format <format>     Output format (json, table, csv, yaml)
+
+    EXAMPLES:
+      mistdemo lookup-all --record-names note-1,note-2,note-3 --batch-size 1
+    """
+
+  private let config: LookupConfig
+
+  /// Creates a new instance.
+  public init(config: LookupConfig) {
+    self.config = config
+  }
+
+  /// Executes the command.
+  public func execute() async throws {
+    do {
+      let client = try MistKitClientFactory.create(for: config.base)
+
+      let batches = (config.recordNames.count + config.batchSize - 1) / config.batchSize
+      let note =
+        "lookup-all: \(config.recordNames.count) name(s), batchSize \(config.batchSize) "
+        + "→ \(batches) request(s)\n"
+      FileHandle.standardError.write(Data(note.utf8))
+
+      let results = try await client.lookupAllRecords(
+        recordNames: config.recordNames,
+        desiredKeys: config.fields,
+        database: config.base.database,
+        batchSize: config.batchSize
+      )
+
+      let records = results.compactMap { result in
+        if case .success(let record) = result { record } else { nil }
+      }
+      try await outputResults(records, format: config.output)
+    } catch let error as LookupError {
+      throw error
+    } catch {
+      throw LookupError.operationFailed(error.localizedDescription)
+    }
+  }
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/LookupAllRecordsCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/LookupAllRecordsCommand.swift
@@ -71,30 +71,29 @@ public struct LookupAllRecordsCommand: MistDemoCommand, OutputFormatting {
 
   /// Executes the command.
   public func execute() async throws {
-    do {
-      let client = try MistKitClientFactory.create(for: config.base)
+    let client = try MistKitClientFactory.create(for: config.base)
 
-      let batches = (config.recordNames.count + config.batchSize - 1) / config.batchSize
-      let note =
-        "lookup-all: \(config.recordNames.count) name(s), batchSize \(config.batchSize) "
-        + "→ \(batches) request(s)\n"
-      FileHandle.standardError.write(Data(note.utf8))
+    let effectiveBatchSize = min(
+      max(config.batchSize, 1),
+      CloudKitService.maxRecordsPerRequest
+    )
+    let batches =
+      (config.recordNames.count + effectiveBatchSize - 1) / effectiveBatchSize
+    let note =
+      "lookup-all: \(config.recordNames.count) name(s), batchSize \(config.batchSize) "
+      + "→ \(batches) request(s)\n"
+    FileHandle.standardError.write(Data(note.utf8))
 
-      let results = try await client.lookupAllRecords(
-        recordNames: config.recordNames,
-        desiredKeys: config.fields,
-        database: config.base.database,
-        batchSize: config.batchSize
-      )
+    let results = try await client.lookupAllRecords(
+      recordNames: config.recordNames,
+      desiredKeys: config.fields,
+      database: config.base.database,
+      batchSize: config.batchSize
+    )
 
-      let records = results.compactMap { result in
-        if case .success(let record) = result { record } else { nil }
-      }
-      try await outputResults(records, format: config.output)
-    } catch let error as LookupError {
-      throw error
-    } catch {
-      throw LookupError.operationFailed(error.localizedDescription)
+    let records = results.compactMap { result in
+      if case .success(let record) = result { record } else { nil }
     }
+    try await outputResults(records, format: config.output)
   }
 }

--- a/Examples/MistDemo/Sources/MistDemoKit/Configuration/DiscoverConfig.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Configuration/DiscoverConfig.swift
@@ -41,6 +41,9 @@ public struct DiscoverConfig: Sendable, ConfigurationParseable {
   public let base: MistDemoConfig
   /// The email addresses to look up.
   public let emails: [String]
+  /// Maximum items per request for the auto-chunking `discover-all` command
+  /// (the plain `discover` command ignores it).
+  public let batchSize: Int
   /// The output format.
   public let output: OutputFormat
 
@@ -48,10 +51,12 @@ public struct DiscoverConfig: Sendable, ConfigurationParseable {
   public init(
     base: MistDemoConfig,
     emails: [String],
+    batchSize: Int = 200,
     output: OutputFormat = .json
   ) {
     self.base = base
     self.emails = emails
+    self.batchSize = batchSize
     self.output = output
   }
 
@@ -79,9 +84,13 @@ public struct DiscoverConfig: Sendable, ConfigurationParseable {
       ) ?? MistDemoConstants.Defaults.outputFormat
     let output = OutputFormat(rawValue: outputString) ?? .json
 
+    let batchSize =
+      configuration.int(forKey: MistDemoConstants.ConfigKeys.batchSize, default: 200) ?? 200
+
     self.init(
       base: baseConfig,
       emails: emails,
+      batchSize: batchSize,
       output: output
     )
   }

--- a/Examples/MistDemo/Sources/MistDemoKit/Configuration/DiscoverConfig.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Configuration/DiscoverConfig.swift
@@ -29,7 +29,7 @@
 
 public import ConfigKeyKit
 internal import Foundation
-internal import MistKit
+public import MistKit
 
 /// Configuration for the `discover` command (email lookup).
 public struct DiscoverConfig: Sendable, ConfigurationParseable {

--- a/Examples/MistDemo/Sources/MistDemoKit/Configuration/DiscoverConfig.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Configuration/DiscoverConfig.swift
@@ -29,6 +29,7 @@
 
 public import ConfigKeyKit
 internal import Foundation
+internal import MistKit
 
 /// Configuration for the `discover` command (email lookup).
 public struct DiscoverConfig: Sendable, ConfigurationParseable {
@@ -51,7 +52,7 @@ public struct DiscoverConfig: Sendable, ConfigurationParseable {
   public init(
     base: MistDemoConfig,
     emails: [String],
-    batchSize: Int = 200,
+    batchSize: Int = CloudKitService.maxRecordsPerRequest,
     output: OutputFormat = .json
   ) {
     self.base = base
@@ -85,7 +86,10 @@ public struct DiscoverConfig: Sendable, ConfigurationParseable {
     let output = OutputFormat(rawValue: outputString) ?? .json
 
     let batchSize =
-      configuration.int(forKey: MistDemoConstants.ConfigKeys.batchSize, default: 200) ?? 200
+      configuration.int(
+        forKey: MistDemoConstants.ConfigKeys.batchSize,
+        default: CloudKitService.maxRecordsPerRequest
+      ) ?? CloudKitService.maxRecordsPerRequest
 
     self.init(
       base: baseConfig,

--- a/Examples/MistDemo/Sources/MistDemoKit/Configuration/LookupConfig.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Configuration/LookupConfig.swift
@@ -43,6 +43,9 @@ public struct LookupConfig: Sendable, ConfigurationParseable {
   public let recordNames: [String]
   /// The optional field names to include in the response.
   public let fields: [String]?
+  /// Maximum items per request for the auto-chunking `lookup-all` command
+  /// (the plain `lookup` command ignores it).
+  public let batchSize: Int
   /// The output format.
   public let output: OutputFormat
 
@@ -51,11 +54,13 @@ public struct LookupConfig: Sendable, ConfigurationParseable {
     base: MistDemoConfig,
     recordNames: [String],
     fields: [String]? = nil,
+    batchSize: Int = 200,
     output: OutputFormat = .json
   ) {
     self.base = base
     self.recordNames = recordNames
     self.fields = fields
+    self.batchSize = batchSize
     self.output = output
   }
 
@@ -111,10 +116,14 @@ public struct LookupConfig: Sendable, ConfigurationParseable {
       ) ?? MistDemoConstants.Defaults.outputFormat
     let output = OutputFormat(rawValue: outputString) ?? .json
 
+    let batchSize =
+      configReader.int(forKey: MistDemoConstants.ConfigKeys.batchSize, default: 200) ?? 200
+
     self.init(
       base: baseConfig,
       recordNames: recordNames,
       fields: fields,
+      batchSize: batchSize,
       output: output
     )
   }

--- a/Examples/MistDemo/Sources/MistDemoKit/Configuration/LookupConfig.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Configuration/LookupConfig.swift
@@ -29,7 +29,7 @@
 
 public import ConfigKeyKit
 internal import Foundation
-internal import MistKit
+public import MistKit
 
 /// Configuration for lookup command.
 public struct LookupConfig: Sendable, ConfigurationParseable {

--- a/Examples/MistDemo/Sources/MistDemoKit/Configuration/LookupConfig.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Configuration/LookupConfig.swift
@@ -29,6 +29,7 @@
 
 public import ConfigKeyKit
 internal import Foundation
+internal import MistKit
 
 /// Configuration for lookup command.
 public struct LookupConfig: Sendable, ConfigurationParseable {
@@ -54,7 +55,7 @@ public struct LookupConfig: Sendable, ConfigurationParseable {
     base: MistDemoConfig,
     recordNames: [String],
     fields: [String]? = nil,
-    batchSize: Int = 200,
+    batchSize: Int = CloudKitService.maxRecordsPerRequest,
     output: OutputFormat = .json
   ) {
     self.base = base
@@ -117,7 +118,10 @@ public struct LookupConfig: Sendable, ConfigurationParseable {
     let output = OutputFormat(rawValue: outputString) ?? .json
 
     let batchSize =
-      configReader.int(forKey: MistDemoConstants.ConfigKeys.batchSize, default: 200) ?? 200
+      configReader.int(
+        forKey: MistDemoConstants.ConfigKeys.batchSize,
+        default: CloudKitService.maxRecordsPerRequest
+      ) ?? CloudKitService.maxRecordsPerRequest
 
     self.init(
       base: baseConfig,

--- a/Examples/MistDemo/Sources/MistDemoKit/Constants/MistDemoConstants.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Constants/MistDemoConstants.swift
@@ -81,6 +81,8 @@ public enum MistDemoConstants {
     public static let operationsFile = "operations.file"
     /// Atomic configuration key.
     public static let atomic = "atomic"
+    /// Batch size configuration key for the auto-chunking `*-all` commands.
+    public static let batchSize = "batch.size"
   }
 
   // MARK: - Field Names

--- a/Examples/MistDemo/Sources/MistDemoKit/MistDemoRunner.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/MistDemoRunner.swift
@@ -58,6 +58,8 @@ public enum MistDemoRunner {
     await registry.register(ListZonesCommand.self)
     await registry.register(ModifyZonesCommand.self)
     await registry.register(DiscoverCommand.self)
+    await registry.register(LookupAllRecordsCommand.self)
+    await registry.register(DiscoverAllUserIdentitiesCommand.self)
     await registry.register(ValidateCommand.self)
     await registry.register(DeleteZoneCommand.self)
     await registry.register(FetchChangesCommand.self)

--- a/Sources/MistKit/CloudKitService/CloudKitService+BatchChunking.swift
+++ b/Sources/MistKit/CloudKitService/CloudKitService+BatchChunking.swift
@@ -1,0 +1,82 @@
+//
+//  CloudKitService+BatchChunking.swift
+//  MistKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+extension CloudKitService {
+  /// Split `items` into batches of at most `batchSize`, invoke `perBatch`
+  /// for each batch in order, and concatenate the results.
+  ///
+  /// This is the shared engine behind the auto-chunking convenience methods
+  /// (`lookupAllRecords`, `discoverAllUserIdentities(lookupInfos:)`, etc.) that
+  /// sit on top of CloudKit's single-request batch primitives. CloudKit caps
+  /// most batch endpoints at ``maxRecordsPerRequest`` items per request, so a
+  /// caller with a larger input must split it across multiple requests.
+  ///
+  /// Unlike server-driven pagination, the number of batches here is fully
+  /// determined up front (`ceil(items.count / batchSize)`), so there is no
+  /// runaway-loop risk and therefore no `maxPages`-style ceiling that throws —
+  /// `batchSize` is the only knob, clamped to `1...maxRecordsPerRequest`.
+  ///
+  /// - Parameters:
+  ///   - items: The full input to process; an empty input issues no requests.
+  ///   - batchSize: Maximum items per batch, clamped to
+  ///     `1...maxRecordsPerRequest`.
+  ///   - context: Operation label used when mapping cancellation to
+  ///     `CloudKitError`.
+  ///   - perBatch: Performs one batch (a single CloudKit request) and returns
+  ///     that batch's results.
+  /// - Returns: Every batch's results concatenated in input order.
+  internal func chunkedBatches<Input, Output>(
+    _ items: [Input],
+    batchSize: Int,
+    context: String,
+    _ perBatch: ([Input]) async throws(CloudKitError) -> [Output]
+  ) async throws(CloudKitError) -> [Output] {
+    guard !items.isEmpty else {
+      return []
+    }
+
+    let size = min(max(batchSize, 1), CloudKitService.maxRecordsPerRequest)
+    var results: [Output] = []
+    var index = 0
+
+    while index < items.count {
+      do {
+        try Task.checkCancellation()
+      } catch {
+        throw mapToCloudKitError(error, context: context)
+      }
+
+      let end = min(index + size, items.count)
+      results.append(contentsOf: try await perBatch(Array(items[index..<end])))
+      index = end
+    }
+
+    return results
+  }
+}

--- a/Sources/MistKit/CloudKitService/CloudKitService+LookupAllRecords.swift
+++ b/Sources/MistKit/CloudKitService/CloudKitService+LookupAllRecords.swift
@@ -1,0 +1,69 @@
+//
+//  CloudKitService+LookupAllRecords.swift
+//  MistKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+extension CloudKitService {
+  /// Look up records by name, automatically chunking large inputs.
+  ///
+  /// Convenience over ``lookupRecords(recordNames:desiredKeys:database:)`` that
+  /// splits `recordNames` into batches of at most `batchSize` (CloudKit caps a
+  /// single lookup request at ``maxRecordsPerRequest`` records) and concatenates
+  /// the per-batch results in input order. Use this whenever the number of
+  /// record names may exceed 200; the bare primitive sends them all in one
+  /// request and CloudKit rejects more than 200 with `BAD_REQUEST`.
+  ///
+  /// - Parameters:
+  ///   - recordNames: Record names to fetch (any length).
+  ///   - desiredKeys: Optional array of field names to fetch.
+  ///   - database: The CloudKit database scope to read from
+  ///     (`.public`, `.private`, `.shared`).
+  ///   - batchSize: Maximum record names per request, clamped to
+  ///     `1...maxRecordsPerRequest` (defaults to ``maxRecordsPerRequest``).
+  /// - Returns: A ``RecordResult`` per requested record, in the same order as
+  ///   `recordNames` — `.success` for a found record, `.failure` (e.g.
+  ///   `NOT_FOUND`) for one CloudKit could not return.
+  /// - Throws: `CloudKitError` if any batch fails.
+  public func lookupAllRecords(
+    recordNames: [String],
+    desiredKeys: [String]? = nil,
+    database: Database,
+    batchSize: Int = CloudKitService.maxRecordsPerRequest
+  ) async throws(CloudKitError) -> [RecordResult] {
+    try await chunkedBatches(
+      recordNames,
+      batchSize: batchSize,
+      context: "lookupAllRecords"
+    ) { batch throws(CloudKitError) in
+      try await self.lookupRecords(
+        recordNames: batch,
+        desiredKeys: desiredKeys,
+        database: database
+      )
+    }
+  }
+}

--- a/Sources/MistKit/CloudKitService/CloudKitService+LookupOperations.swift
+++ b/Sources/MistKit/CloudKitService/CloudKitService+LookupOperations.swift
@@ -50,6 +50,10 @@ extension CloudKitService {
   ///
   /// - Note: Pass `desiredKeys` to limit which fields come back. Useful
   ///   for list views that only need a projection.
+  /// - Note: This is the single-request primitive — CloudKit caps it at
+  ///   ``maxRecordsPerRequest`` record names. For larger inputs use
+  ///   ``lookupAllRecords(recordNames:desiredKeys:database:batchSize:)``, which
+  ///   chunks automatically.
   /// - Returns: A ``RecordResult`` per requested record — `.success` for a found
   ///   record, `.failure` (e.g. `NOT_FOUND`) for one CloudKit could not return.
   public func lookupRecords(

--- a/Sources/MistKit/CloudKitService/CloudKitService+UserIdentityChunking.swift
+++ b/Sources/MistKit/CloudKitService/CloudKitService+UserIdentityChunking.swift
@@ -1,0 +1,63 @@
+//
+//  CloudKitService+UserIdentityChunking.swift
+//  MistKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+extension CloudKitService {
+  /// Discover user identities for the given lookup infos, automatically
+  /// chunking large inputs.
+  ///
+  /// Convenience over ``discoverUserIdentities(lookupInfos:)`` that splits
+  /// `lookupInfos` into batches of at most `batchSize` (CloudKit caps a single
+  /// `users/discover` request at ``maxRecordsPerRequest`` infos) and
+  /// concatenates the per-batch identities in input order.
+  ///
+  /// - Note: This overloads the (input-less) address-book discovery
+  ///   `discoverAllUserIdentities()` — *this* form discovers identities matching
+  ///   the supplied `lookupInfos` via the batched POST `users/discover`
+  ///   endpoint, whereas the no-argument form enumerates the caller's address
+  ///   book via GET.
+  ///
+  /// - Parameters:
+  ///   - lookupInfos: Email/phone/record-name lookups to resolve (any length).
+  ///   - batchSize: Maximum infos per request, clamped to
+  ///     `1...maxRecordsPerRequest` (defaults to ``maxRecordsPerRequest``).
+  /// - Returns: The resolved identities across all batches, in input order.
+  /// - Throws: `CloudKitError` if any batch fails.
+  public func discoverAllUserIdentities(
+    lookupInfos: [UserIdentityLookupInfo],
+    batchSize: Int = CloudKitService.maxRecordsPerRequest
+  ) async throws(CloudKitError) -> [UserIdentity] {
+    try await chunkedBatches(
+      lookupInfos,
+      batchSize: batchSize,
+      context: "discoverAllUserIdentities"
+    ) { batch throws(CloudKitError) in
+      try await self.discoverUserIdentities(lookupInfos: batch)
+    }
+  }
+}

--- a/Sources/MistKit/CloudKitService/CloudKitService+UserOperations.swift
+++ b/Sources/MistKit/CloudKitService/CloudKitService+UserOperations.swift
@@ -143,6 +143,11 @@ extension CloudKitService {
   ///
   /// Hits CloudKit's POST `users/discover` endpoint. Routed against the public
   /// database with web-auth credentials.
+  ///
+  /// - Note: This is the single-request primitive — CloudKit caps it at
+  ///   ``maxRecordsPerRequest`` lookup infos. For larger inputs use
+  ///   ``discoverAllUserIdentities(lookupInfos:batchSize:)``, which chunks
+  ///   automatically.
   public func discoverUserIdentities(
     lookupInfos: [UserIdentityLookupInfo]
   ) async throws(CloudKitError) -> [UserIdentity] {

--- a/Sources/MistKit/CloudKitService/CloudKitService.swift
+++ b/Sources/MistKit/CloudKitService/CloudKitService.swift
@@ -59,8 +59,11 @@ public struct CloudKitService: Sendable {
   public static let baseURL = URL(string: "https://api.apple-cloudkit.com")!
   // swiftlint:enable force_unwrapping
 
-  /// CloudKit's maximum number of records returned per query/modify request.
-  internal static let maxRecordsPerRequest: Int = 200
+  /// CloudKit's maximum number of items (records, lookups, or operations)
+  /// accepted or returned per batch request. The auto-chunking convenience
+  /// methods (e.g. ``lookupAllRecords(recordNames:desiredKeys:database:batchSize:)``)
+  /// default their `batchSize` to this value.
+  public static let maxRecordsPerRequest: Int = 200
 
   /// CloudKit's documented per-record field-data limit (1 MB). Assets travel
   /// via the CDN and don't count against this limit. MistKit does not

--- a/Tests/MistKitTests/CloudKitService/BatchChunking/CloudKitServiceTests.BatchChunking+Helpers.swift
+++ b/Tests/MistKitTests/CloudKitService/BatchChunking/CloudKitServiceTests.BatchChunking+Helpers.swift
@@ -36,8 +36,8 @@ internal import Testing
 extension CloudKitServiceTests.BatchChunking {
   private static let testAPIToken = TestConstants.apiToken
 
-  /// A service whose provider returns `identitiesPerCall` identities for every
-  /// `users/*` request, with web-auth credentials.
+  /// A `CloudKitService` backed by `provider`, configured with web-auth
+  /// credentials (so `.private` and `users/*` routes both work).
   internal static func makeUserService(
     provider: ResponseProvider
   ) throws -> CloudKitService {
@@ -52,14 +52,6 @@ extension CloudKitServiceTests.BatchChunking {
       ),
       transport: transport
     )
-  }
-
-  /// A service whose provider returns `recordsPerCall` records for every
-  /// `lookupRecords` request, with web-auth credentials (so `.private` works).
-  internal static func makeLookupRecordsService(
-    provider: ResponseProvider
-  ) throws -> CloudKitService {
-    try makeUserService(provider: provider)
   }
 
   // MARK: - Request body inspection

--- a/Tests/MistKitTests/CloudKitService/BatchChunking/CloudKitServiceTests.BatchChunking+Helpers.swift
+++ b/Tests/MistKitTests/CloudKitService/BatchChunking/CloudKitServiceTests.BatchChunking+Helpers.swift
@@ -1,0 +1,128 @@
+//
+//  CloudKitServiceTests.BatchChunking+Helpers.swift
+//  MistKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+internal import Foundation
+internal import HTTPTypes
+internal import Testing
+
+@testable import MistKit
+
+extension CloudKitServiceTests.BatchChunking {
+  private static let testAPIToken = TestConstants.apiToken
+
+  /// A service whose provider returns `identitiesPerCall` identities for every
+  /// `users/*` request, with web-auth credentials.
+  internal static func makeUserService(
+    provider: ResponseProvider
+  ) throws -> CloudKitService {
+    let transport = MockTransport(responseProvider: provider)
+    return try CloudKitService(
+      containerIdentifier: TestConstants.serviceContainerIdentifier,
+      credentials: Credentials(
+        apiAuth: APICredentials(
+          apiToken: testAPIToken,
+          webAuthToken: TestConstants.webAuthToken
+        )
+      ),
+      transport: transport
+    )
+  }
+
+  /// A service whose provider returns `recordsPerCall` records for every
+  /// `lookupRecords` request, with web-auth credentials (so `.private` works).
+  internal static func makeLookupRecordsService(
+    provider: ResponseProvider
+  ) throws -> CloudKitService {
+    try makeUserService(provider: provider)
+  }
+
+  // MARK: - Request body inspection
+
+  /// Number of items in each recorded request body, reading the array under
+  /// `key` (e.g. `"records"`, `"users"`, `"lookupInfos"`).
+  internal static func itemCounts(in bodies: [Data?], key: String) -> [Int] {
+    bodies.map { data in
+      guard let data,
+        let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+        let items = json[key] as? [[String: Any]]
+      else {
+        return 0
+      }
+      return items.count
+    }
+  }
+
+  /// Concatenate the `field`-valued strings of every item across all bodies,
+  /// reading items under `key` — used to verify input order is preserved.
+  internal static func orderedValues(
+    in bodies: [Data?],
+    key: String,
+    field: String
+  ) -> [String] {
+    bodies.flatMap { data -> [String] in
+      guard let data,
+        let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+        let items = json[key] as? [[String: Any]]
+      else {
+        return []
+      }
+      return items.compactMap { $0[field] as? String }
+    }
+  }
+}
+
+// MARK: - lookupRecords Response Builder
+
+extension ResponseConfig {
+  internal static func successfulLookupRecordsResponse(
+    recordCount: Int = 1
+  ) throws -> ResponseConfig {
+    var records: [[String: Any]] = []
+    for index in 0..<recordCount {
+      records.append([
+        "recordName": "found-\(index)",
+        "recordType": "TestRecord",
+        "recordChangeTag": "tag-\(index)",
+        "fields": [String: Any](),
+      ])
+    }
+
+    let bodyData = try JSONSerialization.data(withJSONObject: ["records": records])
+
+    var headers = HTTPFields()
+    headers[.contentType] = "application/json"
+
+    return ResponseConfig(
+      statusCode: 200,
+      headers: headers,
+      body: bodyData,
+      error: nil
+    )
+  }
+}

--- a/Tests/MistKitTests/CloudKitService/BatchChunking/CloudKitServiceTests.BatchChunking+LookupAllRecords.swift
+++ b/Tests/MistKitTests/CloudKitService/BatchChunking/CloudKitServiceTests.BatchChunking+LookupAllRecords.swift
@@ -41,7 +41,7 @@ extension CloudKitServiceTests.BatchChunking {
       let provider = ResponseProvider(
         defaultResponse: try .successfulLookupRecordsResponse(recordCount: recordsPerCall)
       )
-      let service = try CloudKitServiceTests.BatchChunking.makeLookupRecordsService(
+      let service = try CloudKitServiceTests.BatchChunking.makeUserService(
         provider: provider
       )
       return (service, provider)
@@ -68,6 +68,8 @@ extension CloudKitServiceTests.BatchChunking {
       )
       #expect(count == 1)
       #expect(sizes == [5])
+      // The mock returns `recordsPerCall` records per request regardless of
+      // input size, so the result count reflects the mock, not `names.count`.
       #expect(results.count == Self.recordsPerCall)
     }
 
@@ -179,6 +181,37 @@ extension CloudKitServiceTests.BatchChunking {
 
       #expect(results.isEmpty)
       #expect(await provider.callCount(for: "lookupRecords") == 0)
+    }
+
+    @Test("a failing batch throws and stops the loop")
+    internal func failingBatchPropagates() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let provider = ResponseProvider(
+        defaultResponse: try .successfulLookupRecordsResponse(recordCount: Self.recordsPerCall)
+      )
+      // First batch succeeds, second fails: the loop must stop on the error
+      // rather than issuing the remaining batch.
+      await provider.enqueue(
+        try .successfulLookupRecordsResponse(recordCount: Self.recordsPerCall),
+        for: "lookupRecords"
+      )
+      await provider.enqueue(.authenticationError(), for: "lookupRecords")
+      let service = try CloudKitServiceTests.BatchChunking.makeUserService(
+        provider: provider
+      )
+      let names = (0..<450).map { "rec-\($0)" }
+
+      await #expect(throws: CloudKitError.self) {
+        _ = try await service.lookupAllRecords(
+          recordNames: names,
+          database: .private
+        )
+      }
+      // Two batches issued (success then failure); the third is never sent.
+      #expect(await provider.callCount(for: "lookupRecords") == 2)
     }
   }
 }

--- a/Tests/MistKitTests/CloudKitService/BatchChunking/CloudKitServiceTests.BatchChunking+LookupAllRecords.swift
+++ b/Tests/MistKitTests/CloudKitService/BatchChunking/CloudKitServiceTests.BatchChunking+LookupAllRecords.swift
@@ -1,0 +1,184 @@
+//
+//  CloudKitServiceTests.BatchChunking+LookupAllRecords.swift
+//  MistKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+internal import Foundation
+internal import Testing
+
+@testable import MistKit
+
+extension CloudKitServiceTests.BatchChunking {
+  @Suite("lookupAllRecords")
+  internal struct LookupAllRecords {
+    private static let recordsPerCall = 2
+
+    private static func makeService() throws -> (CloudKitService, ResponseProvider) {
+      let provider = ResponseProvider(
+        defaultResponse: try .successfulLookupRecordsResponse(recordCount: recordsPerCall)
+      )
+      let service = try CloudKitServiceTests.BatchChunking.makeLookupRecordsService(
+        provider: provider
+      )
+      return (service, provider)
+    }
+
+    @Test("issues one request and passes results through for a single batch")
+    internal func singleBatch() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let (service, provider) = try Self.makeService()
+      let names = (0..<5).map { "rec-\($0)" }
+
+      let results = try await service.lookupAllRecords(
+        recordNames: names,
+        database: .private
+      )
+
+      let count = await provider.callCount(for: "lookupRecords")
+      let sizes = CloudKitServiceTests.BatchChunking.itemCounts(
+        in: await provider.bodies(for: "lookupRecords"),
+        key: "records"
+      )
+      #expect(count == 1)
+      #expect(sizes == [5])
+      #expect(results.count == Self.recordsPerCall)
+    }
+
+    @Test("accumulates results across multiple batches and preserves order")
+    internal func multiBatchAccumulation() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let (service, provider) = try Self.makeService()
+      let names = (0..<450).map { "rec-\($0)" }
+
+      let results = try await service.lookupAllRecords(
+        recordNames: names,
+        database: .private
+      )
+
+      let bodies = await provider.bodies(for: "lookupRecords")
+      let sizes = CloudKitServiceTests.BatchChunking.itemCounts(in: bodies, key: "records")
+      let order = CloudKitServiceTests.BatchChunking.orderedValues(
+        in: bodies,
+        key: "records",
+        field: "recordName"
+      )
+      #expect(await provider.callCount(for: "lookupRecords") == 3)
+      #expect(sizes == [200, 200, 50])
+      #expect(order == names)
+      #expect(results.count == 3 * Self.recordsPerCall)
+    }
+
+    @Test("custom batchSize controls chunk boundaries")
+    internal func customBatchSize() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let (service, provider) = try Self.makeService()
+      let names = (0..<5).map { "rec-\($0)" }
+
+      _ = try await service.lookupAllRecords(
+        recordNames: names,
+        database: .private,
+        batchSize: 2
+      )
+
+      let sizes = CloudKitServiceTests.BatchChunking.itemCounts(
+        in: await provider.bodies(for: "lookupRecords"),
+        key: "records"
+      )
+      #expect(sizes == [2, 2, 1])
+    }
+
+    @Test("batchSize below 1 clamps to 1")
+    internal func batchSizeClampsLow() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let (service, provider) = try Self.makeService()
+      let names = (0..<3).map { "rec-\($0)" }
+
+      _ = try await service.lookupAllRecords(
+        recordNames: names,
+        database: .private,
+        batchSize: 0
+      )
+
+      let sizes = CloudKitServiceTests.BatchChunking.itemCounts(
+        in: await provider.bodies(for: "lookupRecords"),
+        key: "records"
+      )
+      #expect(sizes == [1, 1, 1])
+    }
+
+    @Test("batchSize above the cap clamps to maxRecordsPerRequest")
+    internal func batchSizeClampsHigh() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let (service, provider) = try Self.makeService()
+      let names = (0..<250).map { "rec-\($0)" }
+
+      _ = try await service.lookupAllRecords(
+        recordNames: names,
+        database: .private,
+        batchSize: 9_999
+      )
+
+      let sizes = CloudKitServiceTests.BatchChunking.itemCounts(
+        in: await provider.bodies(for: "lookupRecords"),
+        key: "records"
+      )
+      #expect(sizes == [200, 50])
+    }
+
+    @Test("empty input issues no requests")
+    internal func emptyInput() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let (service, provider) = try Self.makeService()
+
+      let results = try await service.lookupAllRecords(
+        recordNames: [],
+        database: .private
+      )
+
+      #expect(results.isEmpty)
+      #expect(await provider.callCount(for: "lookupRecords") == 0)
+    }
+  }
+}

--- a/Tests/MistKitTests/CloudKitService/BatchChunking/CloudKitServiceTests.BatchChunking+UserIdentityChunking.swift
+++ b/Tests/MistKitTests/CloudKitService/BatchChunking/CloudKitServiceTests.BatchChunking+UserIdentityChunking.swift
@@ -1,0 +1,108 @@
+//
+//  CloudKitServiceTests.BatchChunking+UserIdentityChunking.swift
+//  MistKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+internal import Foundation
+internal import Testing
+
+@testable import MistKit
+
+extension CloudKitServiceTests.BatchChunking {
+  @Suite("User-identity chunking")
+  internal struct UserIdentityChunking {
+    private static let identitiesPerCall = 2
+
+    private static func makeService() throws -> (CloudKitService, ResponseProvider) {
+      let provider = ResponseProvider(
+        defaultResponse: try .successfulDiscoverUserIdentitiesResponse(
+          identityCount: identitiesPerCall
+        )
+      )
+      let service = try CloudKitServiceTests.BatchChunking.makeUserService(provider: provider)
+      return (service, provider)
+    }
+
+    // MARK: - discoverAllUserIdentities(lookupInfos:)
+
+    @Test("discoverAllUserIdentities chunks, accumulates, and preserves order")
+    internal func discoverMultiBatch() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let (service, provider) = try Self.makeService()
+      let infos = (0..<450).map { UserIdentityLookupInfo(userRecordName: "_user-\($0)") }
+
+      let identities = try await service.discoverAllUserIdentities(lookupInfos: infos)
+
+      let bodies = await provider.bodies(for: "discoverUserIdentities")
+      let sizes = CloudKitServiceTests.BatchChunking.itemCounts(in: bodies, key: "lookupInfos")
+      let order = CloudKitServiceTests.BatchChunking.orderedValues(
+        in: bodies,
+        key: "lookupInfos",
+        field: "userRecordName"
+      )
+      #expect(await provider.callCount(for: "discoverUserIdentities") == 3)
+      #expect(sizes == [200, 200, 50])
+      #expect(order == infos.map { $0.userRecordName ?? "" })
+      #expect(identities.count == 3 * Self.identitiesPerCall)
+    }
+
+    @Test("discoverAllUserIdentities clamps batchSize to the per-request cap")
+    internal func discoverClampsBatchSize() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let (service, provider) = try Self.makeService()
+      let infos = (0..<250).map { UserIdentityLookupInfo(userRecordName: "_user-\($0)") }
+
+      _ = try await service.discoverAllUserIdentities(lookupInfos: infos, batchSize: 9_999)
+
+      let sizes = CloudKitServiceTests.BatchChunking.itemCounts(
+        in: await provider.bodies(for: "discoverUserIdentities"),
+        key: "lookupInfos"
+      )
+      #expect(sizes == [200, 50])
+    }
+
+    @Test("discoverAllUserIdentities issues no requests for empty input")
+    internal func discoverEmptyInput() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let (service, provider) = try Self.makeService()
+
+      let identities = try await service.discoverAllUserIdentities(lookupInfos: [])
+
+      #expect(identities.isEmpty)
+      #expect(await provider.callCount(for: "discoverUserIdentities") == 0)
+    }
+  }
+}

--- a/Tests/MistKitTests/CloudKitService/BatchChunking/CloudKitServiceTests.BatchChunking.swift
+++ b/Tests/MistKitTests/CloudKitService/BatchChunking/CloudKitServiceTests.BatchChunking.swift
@@ -1,9 +1,9 @@
 //
-//  MockTransport.swift
+//  CloudKitServiceTests.BatchChunking.swift
 //  MistKit
 //
 //  Created by Leo Dion.
-//  Copyright © 2025 BrightDigit.
+//  Copyright © 2026 BrightDigit.
 //
 //  Permission is hereby granted, free of charge, to any person
 //  obtaining a copy of this software and associated documentation
@@ -28,33 +28,11 @@
 //
 
 internal import Foundation
-internal import HTTPTypes
-internal import OpenAPIRuntime
+internal import Testing
 
-/// Mock transport for testing that doesn't make actual network calls
-internal struct MockTransport: ClientTransport, Sendable {
-  internal let responseProvider: ResponseProvider
+@testable import MistKit
 
-  internal init(responseProvider: ResponseProvider = .default) {
-    self.responseProvider = responseProvider
-  }
-
-  internal func send(
-    _ request: HTTPRequest,
-    body: HTTPBody?,
-    baseURL: URL,
-    operationID: String
-  ) async throws -> (HTTPResponse, HTTPBody?) {
-    let bodyData: Data? =
-      if let body {
-        try await Data(collecting: body, upTo: 10 * 1_024 * 1_024)
-      } else {
-        nil
-      }
-    return try await responseProvider.response(
-      for: operationID,
-      request: request,
-      body: bodyData
-    )
-  }
+extension CloudKitServiceTests {
+  @Suite("CloudKitService Batch Chunking", .enabled(if: Platform.isCryptoAvailable))
+  internal enum BatchChunking {}
 }

--- a/Tests/MistKitTests/Mocks/ResponseProvider.swift
+++ b/Tests/MistKitTests/Mocks/ResponseProvider.swift
@@ -27,6 +27,7 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
+internal import Foundation
 internal import HTTPTypes
 internal import OpenAPIRuntime
 
@@ -44,6 +45,9 @@ internal actor ResponseProvider {
   private var responses: [String: ResponseConfig]
   private var defaultResponse: ResponseConfig
   private var responseQueues: [String: [ResponseConfig]] = [:]
+
+  /// Every request received, in order, captured for test assertions.
+  private var requestLog: [(operationID: String, body: Data?)] = []
 
   // MARK: - Initializers
 
@@ -83,10 +87,25 @@ internal actor ResponseProvider {
     responseQueues[operationID, default: []].append(response)
   }
 
+  // MARK: - Request Inspection
+
+  /// Number of requests received for `operationID`.
+  internal func callCount(for operationID: String) -> Int {
+    requestLog.filter { $0.operationID == operationID }.count
+  }
+
+  /// The request bodies received for `operationID`, in order.
+  internal func bodies(for operationID: String) -> [Data?] {
+    requestLog.filter { $0.operationID == operationID }.map(\.body)
+  }
+
   internal func response(
     for operationID: String,
-    request _: HTTPRequest
+    request _: HTTPRequest,
+    body: Data? = nil
   ) throws -> (HTTPResponse, HTTPBody?) {
+    requestLog.append((operationID: operationID, body: body))
+
     let config: ResponseConfig
     if var queue = responseQueues[operationID], !queue.isEmpty {
       config = queue.removeFirst()


### PR DESCRIPTION
Closes #307 (partial — see scope note).

## Summary

Applies the page-primitive + auto-paginating-extension pattern (established by `queryRecords`/`queryAllRecords`) to the remaining non-deprecated, 200-item-capped batch operations. Most of #307 was already done on this milestone (`fetchAllRecordChanges`, `fetchAllZoneChanges`); this PR closes the gap for the batch-chunking candidates.

### New public API

| Primitive (single request) | Auto-chunking convenience |
|---|---|
| `lookupRecords(recordNames:desiredKeys:database:)` | `lookupAllRecords(recordNames:desiredKeys:database:batchSize:)` |
| `discoverUserIdentities(lookupInfos:)` | `discoverAllUserIdentities(lookupInfos:batchSize:)` |

Both delegate to a shared internal `chunkedBatches` engine: splits the input into `≤batchSize` batches (clamped to `1...maxRecordsPerRequest`), calls the primitive per batch, concatenates results in input order. Chunk count is `ceil(n/batchSize)` — deterministic and finite — so there is **no** `maxPages`-style throwing ceiling; `batchSize` (default `maxRecordsPerRequest`) is the only knob. `CloudKitService.maxRecordsPerRequest` is now `public`.

### Scope decisions

- **`users/lookup/email` and `users/lookup/id` get no chunking convenience.** Both are **deprecated by Apple** in favor of POST `users/discover` (verified against Apple's archived CloudKit Web Services reference). Adding new public API on deprecated endpoints would be wrong; callers needing >200 should use `discoverAllUserIdentities(lookupInfos:)`. The existing primitives are left as-is (no deprecation annotations) pending public feedback.
- **`listZones` is not a pagination candidate** — `zones/list` (GET) returns every zone in one response, no continuation marker.
- `modifyRecords`/`sync<T>` already chunk by 200; `fetchAllRecordChanges`/`fetchAllZoneChanges` already implement the pattern.

## Tests

`ResponseProvider` now records request count + bodies, so tests assert exact batch boundaries, input order, accumulation, `batchSize` clamping (low/high), and empty input. 9 new chunking tests; full suite (529) passes. `./Scripts/lint.sh` clean (swiftlint, headers, periphery).

## MistDemo

Adds `lookup-all` and `discover-all` subcommands with a `--batch-size` flag. Verified end-to-end against live CloudKit: `--batch-size 1` issues N separate requests and the results are correctly accumulated in order (identical to a single `--batch-size 200` request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)