### PR TITLE
Add confirmed zone metadata (syncToken, atomic) to zone schemas

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -12,6 +12,7 @@ Project-scoped agent memory for MistKit. This directory **replaces** any native 
 ## Index
 
 - [CloudKit archived endpoints not in local docs](reference_cloudkit_archived_endpoints.md) — Verify CloudKit endpoints (e.g. assets/rereference) against Apple's archived reference, not just .claude/docs/webservices.md
+- [CloudKit Zone Dictionary has exactly 3 keys](reference_cloudkit_zone_dictionary.md) — zoneID/syncToken/atomic only; isEager, modify-request `atomic`, and zone create options do NOT exist
 - [wasm CI failure signatures](reference_wasm_ci_signatures.md) — Two distinct wasm failures: silent exit-1 (OOM on big test target) vs curl exit-7 (SDK download flake, just re-run)
 - [Swift Testing availability guard](feedback_swift_testing_availability.md) — Never annotate @Suite types with @available; use guard #available inside @Test functions instead
 - [GitHub Action pinning preference](feedback_action_pinning.md) — Use @v<major> for brightdigit-owned actions; pin third-party actions explicitly

--- a/.claude/memory/reference_cloudkit_zone_dictionary.md
+++ b/.claude/memory/reference_cloudkit_zone_dictionary.md
@@ -1,0 +1,32 @@
+---
+name: reference_cloudkit_zone_dictionary
+description: "CloudKit's Zone Dictionary has exactly three keys (zoneID, syncToken, atomic) — isEager and zone create options do not exist"
+metadata:
+  node_type: memory
+  type: reference
+---
+
+Verified against Apple's archived CloudKit Web Services Reference during issue #386 / PR #427.
+
+**Zone Dictionary documents exactly three keys** ([Types.html](https://developer.apple.com/library/archive/documentation/DataManagement/Conceptual/CloudKitWebServicesReference/Types.html)):
+
+| Key | Apple's wording |
+|-----|-----------------|
+| `zoneID` | "The dictionary that identifies a record zone in the database" |
+| `syncToken` | "The current point in the zone's change history." |
+| `atomic` | "A Boolean value indicating whether this zone supports atomic operations." |
+
+All four zone endpoints (`zones/list`, `zones/lookup`, `zones/modify`, `zones/changes`) route their **success** payload through this dictionary, and their **failure** payload through the "Zone Fetch Error Dictionary" (`zoneID`, `reason`, `serverErrorCode`, `retryAfter`, `redirectURL`).
+
+**Things that do NOT exist — do not add them speculatively:**
+
+- **`isEager`** — appears in no primary Apple source, nor in `.claude/docs/webservices.md` or `.claude/docs/cloudkitjs.md`. It was proposed in issue #386 but is unsourced.
+- **`atomic` on the `zones/modify` request** — the request body is `operations` only. `records/modify` *does* document `atomic`; the asymmetry is deliberate.
+- **Zone create options on `ZoneOperation`** — the operation's `zone` is documented as having "a single `zoneID` key".
+
+**Open discrepancies (unresolved, see issue #386 comment):**
+
+- `zones/changes` documents its token key as **`metaSyncToken`** in both request and response; MistKit sends/reads `syncToken`. Apple's page contradicts itself (the `moreComing` description refers back to "the included `syncToken` key"), so this needs a live-response check before changing.
+- `zones/changes` is documented as **deprecated** in favor of `changes/database`.
+
+Note `ZoneID`'s owner key: Apple documents `ownerRecordName`, while MistKit's `ZoneID` domain type calls it `ownerName` and the wire schema uses `ownerName`. Related: [[reference_cloudkit_archived_endpoints]].

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,9 +232,25 @@ In MistDemo, integration runs targeting these endpoints use `PhaseContext.userCo
 - `QueryResult` — `records: [RecordInfo]`, `continuationMarker: String?`
 - `RecordChangesResult` — `records: [RecordInfo]`, `syncToken: String?`, `moreComing: Bool`
 - `ZoneChangesResult` — `zones: [ZoneInfo]`, `syncToken: String?`, `moreComing: Bool`
+- `ZoneInfo` — `zoneName: String`, `ownerRecordName: String?`, `capabilities: [String]`, `syncToken: String?`, `atomic: Bool?`
 - `UserIdentity` — `userRecordName: String?`, `nameComponents: NameComponents?`, `lookupInfo: UserIdentityLookupInfo?`
 - `UserIdentityLookupInfo` — `emailAddress: String?`, `phoneNumber: String?`, `userRecordName: String?`
 - `NameComponents` — full personal name parts (givenName, familyName, nickname, etc.)
+
+**Zone metadata (issue #386):** all four zone responses (`zones/list`, `zones/lookup`,
+`zones/modify`, `zones/changes`) share one `Zone` schema in `openapi.yaml` carrying the
+three keys Apple's archived ["Zone Dictionary"](https://developer.apple.com/library/archive/documentation/DataManagement/Conceptual/CloudKitWebServicesReference/Types.html)
+documents: `zoneID`, `syncToken`, and `atomic`. These surface on `ZoneInfo` as
+`syncToken`/`atomic`, both optional — `atomic` is **not** defaulted to `false`, so an
+absent key stays distinguishable from an explicit `false`. Note the zone-level
+`syncToken` is distinct from the response-level `syncToken` on `ZoneChangesResult`.
+
+`isEager` is **deliberately not modeled**: it appears in no primary Apple source
+(neither the archived Web Services reference nor `.claude/docs/cloudkitjs.md`).
+Likewise `zones/modify` takes **no** `atomic` request flag and `ZoneOperation` has
+**no** create options — Apple documents the request body as `operations` only, and each
+operation's `zone` as having "a single `zoneID` key". Do not add these speculatively;
+confirm against a live response first.
 
 **Protocols:**
 - `RecordTypeIterating` (`Sources/MistKit/RecordManagement/RecordTypeIterating.swift`) — `forEach(_ action:)` to iterate over CloudKit record types; used by `fetchAllRecordChanges`

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/CreateZoneCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/CreateZoneCommand.swift
@@ -97,6 +97,12 @@ public struct CreateZoneCommand: MistDemoCommand, OutputFormatting {
     if !zone.capabilities.isEmpty {
       print("     Capabilities: \(zone.capabilities.joined(separator: ", "))")
     }
+    if let syncToken = zone.syncToken {
+      print("     Sync Token: \(syncToken)")
+    }
+    if let atomic = zone.atomic {
+      print("     Atomic: \(atomic)")
+    }
 
     print("\n" + String(repeating: "=", count: 60))
     print("✅ Zone creation completed!")

--- a/Examples/MistDemo/Sources/MistDemoKit/Commands/LookupZonesCommand.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Commands/LookupZonesCommand.swift
@@ -94,6 +94,12 @@ public struct LookupZonesCommand: MistDemoCommand, OutputFormatting {
       if !zone.capabilities.isEmpty {
         print("     Capabilities: \(zone.capabilities.joined(separator: ", "))")
       }
+      if let syncToken = zone.syncToken {
+        print("     Sync Token: \(syncToken)")
+      }
+      if let atomic = zone.atomic {
+        print("     Atomic: \(atomic)")
+      }
     }
 
     print("\n" + String(repeating: "=", count: 60))

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/ListZonesPhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/ListZonesPhase.swift
@@ -52,6 +52,12 @@ internal struct ListZonesPhase: IntegrationPhase {
     if context.verbose {
       for zone in zones {
         print("   - \(zone.zoneName)")
+        if let syncToken = zone.syncToken {
+          print("     Sync Token: \(syncToken)")
+        }
+        if let atomic = zone.atomic {
+          print("     Atomic: \(atomic)")
+        }
       }
     }
 

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/LookupZonePhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/LookupZonePhase.swift
@@ -62,6 +62,12 @@ internal struct LookupZonePhase: IntegrationPhase {
       if !zone.capabilities.isEmpty {
         print("   Capabilities: \(zone.capabilities.joined(separator: ", "))")
       }
+      if let syncToken = zone.syncToken {
+        print("   Sync Token: \(syncToken)")
+      }
+      if let atomic = zone.atomic {
+        print("   Atomic: \(atomic)")
+      }
     }
 
     return NoState()

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/ModifyZonesPhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/ModifyZonesPhase.swift
@@ -64,7 +64,7 @@ internal struct ModifyZonesPhase: IntegrationPhase {
         zoneIDs: [zoneID],
         database: context.database
       )
-      guard lookedUp.contains(where: { $0.zoneName == zoneName }) else {
+      guard let verifiedZone = lookedUp.first(where: { $0.zoneName == zoneName }) else {
         try await cleanup(zoneID: zoneID, context: context)
         throw IntegrationTestError.verificationFailed(
           "created zone '\(zoneName)' not returned by lookupZones"
@@ -72,6 +72,12 @@ internal struct ModifyZonesPhase: IntegrationPhase {
       }
       if context.verbose {
         print("   ✅ Verified zone via lookupZones")
+        if let syncToken = verifiedZone.syncToken {
+          print("     Sync Token: \(syncToken)")
+        }
+        if let atomic = verifiedZone.atomic {
+          print("     Atomic: \(atomic)")
+        }
       }
 
       try await cleanup(zoneID: zoneID, context: context)

--- a/Sources/MistKit/CloudKitService/CloudKitService+ModifyZones.swift
+++ b/Sources/MistKit/CloudKitService/CloudKitService+ModifyZones.swift
@@ -87,7 +87,7 @@ extension CloudKitService {
       let zonesData: Components.Schemas.ZonesModifyResponse =
         try await responseProcessor.processModifyZonesResponse(response)
 
-      return try (zonesData.zones ?? []).map { try ZoneInfo(fromZoneID: $0.zoneID) }
+      return try (zonesData.zones ?? []).map { try ZoneInfo(from: $0) }
     } catch {
       throw mapToCloudKitError(error, context: "modifyZones")
     }

--- a/Sources/MistKit/CloudKitService/CloudKitService+ZoneOperations.swift
+++ b/Sources/MistKit/CloudKitService/CloudKitService+ZoneOperations.swift
@@ -62,7 +62,7 @@ extension CloudKitService {
 
       let zonesData: Components.Schemas.ZonesListResponse =
         try await responseProcessor.processListZonesResponse(response)
-      return try (zonesData.zones ?? []).map { try ZoneInfo(fromZoneID: $0.zoneID) }
+      return try (zonesData.zones ?? []).map { try ZoneInfo(from: $0) }
     } catch {
       throw mapToCloudKitError(error, context: "listZones")
     }
@@ -113,7 +113,7 @@ extension CloudKitService {
       let zonesData: Components.Schemas.ZonesLookupResponse =
         try await responseProcessor.processLookupZonesResponse(response)
 
-      return try (zonesData.zones ?? []).map { try ZoneInfo(fromZoneID: $0.zoneID) }
+      return try (zonesData.zones ?? []).map { try ZoneInfo(from: $0) }
     } catch {
       throw mapToCloudKitError(error, context: "lookupZones")
     }

--- a/Sources/MistKit/Models/Zones/ZoneInfo.swift
+++ b/Sources/MistKit/Models/Zones/ZoneInfo.swift
@@ -39,12 +39,30 @@ public struct ZoneInfo: Codable, Sendable {
   /// Note: always empty — CloudKit Web Services zone responses do not include
   /// capabilities in the current OpenAPI schema.
   public let capabilities: [String]
+  /// The current point in the zone's change history.
+  ///
+  /// Present on zone responses that carry Apple's "Zone Dictionary" payload;
+  /// `nil` when the server omits it.
+  public let syncToken: String?
+  /// Whether this zone supports atomic operations.
+  ///
+  /// `nil` when the server omits the key — deliberately *not* defaulted to
+  /// `false`, so "absent" stays distinguishable from "explicitly not atomic".
+  public let atomic: Bool?
 
   /// Initialize zone information
-  public init(zoneName: String, ownerRecordName: String?, capabilities: [String]) {
+  public init(
+    zoneName: String,
+    ownerRecordName: String?,
+    capabilities: [String],
+    syncToken: String? = nil,
+    atomic: Bool? = nil
+  ) {
     self.zoneName = zoneName
     self.ownerRecordName = ownerRecordName
     self.capabilities = capabilities
+    self.syncToken = syncToken
+    self.atomic = atomic
   }
 
   /// Convert a CloudKit zone payload's `zoneID` into a `ZoneInfo`.
@@ -60,7 +78,11 @@ public struct ZoneInfo: Codable, Sendable {
   /// and make the generated decoder reject otherwise-valid payloads, so the
   /// response-side "must be present" rule is enforced here at the domain
   /// boundary instead.
-  internal init(fromZoneID zoneID: Components.Schemas.ZoneID?) throws(ConversionError) {
+  internal init(
+    fromZoneID zoneID: Components.Schemas.ZoneID?,
+    syncToken: String? = nil,
+    atomic: Bool? = nil
+  ) throws(ConversionError) {
     guard let zoneID else {
       try ConversionError.zoneMissingID.reportAndThrow()
     }
@@ -70,7 +92,19 @@ public struct ZoneInfo: Codable, Sendable {
     self.init(
       zoneName: zoneName,
       ownerRecordName: zoneID.ownerName,
-      capabilities: []
+      capabilities: [],
+      syncToken: syncToken,
+      atomic: atomic
+    )
+  }
+
+  /// Convert a CloudKit `Zone` payload into a `ZoneInfo`, carrying the
+  /// zone-level metadata (`syncToken`, `atomic`) alongside the identity.
+  internal init(from zone: Components.Schemas.Zone) throws(ConversionError) {
+    try self.init(
+      fromZoneID: zone.zoneID,
+      syncToken: zone.syncToken,
+      atomic: zone.atomic
     )
   }
 }

--- a/Sources/MistKitOpenAPI/Types.swift
+++ b/Sources/MistKitOpenAPI/Types.swift
@@ -1959,32 +1959,52 @@ public enum Components {
                 case moreComing
             }
         }
+        /// A record zone as returned by the zone endpoints (`zones/list`, `zones/lookup`, `zones/modify`, `zones/changes`). Matches the "Zone Dictionary" in Apple's archived CloudKit Web Services Reference, which documents exactly three keys: `zoneID`, `syncToken`, and `atomic`. `isEager` is deliberately absent — it appears in no primary Apple source (see issue #386).
+        ///
+        ///
+        /// - Remark: Generated from `#/components/schemas/Zone`.
+        public struct Zone: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/Zone/zoneID`.
+            public var zoneID: Components.Schemas.ZoneID?
+            /// The current point in the zone's change history.
+            ///
+            /// - Remark: Generated from `#/components/schemas/Zone/syncToken`.
+            public var syncToken: Swift.String?
+            /// A Boolean value indicating whether this zone supports atomic operations.
+            ///
+            ///
+            /// - Remark: Generated from `#/components/schemas/Zone/atomic`.
+            public var atomic: Swift.Bool?
+            /// Creates a new `Zone`.
+            ///
+            /// - Parameters:
+            ///   - zoneID:
+            ///   - syncToken: The current point in the zone's change history.
+            ///   - atomic: A Boolean value indicating whether this zone supports atomic operations.
+            public init(
+                zoneID: Components.Schemas.ZoneID? = nil,
+                syncToken: Swift.String? = nil,
+                atomic: Swift.Bool? = nil
+            ) {
+                self.zoneID = zoneID
+                self.syncToken = syncToken
+                self.atomic = atomic
+            }
+            public enum CodingKeys: String, CodingKey {
+                case zoneID
+                case syncToken
+                case atomic
+            }
+        }
         /// - Remark: Generated from `#/components/schemas/ZonesListResponse`.
         public struct ZonesListResponse: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/ZonesListResponse/zonesPayload`.
-            public struct zonesPayloadPayload: Codable, Hashable, Sendable {
-                /// - Remark: Generated from `#/components/schemas/ZonesListResponse/zonesPayload/zoneID`.
-                public var zoneID: Components.Schemas.ZoneID?
-                /// Creates a new `zonesPayloadPayload`.
-                ///
-                /// - Parameters:
-                ///   - zoneID:
-                public init(zoneID: Components.Schemas.ZoneID? = nil) {
-                    self.zoneID = zoneID
-                }
-                public enum CodingKeys: String, CodingKey {
-                    case zoneID
-                }
-            }
             /// - Remark: Generated from `#/components/schemas/ZonesListResponse/zones`.
-            public typealias zonesPayload = [Components.Schemas.ZonesListResponse.zonesPayloadPayload]
-            /// - Remark: Generated from `#/components/schemas/ZonesListResponse/zones`.
-            public var zones: Components.Schemas.ZonesListResponse.zonesPayload?
+            public var zones: [Components.Schemas.Zone]?
             /// Creates a new `ZonesListResponse`.
             ///
             /// - Parameters:
             ///   - zones:
-            public init(zones: Components.Schemas.ZonesListResponse.zonesPayload? = nil) {
+            public init(zones: [Components.Schemas.Zone]? = nil) {
                 self.zones = zones
             }
             public enum CodingKeys: String, CodingKey {
@@ -1993,30 +2013,13 @@ public enum Components {
         }
         /// - Remark: Generated from `#/components/schemas/ZonesLookupResponse`.
         public struct ZonesLookupResponse: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/ZonesLookupResponse/zonesPayload`.
-            public struct zonesPayloadPayload: Codable, Hashable, Sendable {
-                /// - Remark: Generated from `#/components/schemas/ZonesLookupResponse/zonesPayload/zoneID`.
-                public var zoneID: Components.Schemas.ZoneID?
-                /// Creates a new `zonesPayloadPayload`.
-                ///
-                /// - Parameters:
-                ///   - zoneID:
-                public init(zoneID: Components.Schemas.ZoneID? = nil) {
-                    self.zoneID = zoneID
-                }
-                public enum CodingKeys: String, CodingKey {
-                    case zoneID
-                }
-            }
             /// - Remark: Generated from `#/components/schemas/ZonesLookupResponse/zones`.
-            public typealias zonesPayload = [Components.Schemas.ZonesLookupResponse.zonesPayloadPayload]
-            /// - Remark: Generated from `#/components/schemas/ZonesLookupResponse/zones`.
-            public var zones: Components.Schemas.ZonesLookupResponse.zonesPayload?
+            public var zones: [Components.Schemas.Zone]?
             /// Creates a new `ZonesLookupResponse`.
             ///
             /// - Parameters:
             ///   - zones:
-            public init(zones: Components.Schemas.ZonesLookupResponse.zonesPayload? = nil) {
+            public init(zones: [Components.Schemas.Zone]? = nil) {
                 self.zones = zones
             }
             public enum CodingKeys: String, CodingKey {
@@ -2025,30 +2028,13 @@ public enum Components {
         }
         /// - Remark: Generated from `#/components/schemas/ZonesModifyResponse`.
         public struct ZonesModifyResponse: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/ZonesModifyResponse/zonesPayload`.
-            public struct zonesPayloadPayload: Codable, Hashable, Sendable {
-                /// - Remark: Generated from `#/components/schemas/ZonesModifyResponse/zonesPayload/zoneID`.
-                public var zoneID: Components.Schemas.ZoneID?
-                /// Creates a new `zonesPayloadPayload`.
-                ///
-                /// - Parameters:
-                ///   - zoneID:
-                public init(zoneID: Components.Schemas.ZoneID? = nil) {
-                    self.zoneID = zoneID
-                }
-                public enum CodingKeys: String, CodingKey {
-                    case zoneID
-                }
-            }
             /// - Remark: Generated from `#/components/schemas/ZonesModifyResponse/zones`.
-            public typealias zonesPayload = [Components.Schemas.ZonesModifyResponse.zonesPayloadPayload]
-            /// - Remark: Generated from `#/components/schemas/ZonesModifyResponse/zones`.
-            public var zones: Components.Schemas.ZonesModifyResponse.zonesPayload?
+            public var zones: [Components.Schemas.Zone]?
             /// Creates a new `ZonesModifyResponse`.
             ///
             /// - Parameters:
             ///   - zones:
-            public init(zones: Components.Schemas.ZonesModifyResponse.zonesPayload? = nil) {
+            public init(zones: [Components.Schemas.Zone]? = nil) {
                 self.zones = zones
             }
             public enum CodingKeys: String, CodingKey {
@@ -2057,25 +2043,8 @@ public enum Components {
         }
         /// - Remark: Generated from `#/components/schemas/ZoneChangesResponse`.
         public struct ZoneChangesResponse: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/ZoneChangesResponse/zonesPayload`.
-            public struct zonesPayloadPayload: Codable, Hashable, Sendable {
-                /// - Remark: Generated from `#/components/schemas/ZoneChangesResponse/zonesPayload/zoneID`.
-                public var zoneID: Components.Schemas.ZoneID?
-                /// Creates a new `zonesPayloadPayload`.
-                ///
-                /// - Parameters:
-                ///   - zoneID:
-                public init(zoneID: Components.Schemas.ZoneID? = nil) {
-                    self.zoneID = zoneID
-                }
-                public enum CodingKeys: String, CodingKey {
-                    case zoneID
-                }
-            }
             /// - Remark: Generated from `#/components/schemas/ZoneChangesResponse/zones`.
-            public typealias zonesPayload = [Components.Schemas.ZoneChangesResponse.zonesPayloadPayload]
-            /// - Remark: Generated from `#/components/schemas/ZoneChangesResponse/zones`.
-            public var zones: Components.Schemas.ZoneChangesResponse.zonesPayload?
+            public var zones: [Components.Schemas.Zone]?
             /// - Remark: Generated from `#/components/schemas/ZoneChangesResponse/syncToken`.
             public var syncToken: Swift.String?
             /// - Remark: Generated from `#/components/schemas/ZoneChangesResponse/moreComing`.
@@ -2087,7 +2056,7 @@ public enum Components {
             ///   - syncToken:
             ///   - moreComing:
             public init(
-                zones: Components.Schemas.ZoneChangesResponse.zonesPayload? = nil,
+                zones: [Components.Schemas.Zone]? = nil,
                 syncToken: Swift.String? = nil,
                 moreComing: Swift.Bool? = nil
             ) {

--- a/Tests/MistKitTests/Models/Zones/ZoneMetadataTests+Responses.swift
+++ b/Tests/MistKitTests/Models/Zones/ZoneMetadataTests+Responses.swift
@@ -1,0 +1,164 @@
+//
+//  ZoneMetadataTests.swift
+//  MistKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+internal import Foundation
+internal import Testing
+
+@testable import MistKit
+@testable import MistKitOpenAPI
+
+extension ZoneMetadataTests {
+  /// Decoding of the new zone metadata across every zone response shape.
+  @Suite("Responses")
+  internal struct Responses {
+    @Test("ZonesListResponse decodes zone metadata")
+    internal func listResponseDecodesMetadata() throws {
+      let response = try JSONDecoder().decode(
+        Components.Schemas.ZonesListResponse.self,
+        from: Data(
+          """
+          {
+            "zones": [
+              {
+                "zoneID": { "zoneName": "Articles" },
+                "syncToken": "list-token",
+                "atomic": true
+              }
+            ]
+          }
+          """.utf8
+        )
+      )
+
+      let zone = try #require(response.zones?.first)
+      #expect(zone.syncToken == "list-token")
+      #expect(zone.atomic == true)
+    }
+
+    @Test("ZonesModifyResponse decodes zone metadata")
+    internal func modifyResponseDecodesMetadata() throws {
+      let response = try JSONDecoder().decode(
+        Components.Schemas.ZonesModifyResponse.self,
+        from: Data(
+          """
+          {
+            "zones": [
+              {
+                "zoneID": { "zoneName": "Articles" },
+                "syncToken": "modify-token",
+                "atomic": false
+              }
+            ]
+          }
+          """.utf8
+        )
+      )
+
+      let zone = try #require(response.zones?.first)
+      #expect(zone.syncToken == "modify-token")
+      #expect(zone.atomic == false)
+    }
+
+    @Test("ZoneChangesResponse decodes per-zone metadata alongside the top-level token")
+    internal func changesResponseDecodesMetadata() throws {
+      let response = try JSONDecoder().decode(
+        Components.Schemas.ZoneChangesResponse.self,
+        from: Data(
+          """
+          {
+            "zones": [
+              {
+                "zoneID": { "zoneName": "Articles" },
+                "syncToken": "zone-level-token",
+                "atomic": true
+              }
+            ],
+            "syncToken": "top-level-token",
+            "moreComing": true
+          }
+          """.utf8
+        )
+      )
+
+      let result = try ZoneChangesResult(from: response)
+
+      // The per-zone token and the response-level token are distinct values.
+      #expect(result.syncToken == "top-level-token")
+      #expect(result.moreComing)
+      let zone = try #require(result.zones.first)
+      #expect(zone.syncToken == "zone-level-token")
+      #expect(zone.atomic == true)
+    }
+
+    @Test("ZonesLookupResponse decodes zone metadata")
+    internal func lookupResponseDecodesMetadata() throws {
+      let response = try JSONDecoder().decode(
+        Components.Schemas.ZonesLookupResponse.self,
+        from: Data(
+          """
+          {
+            "zones": [
+              {
+                "zoneID": { "zoneName": "Articles", "ownerName": "_defaultOwner" },
+                "syncToken": "lookup-token",
+                "atomic": true
+              }
+            ]
+          }
+          """.utf8
+        )
+      )
+
+      let zone = try #require(response.zones?.first)
+      let info = try ZoneInfo(from: zone)
+      #expect(info.syncToken == "lookup-token")
+      #expect(info.atomic == true)
+    }
+
+    @Test("ZoneOperation encodes only operationType and zoneID")
+    internal func zoneOperationEncodesDocumentedKeysOnly() throws {
+      // Apple documents the operation's `zone` as having "a single zoneID key",
+      // so no create options are emitted (see issue #386).
+      let operation = Components.Schemas.ZoneOperation(
+        from: .create(ZoneID(zoneName: "Articles"))
+      )
+
+      let data = try JSONEncoder().encode(operation)
+      let object = try #require(
+        try JSONSerialization.jsonObject(with: data) as? [String: Any]
+      )
+
+      #expect(object["operationType"] as? String == "create")
+      let zone = try #require(object["zone"] as? [String: Any])
+      #expect(Set(zone.keys) == ["zoneID"])
+      let zoneID = try #require(zone["zoneID"] as? [String: Any])
+      #expect(zoneID["zoneName"] as? String == "Articles")
+    }
+  }
+}

--- a/Tests/MistKitTests/Models/Zones/ZoneMetadataTests+ZoneInfoConversion.swift
+++ b/Tests/MistKitTests/Models/Zones/ZoneMetadataTests+ZoneInfoConversion.swift
@@ -1,0 +1,130 @@
+//
+//  ZoneMetadataTests.swift
+//  MistKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+internal import Foundation
+internal import Testing
+
+@testable import MistKit
+@testable import MistKitOpenAPI
+
+extension ZoneMetadataTests {
+  /// Conversion of a `Zone` payload into the domain `ZoneInfo`.
+  @Suite("ZoneInfo Conversion")
+  internal struct ZoneInfoConversion {
+    /// Decode a JSON zone payload into the generated `Zone` schema type.
+    internal static func decodeZone(_ json: String) throws -> Components.Schemas.Zone {
+      try JSONDecoder().decode(Components.Schemas.Zone.self, from: Data(json.utf8))
+    }
+
+    @Test("Zone payload decodes syncToken and atomic")
+    internal func zoneDecodesMetadata() throws {
+      let zone = try Self.decodeZone(
+        """
+        {
+          "zoneID": { "zoneName": "Articles", "ownerName": "_defaultOwner" },
+          "syncToken": "AQAAAAAAAAAB",
+          "atomic": true
+        }
+        """
+      )
+
+      #expect(zone.zoneID?.zoneName == "Articles")
+      #expect(zone.syncToken == "AQAAAAAAAAAB")
+      #expect(zone.atomic == true)
+    }
+
+    @Test("ZoneInfo carries syncToken and atomic from a Zone payload")
+    internal func zoneInfoCarriesMetadata() throws {
+      let zone = try Self.decodeZone(
+        """
+        {
+          "zoneID": { "zoneName": "Articles", "ownerName": "_defaultOwner" },
+          "syncToken": "AQAAAAAAAAAB",
+          "atomic": true
+        }
+        """
+      )
+
+      let info = try ZoneInfo(from: zone)
+
+      #expect(info.zoneName == "Articles")
+      #expect(info.ownerRecordName == "_defaultOwner")
+      #expect(info.syncToken == "AQAAAAAAAAAB")
+      #expect(info.atomic == true)
+    }
+
+    @Test("Absent metadata stays nil rather than defaulting")
+    internal func absentMetadataStaysNil() throws {
+      let zone = try Self.decodeZone(
+        """
+        { "zoneID": { "zoneName": "Articles" } }
+        """
+      )
+
+      let info = try ZoneInfo(from: zone)
+
+      // `atomic` must stay nil so "absent" remains distinguishable from
+      // an explicit `false`.
+      #expect(info.syncToken == nil)
+      #expect(info.atomic == nil)
+      #expect(info.zoneName == "Articles")
+    }
+
+    @Test("atomic decodes false without collapsing into nil")
+    internal func atomicFalseIsPreserved() throws {
+      let zone = try Self.decodeZone(
+        """
+        { "zoneID": { "zoneName": "Articles" }, "atomic": false }
+        """
+      )
+
+      let info = try ZoneInfo(from: zone)
+
+      #expect(try #require(info.atomic) == false)
+    }
+
+    @Test("ZoneInfo still throws when the zone payload has no zoneName")
+    internal func missingZoneNameThrows() throws {
+      let zone = try Self.decodeZone(
+        """
+        { "zoneID": { "ownerName": "_defaultOwner" }, "atomic": true }
+        """
+      )
+
+      ConversionFailureReporter.$assertionHandler.withValue(
+        { _, _, _ in },
+        operation: {
+          #expect(throws: ConversionError.self) {
+            _ = try ZoneInfo(from: zone)
+          }
+        }
+      )
+    }
+  }
+}

--- a/Tests/MistKitTests/Models/Zones/ZoneMetadataTests.swift
+++ b/Tests/MistKitTests/Models/Zones/ZoneMetadataTests.swift
@@ -1,5 +1,5 @@
 //
-//  ZoneChangesResult.swift
+//  ZoneMetadataTests.swift
 //  MistKit
 //
 //  Created by Leo Dion.
@@ -27,38 +27,12 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
-internal import MistKitOpenAPI
+internal import Testing
 
-/// Result from fetching zone changes.
+/// Coverage for the zone metadata added in issue #386.
 ///
-/// Contains zones that have changed since the provided sync token,
-/// along with a new sync token for subsequent fetches.
-public struct ZoneChangesResult: Codable, Sendable {
-  /// Zones that have changed
-  public let zones: [ZoneInfo]
-  /// Token to use for next fetch to get incremental changes
-  public let syncToken: String?
-  /// Whether more changes are available (for large zone change sets)
-  public let moreComing: Bool
-
-  /// Initialize a zone changes result
-  public init(
-    zones: [ZoneInfo],
-    syncToken: String?,
-    moreComing: Bool = false
-  ) {
-    self.zones = zones
-    self.syncToken = syncToken
-    self.moreComing = moreComing
-  }
-
-  internal init(from response: Components.Schemas.ZoneChangesResponse) throws(ConversionError) {
-    var zones: [ZoneInfo] = []
-    for zone in response.zones ?? [] {
-      zones.append(try ZoneInfo(from: zone))
-    }
-    self.zones = zones
-    self.syncToken = response.syncToken
-    self.moreComing = response.moreComing ?? false
-  }
-}
+/// Apple's archived "Zone Dictionary" documents exactly three keys —
+/// `zoneID`, `syncToken`, and `atomic` — and these suites pin the decode
+/// path for the latter two across every zone response shape.
+@Suite("Zone Metadata")
+internal enum ZoneMetadataTests {}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1473,16 +1473,34 @@ components:
         moreComing:
           type: boolean
 
+    Zone:
+      type: object
+      description: >
+        A record zone as returned by the zone endpoints (`zones/list`,
+        `zones/lookup`, `zones/modify`, `zones/changes`). Matches the
+        "Zone Dictionary" in Apple's archived CloudKit Web Services
+        Reference, which documents exactly three keys: `zoneID`,
+        `syncToken`, and `atomic`. `isEager` is deliberately absent — it
+        appears in no primary Apple source (see issue #386).
+      properties:
+        zoneID:
+          $ref: '#/components/schemas/ZoneID'
+        syncToken:
+          type: string
+          description: The current point in the zone's change history.
+        atomic:
+          type: boolean
+          description: >
+            A Boolean value indicating whether this zone supports atomic
+            operations.
+
     ZonesListResponse:
       type: object
       properties:
         zones:
           type: array
           items:
-            type: object
-            properties:
-              zoneID:
-                $ref: '#/components/schemas/ZoneID'
+            $ref: '#/components/schemas/Zone'
 
     ZonesLookupResponse:
       type: object
@@ -1490,10 +1508,7 @@ components:
         zones:
           type: array
           items:
-            type: object
-            properties:
-              zoneID:
-                $ref: '#/components/schemas/ZoneID'
+            $ref: '#/components/schemas/Zone'
 
     ZonesModifyResponse:
       type: object
@@ -1501,10 +1516,7 @@ components:
         zones:
           type: array
           items:
-            type: object
-            properties:
-              zoneID:
-                $ref: '#/components/schemas/ZoneID'
+            $ref: '#/components/schemas/Zone'
 
     ZoneChangesResponse:
       type: object
@@ -1512,10 +1524,7 @@ components:
         zones:
           type: array
           items:
-            type: object
-            properties:
-              zoneID:
-                $ref: '#/components/schemas/ZoneID'
+            $ref: '#/components/schemas/Zone'
         syncToken:
           type: string
         moreComing:


### PR DESCRIPTION
## Summary

Every zone response modeled a zone as just `{ zoneID }`. This adds a shared `Zone` schema in `openapi.yaml` — reused by `ZonesListResponse`, `ZonesLookupResponse`, `ZonesModifyResponse`, and `ZoneChangesResponse` — carrying the zone metadata that Apple actually documents, and surfaces it on the domain `ZoneInfo`.

**The issue flagged these field names as unverified, and verification changed the scope.** Only two of the three proposed response fields exist in a primary source, and neither of the two proposed *request* changes does. I implemented the confirmed subset and left the rest out rather than guessing.

## Verification against primary sources

Verified against Apple's archived CloudKit Web Services Reference (`.claude/docs/webservices.md` is abbreviated on zone payloads and confirms none of these, per `.claude/memory/reference_cloudkit_archived_endpoints.md`).

### ✅ CONFIRMED — implemented

| Field | Where | Apple's wording | Source |
|---|---|---|---|
| `zoneID` | Zone Dictionary | "The dictionary that identifies a record zone in the database" | [Types.html](https://developer.apple.com/library/archive/documentation/DataManagement/Conceptual/CloudKitWebServicesReference/Types.html) |
| `syncToken` | Zone Dictionary | "The current point in the zone's change history." | [Types.html](https://developer.apple.com/library/archive/documentation/DataManagement/Conceptual/CloudKitWebServicesReference/Types.html) |
| `atomic` | Zone Dictionary | "A Boolean value indicating whether this zone supports atomic operations." | [Types.html](https://developer.apple.com/library/archive/documentation/DataManagement/Conceptual/CloudKitWebServicesReference/Types.html) |

The Zone Dictionary documents **exactly these three keys** — no more. All four zone endpoints route their success payload through it: [zones/list](https://developer.apple.com/library/archive/documentation/DataManagement/Conceptual/CloudKitWebServicesReference/GettingAllZones.html), [zones/lookup](https://developer.apple.com/library/archive/documentation/DataManagement/Conceptual/CloudKitWebServicesReference/GettingZonesbyIdentifier.html), [zones/modify](https://developer.apple.com/library/archive/documentation/DataManagement/Conceptual/CloudKitWebServicesReference/ModifyZones.html), [zones/changes](https://developer.apple.com/library/archive/documentation/DataManagement/Conceptual/CloudKitWebServicesReference/GetZoneChanges.html) — each says "If successful, the result dictionary contains the keys described in Zone Dictionary."

### ❌ NOT CONFIRMED — deliberately omitted

| Proposed | Why omitted |
|---|---|
| `isEager` on zone responses | Appears in **no** primary source. Not in the Zone Dictionary, not anywhere in the archived reference, and `grep -i isEager` over `.claude/docs/webservices.md` + `.claude/docs/cloudkitjs.md` returns nothing. No basis to encode a name or type. |
| `atomic` on the `zones/modify` **request** | [ModifyZones.html](https://developer.apple.com/library/archive/documentation/DataManagement/Conceptual/CloudKitWebServicesReference/ModifyZones.html) documents the request body as `operations` only ("This key is required"), with no `atomic` key. Contrast `records/modify`, which *does* document `atomic` — the asymmetry looks deliberate. |
| Zone create options on `ZoneOperation` | Same page documents the operation's `zone` as "A dictionary representing the zone to modify. It has a **single `zoneID` key**." No room for create options. |

A regression test (`ZoneOperation encodes only operationType and zoneID`) pins the request shape so create options can't be added back accidentally without a doc update.

### Incidental findings (not acted on — filed as an issue comment)

- `zones/changes` is documented as **deprecated** in favor of `changes/database`.
- Its token key is documented as **`metaSyncToken`**, in both request and response — MistKit currently sends/reads `syncToken`. Left alone: out of scope, and Apple's own page is internally inconsistent (the `moreComing` description refers back to "the included `syncToken` key"), so this needs a live-response check rather than a doc-driven change.

## Changes

- `openapi.yaml` — new shared `Zone` schema; all four zone responses now `$ref` it.
- Regenerated `Sources/MistKitOpenAPI/Types.swift` via `./Scripts/generate-openapi.sh` (not hand-edited). The four inline anonymous zone structs collapse into one `Components.Schemas.Zone`, which is why that file shows net deletions.
- `ZoneInfo` — adds `syncToken: String?` and `atomic: Bool?`, plus an `init(from: Components.Schemas.Zone)` conversion.
- `CloudKitService+ZoneOperations.swift`, `CloudKitService+ModifyZones.swift`, `ZoneChangesResult.swift` — converted through the new initializer so metadata reaches callers.
- `AGENTS.md` (symlinked as `CLAUDE.md`) — Result Types entry for `ZoneInfo` plus a zone-metadata section recording what is confirmed and what must not be added speculatively.

### Design note

`atomic` is `Bool?`, **not** defaulted to `false` — an absent key stays distinguishable from an explicit `false`. Same for `syncToken`. Note the per-zone `syncToken` is distinct from the response-level `syncToken` on `ZoneChangesResult`; a test pins both.

## Source compatibility

**No breaks.** Both `ZoneInfo` properties are added with defaulted initializer parameters, so the existing `init(zoneName:ownerRecordName:capabilities:)` still compiles. `modifyZones` gained no parameters — the proposed `atomic:` flag was unconfirmed, so the signature is untouched. `ZoneInfo` is a `struct` with a memberwise-style public init, so adding stored properties is additive here.

## Out of scope: RecordResult pattern

Per `.claude/memory/feedback_record_result_pattern_throughout.md`, per-item modify failures should surface via the `RecordResult` pattern for zones too. **`modifyZones` does not do this today** — it returns `[ZoneInfo]` and silently drops errored entries, exactly the gap that memory describes. Apple documents a "Zone Fetch Error Dictionary" (`zoneID`, `reason`, `serverErrorCode`, `retryAfter`, `redirectURL`) returned inline for failed zones in `zones/list`, `zones/lookup`, **and** `zones/modify`.

Fixing it means a `ZoneOperationFailure` schema, a `oneOf` response, and changing `modifyZones`' return type — a real source break and a distinct piece of work from this schema enrichment. Filed separately rather than folded in here.

## Verification

All run locally in the worktree:

- `swift build` — ✅ clean
- `swift test` — ✅ **560 tests in 176 suites passed** (10 new)
- `mise exec -- swift-format -i -r Sources/ Tests/` — ✅ applied
- `./Scripts/lint.sh` — ✅ **0 violations in 393 files**, periphery reports no unused code. (One pre-existing swift-format warning in `CloudKitService+BatchChunking.swift`, a file this PR does not touch.)
- `Examples/MistDemo` `swift build` — ✅ clean (API shape changed, so verified)

New tests cover: `Zone` payload decoding, `ZoneInfo` metadata carry-through, absent-stays-nil, `atomic: false` preservation, the existing missing-`zoneName` throw path, decoding across all four response types, zone-level vs response-level `syncToken`, and the `ZoneOperation` request shape.

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)
