### PR TITLE
Fix MistDemoApp build: explicit inits for NoteEditView & RecordDetailView

### DIFF
--- a/Examples/MistDemo/Sources/MistDemoApp/Views/NoteEditView.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Views/NoteEditView.swift
@@ -147,6 +147,11 @@
       }
     }
 
+    internal init(mode: Mode, onSaved: @escaping (Note) -> Void) {
+      self.mode = mode
+      self.onSaved = onSaved
+    }
+
     private func handleFileImport(_ result: Result<[URL], any Error>) {
       switch result {
       case .success(let urls):

--- a/Examples/MistDemo/Sources/MistDemoApp/Views/RecordDetailView.swift
+++ b/Examples/MistDemo/Sources/MistDemoApp/Views/RecordDetailView.swift
@@ -146,6 +146,11 @@
       }
     }
 
+    internal init(note: Note, onChange: @escaping () -> Void) {
+      self._note = State(initialValue: note)
+      self.onChange = onChange
+    }
+
     private func delete() async {
       deleting = true
       actionError = nil


### PR DESCRIPTION
Closes #419.

## Problem

`MistDemoApp` fails to compile under Swift 6.3.2. `NoteEditView` and `RecordDetailView` each mix a **non-private stored input** with `@State private` / `@Environment private` state. Swift derives the synthesized memberwise initializer's access level from the *most restrictive* stored property, so the private state drops the init to `private`. Both views are constructed from other files (`QueryView.swift`, `RecordDetailView.swift`), producing:

```
'RecordDetailView' cannot be constructed because it has no accessible initializers
'NoteEditView' cannot be constructed because it has no accessible initializers
cannot infer contextual base in reference to member 'create' / 'edit'   # cascades
```

Pre-existing on `v1.0.0-beta.3` (and `main`); surfaced by the Swift 6.3.2 toolchain. Because `MistDemoApp` is a separate SwiftPM product from `MistDemoKit`, only a full-package `swift build` / `swift test` from `Examples/MistDemo` trips over it.

## Fix

Add an explicit `internal init` to each view exposing only the externally-set properties, mirroring the existing `CompositionDisclosure` pattern. `@State private` / `@Environment` members keep their inline defaults. `RecordDetailView` seeds its `@State note` via `State(initialValue:)`. No call sites change.

Only these two views strictly break (non-private input + private state + cross-file construction). The parameterless views (`QueryView`, `RecordsView`, etc.) construct via zero-arg `View()` and compile fine — left untouched.

## Verification

From `Examples/MistDemo`:

- `swift build --target MistDemoApp` — previously failed, now succeeds
- `swift build` (whole package) — succeeds
- `swift test` — 960 tests / 287 suites pass
- `swift-format` clean, `swiftlint` 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)