### PR TITLE
Skip windows-2025 Swift 6.1/6.2 in CI matrix (MSVC 14.51 STL needs Clang 20)

### DIFF
--- a/.github/workflows/MistKit.yml
+++ b/.github/workflows/MistKit.yml
@@ -139,6 +139,18 @@ jobs:
             build: 6.2-RELEASE
           - version: swift-6.3-release
             build: 6.3-RELEASE
+        exclude:
+          # windows-2025's default MSVC 14.51 STL requires Clang 20+, but Swift 6.1/6.2
+          # ship Clang 19 (STL1000 error via swift-crypto's CCryptoBoringSSL). Those run on
+          # windows-2022 (older 14.4x toolset); only Swift 6.3 (Clang 20) builds on windows-2025.
+          - runs-on: windows-2025
+            swift:
+              version: swift-6.1-release
+              build: 6.1-RELEASE
+          - runs-on: windows-2025
+            swift:
+              version: swift-6.2-release
+              build: 6.2-RELEASE
     steps:
       - uses: actions/checkout@v6
       - uses: brightdigit/swift-build@v1


### PR DESCRIPTION
## Problem

The `build-windows` job fails on **windows-2025 with Swift 6.1 and 6.2**. It's an environmental toolchain incompatibility, not a MistKit code bug:

- The `windows-2025` runner image now resolves the **newest** installed Visual Studio toolset (MSVC **14.51**, VS18) via `vswhere`. Its STL header `yvals_core.h` hard-asserts `STL1000: Unexpected compiler version, expected Clang 20 or newer`.
- Swift **6.1 and 6.2** bundle **Clang 19**, so the assert fires when swift-crypto's `CCryptoBoringSSL` includes `<memory>`. Swift **6.3** bundles Clang 20, so it passes.
- `windows-2022` defaults to an older **14.4x** toolset compatible with Clang 19, so it builds all three Swift versions fine.

In a recent run, the only red Windows jobs were `windows-2025 × 6.1-RELEASE` and `windows-2025 × 6.2-RELEASE`; everything else was green.

## Change

Add a matrix `exclude` for `windows-2025 × {6.1, 6.2}`. Resulting Windows coverage:

| Runner | Swift |
|--------|-------|
| windows-2022 | 6.1, 6.2, 6.3 |
| windows-2025 | 6.3 |

Swift 6.1/6.2 stay covered on windows-2022; Swift 6.3 still exercises the new 14.51 toolset on windows-2025. No package or shared-action changes.

## Why not pin an older toolset

Pinning windows-2025 to the VS2022/14.44 toolset would keep 6.1/6.2 coverage there, but it's a fragile env workaround (depends on the Swift/clang driver honoring an injected `INCLUDE`/`LIB` over `vswhere`'s latest, and on the older toolset staying installed). The exclude is a zero-risk config change with full passing evidence on windows-2022.

**Follow-up:** GitHub will eventually retire `windows-2022`. When that happens (or 6.1/6.2 are dropped), revisit — toolset-pinning or `-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH` becomes the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)