### PR TITLE
Drop obsolete scheme input from example workflows (#403)

### DIFF
--- a/Examples/BushelCloud/.github/workflows/BushelCloud.yml
+++ b/Examples/BushelCloud/.github/workflows/BushelCloud.yml
@@ -193,7 +193,6 @@ jobs:
         id: build
         uses: brightdigit/swift-build@v1
         with:
-          scheme: ${{ env.PACKAGE_NAME }}-Package
           type: ${{ matrix.type }}
           xcode: ${{ matrix.xcode }}
           deviceName: ${{ matrix.deviceName }}
@@ -263,7 +262,6 @@ jobs:
         id: build
         uses: brightdigit/swift-build@v1
         with:
-          scheme: ${{ env.PACKAGE_NAME }}-Package
           type: ${{ matrix.type }}
           xcode: ${{ matrix.xcode }}
           deviceName: ${{ matrix.deviceName }}

--- a/Examples/CelestraCloud/.github/workflows/CelestraCloud.yml
+++ b/Examples/CelestraCloud/.github/workflows/CelestraCloud.yml
@@ -196,7 +196,6 @@ jobs:
         id: build
         uses: brightdigit/swift-build@v1
         with:
-          scheme: ${{ env.PACKAGE_NAME }}-Package
           type: ${{ matrix.type }}
           xcode: ${{ matrix.xcode }}
           deviceName: ${{ matrix.deviceName }}
@@ -264,7 +263,6 @@ jobs:
         id: build
         uses: brightdigit/swift-build@v1
         with:
-          scheme: ${{ env.PACKAGE_NAME }}-Package
           type: ${{ matrix.type }}
           xcode: ${{ matrix.xcode }}
           deviceName: ${{ matrix.deviceName }}


### PR DESCRIPTION
`brightdigit/swift-build@v1` no longer needs an explicit `scheme` — the MistKit and MistDemo workflows already omit it. Removes the now-obsolete `scheme:` input from the **BushelCloud** and **CelestraCloud** workflows to match.

These are subrepo workflows; changes will be propagated upstream via `git subrepo push` after approval.

**ConfigKeyKit excluded:** that subrepo is being removed entirely in #417, so its workflow is not modified here.

⚠️ The issue body was empty — please confirm this is the intended target set.

Closes #403.