### PR TITLE
Add phone-number support to MistDemo web users/discover (#398); survey finds no protocol-extension hazard (#399)

### DIFF
--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/index.html
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/index.html
@@ -263,6 +263,9 @@
                         <textarea id="users-discover-emails" placeholder="emails, comma-separated"></textarea>
                     </div>
                     <div class="panel-row">
+                        <textarea id="users-discover-phone-numbers" placeholder="phone numbers, comma-separated"></textarea>
+                    </div>
+                    <div class="panel-row">
                         <textarea id="users-discover-record-names" placeholder="user record names, comma-separated"></textarea>
                         <button id="users-discover-btn" type="button">Discover</button>
                     </div>

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/js/users.js
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/js/users.js
@@ -1,7 +1,7 @@
 // users/caller · users/discover panel handlers. The deprecated
 // users/lookup/email and users/lookup/id primitives are not exposed —
-// users/discover is Apple's supported replacement and handles both email
-// and record-name lookups (phone-number support tracked in #398).
+// users/discover is Apple's supported replacement and handles email,
+// phone-number, and record-name lookups.
 
 const usersCallerStatus = document.getElementById('users-caller-status');
 const usersCallerRaw = document.getElementById('users-caller-raw');
@@ -24,9 +24,10 @@ document.getElementById('users-caller-btn').addEventListener('click', async () =
 
 document.getElementById('users-discover-btn').addEventListener('click', async () => {
     const emails = csv(document.getElementById('users-discover-emails').value);
+    const phoneNumbers = csv(document.getElementById('users-discover-phone-numbers').value);
     const userRecordNames = csv(document.getElementById('users-discover-record-names').value);
-    if (emails.length === 0 && userRecordNames.length === 0) {
-        setStatus(usersDiscoverStatus, 'Provide at least one email or record name.', 'error');
+    if (emails.length === 0 && phoneNumbers.length === 0 && userRecordNames.length === 0) {
+        setStatus(usersDiscoverStatus, 'Provide at least one email, phone number, or record name.', 'error');
         return;
     }
     await runPanelOperation({
@@ -35,7 +36,7 @@ document.getElementById('users-discover-btn').addEventListener('click', async ()
         label: 'Discover users',
         fn: async () => {
             if (currentMode === 'mistkit') {
-                return await postJSON('/api/users/discover', { emails, userRecordNames });
+                return await postJSON('/api/users/discover', { emails, phoneNumbers, userRecordNames });
             }
             // CloudKit JS exposes per-item primitives — loop and aggregate
             // to match the REST endpoint's batch shape.
@@ -46,6 +47,14 @@ document.getElementById('users-discover-btn').addEventListener('click', async ()
                     results.push({ email, identity });
                 } catch (error) {
                     results.push({ email, error: error.message });
+                }
+            }
+            for (const phoneNumber of phoneNumbers) {
+                try {
+                    const identity = await ckJsContainer().discoverUserIdentityWithPhoneNumber(phoneNumber);
+                    results.push({ phoneNumber, identity });
+                } catch (error) {
+                    results.push({ phoneNumber, error: error.message });
                 }
             }
             for (const recordName of userRecordNames) {

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/CloudKitService+WebBackend+Users.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/CloudKitService+WebBackend+Users.swift
@@ -41,10 +41,12 @@ extension CloudKitService {
 
   internal func webDiscoverUsers(
     emails: [String],
+    phoneNumbers: [String],
     userRecordNames: [String]
   ) async throws -> [UserIdentity] {
     let lookupInfos =
       emails.map { UserIdentityLookupInfo(emailAddress: $0) }
+      + phoneNumbers.map { UserIdentityLookupInfo(phoneNumber: $0) }
       + userRecordNames.map { UserIdentityLookupInfo(userRecordName: $0) }
     return try await discoverUserIdentities(lookupInfos: lookupInfos)
   }

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebBackend.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebBackend.swift
@@ -103,6 +103,7 @@ internal protocol WebBackend: Sendable {
 
   func webDiscoverUsers(
     emails: [String],
+    phoneNumbers: [String],
     userRecordNames: [String]
   ) async throws -> [UserIdentity]
 

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebRequests+Users.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebRequests+Users.swift
@@ -33,22 +33,28 @@ internal import Foundation
 // wrapper (`discoverUserIdentities`) operates on the public database with
 // web-auth credentials regardless of the request's selected database.
 extension WebRequests {
-  /// `POST /api/users/discover` — discover user identities by email address
-  /// and/or user record name. Either list may be omitted; an absent key
-  /// decodes to an empty array.
+  /// `POST /api/users/discover` — discover user identities by email address,
+  /// phone number, and/or user record name. Any list may be omitted; an
+  /// absent key decodes to an empty array.
   internal struct DiscoverUsers: Decodable {
     private enum CodingKeys: String, CodingKey {
       case emails
+      case phoneNumbers
       case userRecordNames
     }
 
     internal let emails: [String]
+    internal let phoneNumbers: [String]
     internal let userRecordNames: [String]
 
     internal init(from decoder: any Decoder) throws {
       let container = try decoder.container(keyedBy: CodingKeys.self)
       self.emails =
         try container.decodeIfPresent([String].self, forKey: .emails) ?? []
+      self.phoneNumbers =
+        try container.decodeIfPresent(
+          [String].self, forKey: .phoneNumbers
+        ) ?? []
       self.userRecordNames =
         try container.decodeIfPresent(
           [String].self, forKey: .userRecordNames

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer+Users.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer+Users.swift
@@ -37,7 +37,8 @@
     /// operate on the public database with web-auth credentials, so neither
     /// carries a `database` selector. The deprecated `lookup/email` and
     /// `lookup/id` primitives are intentionally not exposed — `discover` is
-    /// Apple's supported replacement and handles email + record-name lookups.
+    /// Apple's supported replacement and handles email, phone-number, and
+    /// record-name lookups.
     internal func addUsersEndpoints(
       api: RouterGroup<BasicRequestContext>
     ) {
@@ -66,7 +67,7 @@
     }
 
     /// `POST /api/users/discover` — discover user identities by email
-    /// address and/or user record name.
+    /// address, phone number, and/or user record name.
     private func addUsersDiscoverEndpoint(
       api: RouterGroup<BasicRequestContext>
     ) {
@@ -83,6 +84,7 @@
           let backend = try backendFactory.make(token)
           let users = try await backend.webDiscoverUsers(
             emails: body.emails,
+            phoneNumbers: body.phoneNumbers,
             userRecordNames: body.userRecordNames
           )
           return try WebJSON.encoder().encode(

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend+Calls.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend+Calls.swift
@@ -107,6 +107,7 @@
     /// Captured arguments from the most recent `webDiscoverUsers` call.
     internal struct DiscoverUsersCall: Sendable {
       internal let emails: [String]
+      internal let phoneNumbers: [String]
       internal let userRecordNames: [String]
     }
 

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend+UserOperations.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend+UserOperations.swift
@@ -46,16 +46,23 @@
 
     internal func webDiscoverUsers(
       emails: [String],
+      phoneNumbers: [String],
       userRecordNames: [String]
     ) async throws -> [UserIdentity] {
       lastDiscoverUsers = DiscoverUsersCall(
         emails: emails,
+        phoneNumbers: phoneNumbers,
         userRecordNames: userRecordNames
       )
       try consumePendingError()
       return emails.map { email in
         UserIdentity(lookupInfo: UserIdentityLookupInfo(emailAddress: email))
       }
+        + phoneNumbers.map { phoneNumber in
+          UserIdentity(
+            lookupInfo: UserIdentityLookupInfo(phoneNumber: phoneNumber)
+          )
+        }
         + userRecordNames.map { name in
           UserIdentity(userRecordName: .recordName(name))
         }

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+Users.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+Users.swift
@@ -91,13 +91,17 @@
     }
 
     @Test(
-      "POST /api/users/discover forwards emails and record names to the backend"
+      """
+      POST /api/users/discover forwards emails, phone numbers, \
+      and record names to the backend
+      """
     )
     internal func usersDiscoverForwards() async throws {
       let fixture = Self.makeFixture(authenticated: true)
       let app = Application(router: try fixture.server.makeRouter())
       let jsonBody = """
         {"emails":["a@example.com","b@example.com"],\
+        "phoneNumbers":["+15555550123"],\
         "userRecordNames":["_user-1"]}
         """
 
@@ -113,12 +117,13 @@
             UsersPayload.self,
             from: Data(response.body.readableBytesView)
           )
-          #expect(payload.users.count == 3)
+          #expect(payload.users.count == 4)
         }
       }
 
       let captured = await fixture.backend.lastDiscoverUsers
       #expect(captured?.emails == ["a@example.com", "b@example.com"])
+      #expect(captured?.phoneNumbers == ["+15555550123"])
       #expect(captured?.userRecordNames == ["_user-1"])
     }
 


### PR DESCRIPTION
Two issues were assigned to this branch. **#398 is implemented; #399 required no code change** — the survey it asked for found no instances of the pattern. Details below.

---

## #398 — MistDemo web: phone-number support for `/users/discover`

`POST /api/users/discover` already forwarded emails and user record names; the underlying `discoverUserIdentities(lookupInfos:)` also accepts phone numbers via `UserIdentityLookupInfo(phoneNumber:)`, but the web demo didn't expose them. Implemented exactly the spec in the issue.

**No `Sources/MistKit/` change was needed** — `UserIdentityLookupInfo` already has a `phoneNumber` property and a `phoneNumber:` initializer parameter. The whole change is confined to `Examples/MistDemo`.

| Layer | File | Change |
|---|---|---|
| Request DTO | `Server/WebRequests+Users.swift` | `DiscoverUsers` gains `phoneNumbers: [String]` + `.phoneNumbers` coding key, decoded with `decodeIfPresent(...) ?? []` mirroring `emails`/`userRecordNames` |
| Backend protocol | `Server/WebBackend.swift` | `webDiscoverUsers` gains a `phoneNumbers:` parameter |
| Conformance | `Server/CloudKitService+WebBackend+Users.swift` | Appends `phoneNumbers.map { UserIdentityLookupInfo(phoneNumber: $0) }` to the combined lookup-info array |
| Route | `Server/WebServer+Users.swift` | Forwards `body.phoneNumbers`; doc comments updated |
| Frontend markup | `Resources/index.html` | New `users-discover-phone-numbers` textarea in the Discover section |
| Frontend logic | `Resources/js/users.js` | Reads the new input, includes `phoneNumbers` in the POST body, validates "at least one email, phone number, or record name", and loops `discoverUserIdentityWithPhoneNumber` in the CloudKit JS parity path |
| Test mock | `Tests/.../MockBackend+Calls.swift`, `MockBackend+UserOperations.swift` | `DiscoverUsersCall` captures `phoneNumbers`; the mock returns a `UserIdentity` per phone number |
| Test | `Tests/.../WebServerTests+Users.swift` | `usersDiscoverForwards` posts a phone number, asserts 4 identities returned and `captured?.phoneNumbers == ["+15555550123"]` |

The stale `(phone-number support tracked in #398)` comment in `users.js` is removed.

Closes #398

---

## #399 — "Fix Over Extension Use With Protocol Extension Implementation Pattern"

The issue body and comments are **empty** — only a title. I interpreted it as the classic anti-pattern: a protocol requirement implemented in a *protocol extension* rather than on the conforming type, which is statically dispatched and can silently shadow a conformer's implementation.

I surveyed every `protocol` declaration in `Sources/MistKit/` (excluding generated `Sources/MistKitOpenAPI/`), enumerated their declared requirements, and cross-referenced every `extension <Protocol>` in the module.

### Survey results

| Protocol | Extension member | Location | Declared requirement? | Verdict |
|---|---|---|---|---|
| `RecordManaging` | `queryAllRecords(recordType:)` | `RecordManagement/RecordManaging.swift:75` | **Yes** (declared L64) | Safe — witness-table dispatch |
| `Authenticator` | `defaultStorageIdentifier` | `Authentication/Authenticator.swift:96` | **Yes** (declared L59) | Safe — witness-table dispatch |
| `RecordManaging` | `sync<T>`, `list<T>`, `query<T>(_:where:)` | `RecordManaging+Generic.swift:53,85,122` | No | Legitimate convenience |
| `RecordManaging where Self: CloudKitRecordCollection` | `syncAllRecords`, `listAllRecords`, `deleteAllRecords` | `RecordManaging+RecordCollection.swift:62,94,141` | No | Legitimate constrained convenience |
| `OperationInputPath` | `init(containerIdentifier:environment:database:)` | `OpenAPI/OperationInputPath.swift:52` | No — distinct signature from the L46 requirement | Textbook-correct |
| `ContainerOperationInputPath` | `init(containerIdentifier:environment:)` | `OpenAPI/ContainerOperationInputPath.swift:49` | No | Textbook-correct |
| `RecordTypeIterating` | — | — | — | **No extension at all**; sole conformer `RecordTypeSet` implements `forEach` directly |
| `CloudKitRecord`, `CloudKitRecordCollection`, `OperationFailureTarget`, `CloudKitErrorConvertible`, `CloudKitResponseType`, `TokenStorage`, `TokenManager` | — | — | — | No protocol extensions at all |

### Finding: nothing to fix

**The hazard does not occur anywhere in `Sources/MistKit/`.** Every extension-provided member is either (a) a *declared* protocol requirement — so it dispatches through the witness table and a conformer's implementation correctly wins even through an existential, which is the supported "requirement + default implementation" pattern rather than the shadowing bug; or (b) a member with a genuinely different signature than anything the protocol declares, which can never shadow a requirement.

The shadowing bug needs an extension member that is **not** declared as a requirement but matches a conformer's method. No instance of that shape exists in the module.

Two adjacent observations were noted but **deliberately not acted on**, since both would be breaking public-API changes rather than clear fixes: `RecordManaging.queryAllRecords`'s default is a *semantic* trap (delegates to the deprecated single-page query) already mitigated by an `@available(*, deprecated)` annotation, and `Authenticator.defaultStorageIdentifier`'s default is effectively dead code since all three concrete authenticators override it. Neither is the bug the title describes.

Per the "report the evidence rather than manufacture a refactor" guidance, **no code was changed for #399** and this PR does **not** carry `Closes #399`. The full survey is posted as a comment on the issue: https://github.com/brightdigit/MistKit/issues/399#issuecomment-5359979653 — recommend closing it as "no instances found", or re-scoping with a concrete example.

Note: the `CloudKitService+*` extension file split was explicitly *not* treated as in scope — CLAUDE.md documents it as an intentional organizational pattern, and splitting a concrete type's methods across extension files is not a dispatch concern.

---

## Verification

All commands run locally on this branch.

| Check | Command | Result |
|---|---|---|
| Root build | `swift build` | Pass — Build complete (23.5s) |
| Root tests | `swift test` | Pass — **550 tests in 173 suites** |
| MistDemo build | `cd Examples/MistDemo && swift build` | Pass — Build complete (85.7s), includes the `MistDemoApp` SwiftUI target |
| MistDemo tests | `cd Examples/MistDemo && swift test` | Pass — **968 tests in 289 suites**, 1 pre-existing known issue |
| Targeted test | `swift test --filter usersDiscoverForwards` | Pass — verified the updated assertions actually execute |
| Format | `mise exec -- swift-format -i -r Sources/ Tests/ Examples/MistDemo/…` | Clean — no reformatting produced |
| Lint pipeline | `./Scripts/lint.sh` | Pass — SwiftLint **0 violations in 390 files**, header check clean, periphery: no unused code |
| MistDemo lint | `cd Examples/MistDemo && mise exec -- swiftlint` | 5 warnings, **all pre-existing** in files untouched by this PR (`LookupConfig.swift`, `ChangesRequestOptionsPhase.swift`, `LookupAllRecordsCommand.swift`, `DiscoverAllUserIdentitiesCommand.swift`); none in any modified file |

Conventions honored: explicit access modifiers on every import (no new imports were added), explicit ACLs, swiftlint `type_contents_order`, no hand-edits to `Sources/MistKitOpenAPI/`. No subrepo Example (BushelCloud, CelestraCloud) was touched — MistDemo is not a subrepo, so these changes belong on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
