### PR TITLE
Clear two Linux build warnings (#433)

### DIFF
--- a/Sources/MistKit/CloudKitService/CloudKitError+ErrorDescription.swift
+++ b/Sources/MistKit/CloudKitService/CloudKitError+ErrorDescription.swift
@@ -177,16 +177,6 @@ extension CloudKitError {
     return fragment
   }
 
-  private static func networkErrorDescription(_ error: URLError) -> String {
-    var message = "Network error occurred"
-    message += "\nError code: \(error.code.rawValue)"
-    if let url = error.failureURLString {
-      message += "\nFailed URL: \(url)"
-    }
-    message += "\nDescription: \(error.localizedDescription)"
-    return message
-  }
-
   private static func missingCredentialsDescription(
     database: Database, availability: CredentialAvailability, reason: String
   ) -> String {

--- a/Sources/MistKit/CloudKitService/CloudKitError+NetworkErrorDescription.swift
+++ b/Sources/MistKit/CloudKitService/CloudKitError+NetworkErrorDescription.swift
@@ -1,0 +1,69 @@
+//
+//  CloudKitError+NetworkErrorDescription.swift
+//  MistKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+internal import Foundation
+
+#if canImport(FoundationNetworking)
+  internal import FoundationNetworking
+#endif
+
+extension CloudKitError {
+  /// Raw value of Foundation's `NSURLErrorFailingURLStringErrorKey`, spelled
+  /// literally because that constant is itself deprecated on
+  /// swift-corelibs-foundation — naming it would only relocate the warning.
+  /// Verified identical on Darwin Foundation and corelibs-foundation.
+  private static let failingURLStringKey = "NSErrorFailingURLStringKey"
+
+  /// Renders a `URLError` into a human-readable description.
+  ///
+  /// Split out of `CloudKitError+ErrorDescription.swift` to keep that file
+  /// within the file-length limit.
+  internal static func networkErrorDescription(_ error: URLError) -> String {
+    var message = "Network error occurred"
+    message += "\nError code: \(error.code.rawValue)"
+    if let url = Self.failingURLString(for: error) {
+      message += "\nFailed URL: \(url)"
+    }
+    message += "\nDescription: \(error.localizedDescription)"
+    return message
+  }
+
+  /// The URL a `URLError` failed on, rendered as a string.
+  ///
+  /// `failingURL` reads `NSURLErrorFailingURLErrorKey`; the `failureURLString`
+  /// it deprecates read the *distinct* `NSErrorFailingURLStringKey`. An error
+  /// may carry either key, so prefer the typed `URL` and fall back to the
+  /// string key rather than dropping the URL from the description.
+  private static func failingURLString(for error: URLError) -> String? {
+    if let failingURL = error.failingURL {
+      return failingURL.absoluteString
+    }
+    return error.errorUserInfo[Self.failingURLStringKey] as? String
+  }
+}

--- a/Sources/MistKit/Models/AssetUploading/URLRequest+AssetUpload.swift
+++ b/Sources/MistKit/Models/AssetUploading/URLRequest+AssetUpload.swift
@@ -30,7 +30,7 @@
 internal import Foundation
 
 #if canImport(FoundationNetworking)
-  public import FoundationNetworking
+  internal import FoundationNetworking
 #endif
 
 #if !os(WASI)

--- a/Tests/MistKitTests/CloudKitService/CloudKitErrorTests.swift
+++ b/Tests/MistKitTests/CloudKitService/CloudKitErrorTests.swift
@@ -32,8 +32,18 @@ internal import Testing
 
 @testable import MistKit
 
+#if canImport(FoundationNetworking)
+  internal import FoundationNetworking
+#endif
+
 @Suite("CloudKitError")
 internal struct CloudKitErrorTests {
+  /// Raw value of Foundation's `NSURLErrorFailingURLStringErrorKey`. Spelled
+  /// literally rather than named because the constant is deprecated on
+  /// swift-corelibs-foundation; hard-coding it here also keeps this test
+  /// independent of the production constant it exercises.
+  private static let failingURLStringKey = "NSErrorFailingURLStringKey"
+
   @Test(".missingCredentials with .notConfigured describes as not configured")
   internal func missingCredentialsNotConfiguredDescribesAsNotConfigured() throws {
     let error = CloudKitError.missingCredentials(
@@ -61,5 +71,60 @@ internal struct CloudKitErrorTests {
     #expect(description.contains("public"))
     #expect(description.contains("required by preference but not configured"))
     #expect(description.contains("web-auth preference required"))
+  }
+
+  @Test(".networkError reports the failed URL from the string userInfo key")
+  internal func networkErrorReportsFailedURLFromStringKey() throws {
+    let error = CloudKitError.networkError(
+      URLError(
+        .timedOut,
+        userInfo: [Self.failingURLStringKey: "https://api.apple-cloudkit.com/string"]
+      )
+    )
+
+    let description = try #require(error.errorDescription)
+    #expect(description.contains("Network error occurred"))
+    #expect(description.contains("Error code: \(URLError.Code.timedOut.rawValue)"))
+    #expect(description.contains("Failed URL: https://api.apple-cloudkit.com/string"))
+  }
+
+  @Test(".networkError reports the failed URL from the URL userInfo key")
+  internal func networkErrorReportsFailedURLFromURLKey() throws {
+    let url = try #require(URL(string: "https://api.apple-cloudkit.com/url"))
+    let error = CloudKitError.networkError(
+      URLError(.cannotConnectToHost, userInfo: [NSURLErrorFailingURLErrorKey: url])
+    )
+
+    let description = try #require(error.errorDescription)
+    #expect(description.contains("Error code: \(URLError.Code.cannotConnectToHost.rawValue)"))
+    #expect(description.contains("Failed URL: https://api.apple-cloudkit.com/url"))
+  }
+
+  @Test(".networkError prefers the URL userInfo key when both are present")
+  internal func networkErrorPrefersURLKeyWhenBothPresent() throws {
+    let url = try #require(URL(string: "https://api.apple-cloudkit.com/url"))
+    let error = CloudKitError.networkError(
+      URLError(
+        .networkConnectionLost,
+        userInfo: [
+          NSURLErrorFailingURLErrorKey: url,
+          Self.failingURLStringKey: "https://api.apple-cloudkit.com/string",
+        ]
+      )
+    )
+
+    let description = try #require(error.errorDescription)
+    #expect(description.contains("Failed URL: https://api.apple-cloudkit.com/url"))
+    #expect(!description.contains("https://api.apple-cloudkit.com/string"))
+  }
+
+  @Test(".networkError omits the failed URL when neither userInfo key is present")
+  internal func networkErrorOmitsFailedURLWhenNoKeysPresent() throws {
+    let error = CloudKitError.networkError(URLError(.notConnectedToInternet))
+
+    let description = try #require(error.errorDescription)
+    #expect(description.contains("Network error occurred"))
+    #expect(description.contains("Error code: \(URLError.Code.notConnectedToInternet.rawValue)"))
+    #expect(!description.contains("Failed URL:"))
   }
 }


### PR DESCRIPTION
Clears the two Linux build warnings from #433 (Parts 1 and 2). Part 3 (the `openapi.yaml` wording) is owned by another lane, so this is `Part of #433`, not a close.

## 1. Unused `public import FoundationNetworking`

`Sources/MistKit/Models/AssetUploading/URLRequest+AssetUpload.swift:33` → `internal import` (not bare `import` — the package enables `InternalImportsByDefault` but the convention is an explicit modifier on every import).

I verified the other three `public import FoundationNetworking` sites are genuinely justified and left them alone:

| File | Public API using the module |
|---|---|
| `URLSession+AssetUpload.swift` | `public func upload(_:to:)` |
| `URLSession+CourierPoll.swift` | `public var courierTransport`, `public func pollCourier(_:timeout:)` |
| `WebCourierPoller.swift` | `public struct WebCourierPoller`, `public static var ephemeralConfiguration: URLSessionConfiguration` |

## 2. `failureURLString` → `failingURL`, and the userInfo-key subtlety

`failureURLString` reads `NSErrorFailingURLStringKey` and returns `String?`; `failingURL` reads the *distinct* `NSErrorFailingURLKey` and returns `URL?`. A straight rename silently drops the failed URL from the description for any error carrying only the string key.

**Decision: prefer the typed `URL`, fall back to the string key.**

```swift
private static func failingURLString(for error: URLError) -> String? {
  if let failingURL = error.failingURL {
    return failingURL.absoluteString
  }
  return error.errorUserInfo[Self.failingURLStringKey] as? String
}
```

This is not a hypothetical gap — the "string key only" test **fails** without the fallback on both macOS and Linux, because neither Foundation's `failingURL` nor corelibs' consults the string key.

**Why the key is spelled as a literal.** My first attempt read the fallback via the named constant `NSURLErrorFailingURLStringErrorKey`. The Linux build showed that constant is *itself* deprecated on swift-corelibs-foundation:

```
warning: 'NSURLErrorFailingURLStringErrorKey' is deprecated:
         Use NSURLErrorFailingURLErrorKey instead [#DeprecatedDeclaration]
```

so naming it merely relocated the warning rather than clearing it. The fallback therefore uses a documented private constant holding the key's raw value:

```swift
private static let failingURLStringKey = "NSErrorFailingURLStringKey"
```

I verified that raw value is identical on Darwin Foundation and on corelibs-foundation (`swift:6.3-noble`) by printing both constants on each platform. It is a frozen `NSError` userInfo key, so hard-coding it is safe; the alternative — dropping the fallback — would be a silent behavior regression.

**File split.** Adding the helper pushed `CloudKitError+ErrorDescription.swift` to 228 lines, over SwiftLint's 225-line `file_length` limit. `networkErrorDescription` and its helper move to a new `CloudKitError+NetworkErrorDescription.swift`, mirroring the existing `CloudKitError+ZoneErrorDescription.swift`, which was split out of the same file for the same reason.

## Test coverage

There was previously **no** test for the `.networkError` description path. Four tests added to `Tests/MistKitTests/CloudKitService/CloudKitErrorTests.swift`, matching its existing style (`@Suite`/`@Test`/`#expect`/`try #require`, `internal` ACL, `@testable import MistKit`); the suite stays a `struct` since it remains a single file:

1. only the string key present → URL reported (this is the one that regresses without the fallback)
2. only the URL key present → `absoluteString` reported
3. both present → URL key wins, string value absent
4. neither present → no `Failed URL:` line at all

Nothing in the repo constructed `URLError(_:userInfo:)` before, so this establishes that pattern. The tests use the same hard-coded key literal rather than the deprecated constant — which both avoids re-introducing the warning in the test target and keeps the test independent of the production constant it exercises.

## Verification

**macOS** — `swift build` clean, `swift test` **622 tests in 195 suites passed**.

**Linux (`swift:6.3-noble` in Docker)** — I was able to verify this, and it changed the implementation (see the relocated-warning finding above). Before/after on the same image, filtering to warnings in package sources:

*Before (base `v1.0.0-beta.4` @ 61235b5):*
```
CloudKitError+ErrorDescription.swift:183:24: warning: 'failureURLString' is deprecated: Use failingURL instead
URLRequest+AssetUpload.swift:33:10: warning: public import of 'FoundationNetworking' was not used in public declarations or inlinable code
```

*After:* no output — zero warnings. `swift test` on Linux also passes **622 tests in 195 suites**.

**`LINT_MODE=STRICT ./Scripts/lint.sh`** — exits 1 with 28 violations, but this is **exactly the pre-existing state of the base commit**: I ran it on a clean tree at the merge base and on this branch under the same pinned toolchain and diffed the violation lists — identical, zero new or moved violations. (Note: the run must happen after `mise trust`; an untrusted `mise.toml` makes `lint.sh`'s `eval "$(mise env)"` no-op and fall back to unpinned system tools, which produces ~54 spurious violations and rewrites unrelated files.)

Part of #433.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
