### PR TITLE
Fix Linux build: replace fputs(_:stderr) with FileHandle.standardError

### DIFF
--- a/Examples/MistDemo/Sources/MistDemo/MistDemo.swift
+++ b/Examples/MistDemo/Sources/MistDemo/MistDemo.swift
@@ -39,9 +39,12 @@ internal enum MistDemo {
     } catch {
       // PhasedIntegrationTest prints a copy-friendly message before rethrowing;
       // exit cleanly instead of trapping on an uncaught top-level throw.
-      let message = (error as? any LocalizedError)?.errorDescription
+      let message =
+        (error as? any LocalizedError)?.errorDescription
         ?? String(describing: error)
-      fputs("❌ \(message)\n", stderr)
+      // Glibc exposes `stderr` as a mutable global, which Swift 6 strict
+      // concurrency rejects; FileHandle keeps this portable to Linux.
+      FileHandle.standardError.write(Data("❌ \(message)\n".utf8))
       exit(1)
     }
   }


### PR DESCRIPTION
## The error

The `Examples` workflow's **Test MistDemo on Ubuntu** job fails to compile:

```
Examples/MistDemo/Sources/MistDemo/MistDemo.swift:44:33: error: reference to var 'stderr'
  is not concurrency-safe because it involves shared mutable state
44 |       fputs("❌ \(message)\n", stderr)
   |                               `- error
```

## Why it is Linux-only

glibc declares the stream as `extern FILE *stderr` — a plain mutable global — which Swift imports as a global `var`. Under Swift 6 strict concurrency, referencing a non-`Sendable`, non-isolated mutable global is an error.

Darwin's headers expose `stderr` differently (via `__stderrp`), and the Darwin overlay imports it in a form the concurrency checker accepts, so the exact same line compiles cleanly on macOS. That's why this got through review and the macOS jobs: it cannot reproduce locally on a Mac.

The line was introduced in #429 (0b6bea9).

## The fix

One-line change in `Examples/MistDemo/Sources/MistDemo/MistDemo.swift`: write through `FileHandle` instead of the C stream.

```swift
// Glibc exposes `stderr` as a mutable global, which Swift 6 strict
// concurrency rejects; FileHandle keeps this portable to Linux.
FileHandle.standardError.write(Data("❌ \(message)\n".utf8))
```

This is the idiom already used everywhere else in this codebase for stderr output — `MistDemoConfig+DatabaseConfiguration.swift`, `LookupCommand.swift`, `LookupAllRecordsCommand.swift`, `ModifyCommand.swift`, `ModifyZonesCommand.swift`, `DiscoverAllUserIdentitiesCommand.swift`, and `BushelCloudKit`'s `ConsoleOutput` — so the fix matches existing style rather than introducing a new pattern. `internal import Foundation` was already present in the file, so no import change was needed (the repo's explicit-access-modifier import convention is preserved).

I grepped all of `Examples/` and `Sources/` for `stderr`/`stdout`: this was the only *code* reference. Every other hit is a doc comment or a test asserting on help text, none of which touch the C globals. No other changes are included in this PR.

## Verification

| Check | Result |
|---|---|
| `swift build` in `Examples/MistDemo` (macOS, Swift 6.3) | pass |
| `swift test` in `Examples/MistDemo` (macOS) | pass — 994 tests / 295 suites, 1 known issue |
| `swift build` + `swift test` at repo root (macOS) | pass — 618 tests / 195 suites |
| `swiftlint --strict` + `swift-format lint --strict` on the changed file | clean |
| **Linux** `swift build` — `docker run --rm swift:6.3` in `Examples/MistDemo` (same image the CI job uses) | **pass — "Build complete!", the error is gone** |
| **Linux** `swift test` — same container | pass — 994 tests / 295 suites, 1 known issue (matches the macOS run) |

Linux verification was actually performed, not assumed: the pre-fix error reproduces only on Linux, and the `swift:6.3` container build now completes with exit code 0.

Note on `LINT_MODE=STRICT ./Scripts/lint.sh`: it reports 54 pre-existing violations on this base branch (file-name, type-contents-order, line-length, etc. across `Sources/`, `Tests/`, and `Scripts/OpenAPITools/Package.swift`). None are in the file this PR touches, and the count is unchanged by this PR — `Scripts/lint.sh` doesn't even scan `Examples/`. Worth flagging separately: when `$CI` is unset, `lint.sh` runs `swift-format --in-place` and `swiftlint --fix` regardless of `LINT_MODE`, so running it locally rewrites unrelated files (and the locally-resolved swift-format disagrees with the pinned one). That's out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
