### PR TITLE
ci: cancel superseded runs on the five unguarded workflows

### DIFF
--- a/.github/workflows/check-unsafe-flags.yml
+++ b/.github/workflows/check-unsafe-flags.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dump-package-check:
     name: Dump Swift package (authoritative) and scan JSON

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,10 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Optional: Filter by PR author

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,13 @@ on:
   schedule:
     - cron: '20 11 * * 3'
 
+concurrency:
+  # event_name is part of the key so the weekly scheduled scan and a push scan of
+  # the same branch never cancel each other; within one event type, only the
+  # newest run of a branch survives.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 env:
   PACKAGE_NAME: MistKit
 

--- a/.github/workflows/swift-source-compat.yml
+++ b/.github/workflows/swift-source-compat.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   swift-source-compat-suite:
     name: Test Swift ${{ matrix.container }} For Source Compatibility Suite


### PR DESCRIPTION
Makes every PR-driven workflow run only on a PR's latest commit. Five workflows had no `concurrency` block at all, so each re-push left the previous run alive and holding a runner until it finished on its own.

## What was piling up

| Workflow | Fires on | Cost of a stale run |
|---|---|---|
| **`codeql.yml`** | **every push to every branch** (`branches-ignore: ['*WIP']`) | Swift analysis runs on **`macos-26`** — the scarcest runner class |
| `swift-source-compat.yml` | all PRs | 3 ubuntu container jobs |
| `claude-code-review.yml` | every `synchronize` | 1 job |
| `check-unsafe-flags.yml` | main-targeting PRs | 1 job |
| `examples.yml` | main-targeting PRs | 3 ubuntu container jobs |

CodeQL was the expensive one: a branch pushed three times held three macOS runners, none of which could be superseded.

`MistKit.yml`, `MistDemo.yml`, `BushelCloud.yml`, and `CelestraCloud.yml` already cancelled correctly and are untouched.

## The change

All five get the branch-keyed group the rest of the repo already uses:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
  cancel-in-progress: true
```

`codeql.yml` additionally keys on `github.event_name`, so its weekly scheduled scan and a push scan of the same branch land in separate groups and cannot cancel each other. Within a single event type, only the newest run of a branch survives.

**No trigger filters change.** Nothing that was being built, tested, or scanned stops being built, tested, or scanned — the only behavior change is that a superseded run now stops instead of running to completion.

## Deliberately left alone

**`MistDemo-Integration.yml` keeps `cancel-in-progress: false`.** It fires only on pushes to `main` and `v*.*.*`, never on PRs, so it cannot stack per-PR — and killing it mid-run would leave stray records in the live CloudKit container.

**CodeQL's double-fire is not addressed here.** On main-targeting PRs it runs twice per commit, once via `push` and once via `pull_request`, so those commits still consume two macOS runners. Scoping `push` to `main` would fix it — but its `pull_request` filter is `branches: ['main']`, so PRs targeting any other base (a `v1.0.0-beta.*` branch, for instance) would then get **no CodeQL coverage at all**. That is a coverage decision rather than a cost one, so it's left for a separate discussion.

## Verification

Enumerated every workflow's triggers and concurrency config before and after. Before: five workflows reported "no concurrency — piles up." After: every PR-driven workflow reports `cancel-in-progress: true`, with `MistDemo-Integration.yml` the only remaining `false` (deliberate, per above). All 10 root workflow files parse as YAML.

The real proof is behavioral: push twice in quick succession to a PR branch and confirm the first CodeQL run is cancelled rather than left running.