### PR TITLE
Reduce cyclomatic complexity in FieldValue+Codable, drop lint disable (#154)

### DIFF
--- a/Sources/MistKit/Models/FieldValues/FieldValue+Codable.swift
+++ b/Sources/MistKit/Models/FieldValues/FieldValue+Codable.swift
@@ -100,8 +100,18 @@ extension FieldValue {
     try encodeValue(to: &container)
   }
 
-  // swiftlint:disable:next cyclomatic_complexity
   private func encodeValue(to container: inout any SingleValueEncodingContainer) throws {
+    if try encodeScalar(to: &container) {
+      return
+    }
+    try encodeComplex(to: &container)
+  }
+
+  /// Encode the scalar cases (string, bytes, int64, double, date).
+  ///
+  /// - Returns: `true` when `self` was a scalar case and has been encoded;
+  ///   `false` when `self` is a complex case that this method did not handle.
+  private func encodeScalar(to container: inout any SingleValueEncodingContainer) throws -> Bool {
     switch self {
     case .string(let val), .bytes(let val):
       try container.encode(val)
@@ -111,6 +121,15 @@ extension FieldValue {
       try container.encode(val)
     case .date(let val):
       try container.encode(val.timeIntervalSince1970 * Self.millisecondsPerSecond)
+    default:
+      return false
+    }
+    return true
+  }
+
+  /// Encode the complex cases (location, reference, asset, list).
+  private func encodeComplex(to container: inout any SingleValueEncodingContainer) throws {
+    switch self {
     case .location(let val):
       try container.encode(val)
     case .reference(let val):
@@ -119,6 +138,17 @@ extension FieldValue {
       try container.encode(val)
     case .list(let val):
       try container.encode(val)
+    default:
+      // Scalar cases are handled by `encodeScalar(to:)`, which is always
+      // called first; reaching here would mean a new case was added without
+      // routing, so fail loudly rather than silently emit nothing.
+      throw EncodingError.invalidValue(
+        self,
+        EncodingError.Context(
+          codingPath: container.codingPath,
+          debugDescription: "Unhandled FieldValue case in encodeComplex(to:)"
+        )
+      )
     }
   }
 }

--- a/Tests/MistKitTests/Models/FieldValues/FieldValueTests.swift
+++ b/Tests/MistKitTests/Models/FieldValues/FieldValueTests.swift
@@ -6,6 +6,32 @@ internal import Testing
 @Suite("Field Value")
 /// Tests for FieldValue functionality
 internal struct FieldValueTests {
+  /// Cases that survive a full JSON encode → decode round-trip unchanged.
+  ///
+  /// Exercises both encode paths in `FieldValue+Codable`: the scalar arm
+  /// (`.string`/`.int64`/`.double` via `encodeScalar`) and the complex arm
+  /// (`.list`/`.location`/`.reference`/`.asset` via `encodeComplex`). The
+  /// complex cases are exactly those `encodeScalar` returns `false` for, so
+  /// this drives the `encodeScalar` → `encodeComplex` delegation.
+  ///
+  /// The throwing `default` in `encodeComplex` is intentionally unreachable —
+  /// every `FieldValue` case is routed by one of the two arms — so it is a
+  /// defensive guard covered by switch exhaustiveness, not by a test.
+  private static let roundTripCases: [FieldValue] = [
+    .string("test"),
+    .int64(123),
+    // Fractional on purpose: a whole-valued double decodes back as `.int64`.
+    .double(3.14),
+    .list([.string("item1"), .int64(42)]),
+    .location(
+      Location(latitude: 37.7749, longitude: -122.4194, horizontalAccuracy: 10.0)
+    ),
+    .reference(Reference(recordName: "test-record")),
+    .asset(
+      Asset(fileChecksum: "abc123", size: 1_024, downloadURL: "https://example.com/file")
+    ),
+  ]
+
   /// Tests FieldValue string type creation and equality
   @Test("FieldValue string type creation and equality")
   internal func fieldValueString() {
@@ -85,12 +111,42 @@ internal struct FieldValueTests {
     #expect(value == .list(list))
   }
 
-  /// Tests FieldValue JSON encoding and decoding
-  @Test("FieldValue JSON encoding and decoding")
-  internal func fieldValueEncodable() throws {
-    let value = FieldValue.string("test")
+  /// Tests FieldValue JSON encode → decode round-trips for scalar and complex cases
+  @Test(
+    "FieldValue JSON encode/decode round-trip",
+    arguments: FieldValueTests.roundTripCases
+  )
+  internal func fieldValueRoundTrip(_ value: FieldValue) throws {
     let data = try JSONEncoder().encode(value)
     let decoded = try JSONDecoder().decode(FieldValue.self, from: data)
-    #expect(value == decoded)
+    #expect(decoded == value)
+  }
+
+  /// Tests that `.date` encodes as CloudKit milliseconds.
+  ///
+  /// `.date` does not round-trip: the decoder has no date branch on purpose
+  /// (a bare millisecond number is claimed by `.int64`/`.double` first — see
+  /// `decodeComplexTypes`), so this asserts the encoded wire value directly.
+  @Test("FieldValue date encodes as milliseconds")
+  internal func fieldValueDateEncodesMilliseconds() throws {
+    let date = Date(timeIntervalSince1970: 1_700_000_000)
+    let data = try JSONEncoder().encode(FieldValue.date(date))
+    let milliseconds = try JSONDecoder().decode(Double.self, from: data)
+    #expect(milliseconds == date.timeIntervalSince1970 * 1_000)
+  }
+
+  /// Tests that `.bytes` encodes as its raw string payload.
+  ///
+  /// `.bytes` shares the scalar arm with `.string`, so it emits the same wire
+  /// value; it decodes back as `.string` since the decoder has no bytes branch.
+  @Test("FieldValue bytes encodes as its string payload")
+  internal func fieldValueBytesEncodesAsString() throws {
+    let payload = "YWJjMTIz"
+    let bytesData = try JSONEncoder().encode(FieldValue.bytes(payload))
+    let stringData = try JSONEncoder().encode(FieldValue.string(payload))
+    #expect(bytesData == stringData)
+
+    let decoded = try JSONDecoder().decode(FieldValue.self, from: bytesData)
+    #expect(decoded == .string(payload))
   }
 }


### PR DESCRIPTION
## Re-scope note
Issue #154 cited `CustomFieldValue.swift` / `CustomFieldValuePayload.swift` — **those files no longer exist** on `v1.0.0-beta.3`. The remaining actionable hand-written `// swiftlint:disable:next cyclomatic_complexity` was in `FieldValue+Codable.swift` (`encodeValue(to:)`). The other disables live in **generated** `Operations.*.Output.swift` and are out of scope.

## What
Split `encodeValue(to:)` into a thin dispatcher + `encodeScalar`/`encodeComplex` helpers so each stays under the complexity threshold and the disable is removed. Behavior, public API, and serialization output unchanged (date→ms math preserved).

Closes #154.

## Verification
`swift build`, full `swift test` (538 pass), swiftlint `--strict` clean with the disable removed.