### PR TITLE
Model zone payload fields: ownerRecordName, zoneType, deleted (#444)

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -12,7 +12,7 @@ Project-scoped agent memory for MistKit. This directory **replaces** any native 
 ## Index
 
 - [CloudKit archived endpoints not in local docs](reference_cloudkit_archived_endpoints.md) — Verify CloudKit endpoints (e.g. assets/rereference) against Apple's archived reference, not just .claude/docs/webservices.md
-- [CloudKit Zone Dictionary has exactly 3 keys](reference_cloudkit_zone_dictionary.md) — zoneID/syncToken/atomic only; isEager, modify-request `atomic`, and zone create options do NOT exist
+- [CloudKit Zone Dictionary has exactly 3 keys](reference_cloudkit_zone_dictionary.md) — archived docs: zoneID/syncToken/atomic; live change feeds also carry `deleted` + `zoneID.zoneType`; wire owner key is `ownerRecordName` (issue #444)
 - [wasm CI failure signatures](reference_wasm_ci_signatures.md) — Two distinct wasm failures: silent exit-1 (OOM on big test target) vs curl exit-7 (SDK download flake, just re-run)
 - [Swift Testing availability guard](feedback_swift_testing_availability.md) — Never annotate @Suite types with @available; use guard #available inside @Test functions instead
 - [GitHub Action pinning preference](feedback_action_pinning.md) — Use @v<major> for brightdigit-owned actions; pin third-party actions explicitly

--- a/.claude/memory/reference_cloudkit_zone_dictionary.md
+++ b/.claude/memory/reference_cloudkit_zone_dictionary.md
@@ -1,14 +1,14 @@
 ---
 name: reference_cloudkit_zone_dictionary
-description: "CloudKit's Zone Dictionary has exactly three keys (zoneID, syncToken, atomic) — isEager and zone create options do not exist"
+description: "CloudKit Zone Dictionary keys — archived docs plus live-confirmed extensions (issue #444)"
 metadata:
   node_type: memory
   type: reference
 ---
 
-Verified against Apple's archived CloudKit Web Services Reference during issue #386 / PR #427.
+Verified against Apple's archived CloudKit Web Services Reference during issue #386 / PR #427, with live-response confirmation for additional keys in issue #444.
 
-**Zone Dictionary documents exactly three keys** ([Types.html](https://developer.apple.com/library/archive/documentation/DataManagement/Conceptual/CloudKitWebServicesReference/Types.html)):
+**Zone Dictionary — archived docs** ([Types.html](https://developer.apple.com/library/archive/documentation/DataManagement/Conceptual/CloudKitWebServicesReference/Types.html)):
 
 | Key | Apple's wording |
 |-----|-----------------|
@@ -16,7 +16,24 @@ Verified against Apple's archived CloudKit Web Services Reference during issue #
 | `syncToken` | "The current point in the zone's change history." |
 | `atomic` | "A Boolean value indicating whether this zone supports atomic operations." |
 
-All four zone endpoints (`zones/list`, `zones/lookup`, `zones/modify`, `zones/changes`) route their **success** payload through this dictionary, and their **failure** payload through the "Zone Fetch Error Dictionary" (`zoneID`, `reason`, `serverErrorCode`, `retryAfter`, `redirectURL`).
+**Live-confirmed additions (issue #444)** — present on change feeds (`zones/changes`, `changes/database`) but absent from the archived Zone Dictionary page:
+
+| Key | Location | Notes |
+|-----|----------|-------|
+| `deleted` | Zone object (not inside `zoneID`) | `true` = tombstone; sync clients must observe this |
+| `zoneType` | Inside `zoneID` | Observed values: `REGULAR_CUSTOM_ZONE`, `DEFAULT_ZONE` |
+
+**Zone ID Dictionary** — wire key is `ownerRecordName`, **not** `ownerName`:
+
+| Key | Description |
+|-----|-------------|
+| `zoneName` | Required. Default `_defaultZone`. |
+| `ownerRecordName` | Zone owner's user record name (shared zones). |
+| `zoneType` | Optional. `REGULAR_CUSTOM_ZONE` or `DEFAULT_ZONE` on live responses. |
+
+MistKit's domain `ZoneID` keeps the Swift property name `ownerName`; only the wire key is `ownerRecordName`.
+
+All four zone endpoints (`zones/list`, `zones/lookup`, `zones/modify`, `zones/changes`) route their **success** payload through the Zone dictionary, and their **failure** payload through the "Zone Fetch Error Dictionary" (`zoneID`, `reason`, `serverErrorCode`, `retryAfter`, `redirectURL`).
 
 **Things that do NOT exist — do not add them speculatively:**
 
@@ -24,9 +41,9 @@ All four zone endpoints (`zones/list`, `zones/lookup`, `zones/modify`, `zones/ch
 - **`atomic` on the `zones/modify` request** — the request body is `operations` only. `records/modify` *does* document `atomic`; the asymmetry is deliberate.
 - **Zone create options on `ZoneOperation`** — the operation's `zone` is documented as having "a single `zoneID` key".
 
-**Open discrepancies (unresolved, see issue #386 comment):**
+**Resolved discrepancies:**
 
-- `zones/changes` documents its token key as **`metaSyncToken`** in both request and response; MistKit sends/reads `syncToken`. Apple's page contradicts itself (the `moreComing` description refers back to "the included `syncToken` key"), so this needs a live-response check before changing.
-- `zones/changes` is documented as **deprecated** in favor of `changes/database`.
+- `zones/changes` token key is `metaSyncToken` on the wire (issue #430); Swift-facing names unchanged.
+- `ownerRecordName` is the wire key for the zone owner (issue #444); the mistaken `ownerName` key never decoded live responses.
 
-Note `ZoneID`'s owner key: Apple documents `ownerRecordName`, while MistKit's `ZoneID` domain type calls it `ownerName` and the wire schema uses `ownerName`. Related: [[reference_cloudkit_archived_endpoints]].
+Note `zones/changes` is documented as **deprecated** in favor of `changes/database`. Related: [[reference_cloudkit_archived_endpoints]].

--- a/.claude/memory/reference_cloudkit_zone_dictionary.md
+++ b/.claude/memory/reference_cloudkit_zone_dictionary.md
@@ -21,7 +21,7 @@ Verified against Apple's archived CloudKit Web Services Reference during issue #
 | Key | Location | Notes |
 |-----|----------|-------|
 | `deleted` | Zone object (not inside `zoneID`) | `true` = tombstone; sync clients must observe this |
-| `zoneType` | Inside `zoneID` | Observed values: `REGULAR_CUSTOM_ZONE`, `DEFAULT_ZONE` |
+| `zoneType` | Inside `zoneID` | ``ZoneType`` — `DEFAULT_ZONE` or `REGULAR_CUSTOM_ZONE`; key optional |
 
 **Zone ID Dictionary** — wire key is `ownerRecordName`, **not** `ownerName`:
 
@@ -29,7 +29,7 @@ Verified against Apple's archived CloudKit Web Services Reference during issue #
 |-----|-------------|
 | `zoneName` | Required. Default `_defaultZone`. |
 | `ownerRecordName` | Zone owner's user record name (shared zones). |
-| `zoneType` | Optional. `REGULAR_CUSTOM_ZONE` or `DEFAULT_ZONE` on live responses. |
+| `zoneType` | Optional. ``ZoneType`` (`DEFAULT_ZONE` / `REGULAR_CUSTOM_ZONE`); unrecognized values throw at conversion. |
 
 MistKit's domain `ZoneID` keeps the Swift property name `ownerName`; only the wire key is `ownerRecordName`.
 

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/ZonePayloadMetadataPhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/ZonePayloadMetadataPhase.swift
@@ -1,0 +1,205 @@
+//
+//  ZonePayloadMetadataPhase.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+internal import Foundation
+internal import MistKit
+
+/// Live verification for issue #444: zone list/lookup responses carry
+/// `ownerRecordName` and `zoneType`, and `changes/database` surfaces zone
+/// deletions via `deleted`.
+///
+/// Creates a uniquely-named custom zone, asserts the metadata round-trips on
+/// `lookupZones` / `listZones`, then deletes the zone and polls
+/// `fetchDatabaseChanges` for a `deleted: true` tombstone.
+internal struct ZonePayloadMetadataPhase: IntegrationPhase {
+  internal typealias Input = NoState
+  internal typealias Output = NoState
+
+  internal static let title = "Zone payload metadata (ownerRecordName, zoneType, deleted)"
+  internal static let emoji = "🏷️"
+  internal static let apiName = "zonePayloadMetadata"
+
+  private static let customZoneType = "REGULAR_CUSTOM_ZONE"
+  private static let changeFeedPollAttempts = 5
+  private static let changeFeedPollDelay: Duration = .seconds(2)
+
+  internal func run(input: NoState, context: PhaseContext) async throws -> NoState {
+    print("\n\(Self.emoji) \(Self.title)")
+
+    let zoneName = "mistkit-zone-payload-\(UUID().uuidString.lowercased())"
+    let zoneID = ZoneID(zoneName: zoneName)
+
+    let baseline = try await context.service.fetchDatabaseChanges(
+      database: context.database
+    )
+    try ChangeTrackingVerification.requireNoZoneFailures(
+      baseline.failures,
+      operation: "fetchDatabaseChanges (baseline)"
+    )
+
+    do {
+      let created = try await context.service.createZone(
+        zoneName: zoneName,
+        database: context.database
+      )
+      if context.verbose {
+        print("   ✅ Created zone: \(created.zoneName)")
+      }
+
+      let lookedUp = try await context.service.lookupZones(
+        zoneIDs: [zoneID],
+        database: context.database
+      )
+      guard let lookupZone = lookedUp.first(where: { $0.zoneName == zoneName }) else {
+        throw IntegrationTestError.verificationFailed(
+          "lookupZones did not return the created zone '\(zoneName)'"
+        )
+      }
+      try Self.requireLiveZoneMetadata(lookupZone, source: "lookupZones")
+
+      let listed = try await context.service.listZones(database: context.database)
+      guard let listZone = listed.first(where: { $0.zoneName == zoneName }) else {
+        throw IntegrationTestError.verificationFailed(
+          "listZones did not include the created zone '\(zoneName)'"
+        )
+      }
+      try Self.requireLiveZoneMetadata(listZone, source: "listZones")
+
+      let (createdChange, afterCreateDatabaseToken) = try await Self.pollDatabaseChanges(
+        syncToken: baseline.syncToken,
+        zoneName: zoneName,
+        context: context,
+        description: "zone creation"
+      ) { !$0.deleted }
+      try Self.requireLiveZoneMetadata(createdChange, source: "fetchDatabaseChanges (create)")
+
+      try await context.service.deleteZone(
+        zoneName: zoneName,
+        database: context.database
+      )
+      if context.verbose {
+        print("   ✅ Deleted zone: \(zoneName)")
+      }
+
+      let (deletedChange, _) = try await Self.pollDatabaseChanges(
+        syncToken: afterCreateDatabaseToken ?? baseline.syncToken,
+        zoneName: zoneName,
+        context: context,
+        description: "zone deletion tombstone"
+      ) { $0.deleted }
+
+      guard deletedChange.deleted else {
+        throw IntegrationTestError.verificationFailed(
+          "fetchDatabaseChanges did not mark '\(zoneName)' deleted after deleteZone"
+        )
+      }
+
+      if context.verbose {
+        print("   ✅ Change feed tombstone: deleted=true for \(zoneName)")
+        if let owner = deletedChange.ownerRecordName {
+          print("     Owner: \(owner)")
+        }
+        if let zoneType = deletedChange.zoneType {
+          print("     Zone type: \(zoneType)")
+        }
+      }
+
+      print("✅ Zone payload metadata verified for '\(zoneName)'")
+      return NoState()
+    } catch {
+      try? await context.service.deleteZone(
+        zoneName: zoneName,
+        database: context.database
+      )
+      throw error
+    }
+  }
+
+  private static func requireLiveZoneMetadata(
+    _ zone: ZoneInfo,
+    source: String
+  ) throws {
+    guard let owner = zone.ownerRecordName, !owner.isEmpty else {
+      throw IntegrationTestError.verificationFailed(
+        "\(source) omitted ownerRecordName for zone '\(zone.zoneName)'"
+      )
+    }
+    guard zone.zoneType == customZoneType else {
+      throw IntegrationTestError.verificationFailed(
+        "\(source) reported zoneType '\(zone.zoneType ?? "nil")' for '\(zone.zoneName)' "
+          + "(expected \(customZoneType))"
+      )
+    }
+    guard !zone.deleted else {
+      throw IntegrationTestError.verificationFailed(
+        "\(source) reported deleted=true for live zone '\(zone.zoneName)'"
+      )
+    }
+  }
+
+  private static func pollDatabaseChanges(
+    syncToken: String?,
+    zoneName: String,
+    context: PhaseContext,
+    description: String,
+    matching predicate: (ZoneInfo) -> Bool
+  ) async throws -> (zone: ZoneInfo, databaseSyncToken: String?) {
+    for attempt in 1...changeFeedPollAttempts {
+      let result = try await context.service.fetchDatabaseChanges(
+        syncToken: syncToken,
+        database: context.database
+      )
+      try ChangeTrackingVerification.requireNoZoneFailures(
+        result.failures,
+        operation: "fetchDatabaseChanges (\(description))"
+      )
+
+      if let zone = result.changedZones.first(where: {
+        $0.zoneName == zoneName && predicate($0)
+      }) {
+        return (zone, result.syncToken)
+      }
+
+      if attempt < changeFeedPollAttempts {
+        if context.verbose {
+          print(
+            "   ⏳ Change feed empty for '\(zoneName)' (\(description)); "
+              + "retrying (\(attempt)/\(changeFeedPollAttempts))…"
+          )
+        }
+        try await Task.sleep(for: changeFeedPollDelay)
+      }
+    }
+
+    throw IntegrationTestError.verificationFailed(
+      "fetchDatabaseChanges never reported \(description) for zone '\(zoneName)' "
+        + "after \(changeFeedPollAttempts) attempts"
+    )
+  }
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/ZonePayloadMetadataPhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/ZonePayloadMetadataPhase.swift
@@ -45,7 +45,7 @@ internal struct ZonePayloadMetadataPhase: IntegrationPhase {
   internal static let emoji = "🏷️"
   internal static let apiName = "zonePayloadMetadata"
 
-  private static let customZoneType = "REGULAR_CUSTOM_ZONE"
+  private static let customZoneType: ZoneType = .regularCustom
   private static let changeFeedPollAttempts = 5
   private static let changeFeedPollDelay: Duration = .seconds(2)
 
@@ -152,8 +152,8 @@ internal struct ZonePayloadMetadataPhase: IntegrationPhase {
     }
     guard zone.zoneType == customZoneType else {
       throw IntegrationTestError.verificationFailed(
-        "\(source) reported zoneType '\(zone.zoneType ?? "nil")' for '\(zone.zoneName)' "
-          + "(expected \(customZoneType))"
+        "\(source) reported zoneType '\(zone.zoneType?.rawValue ?? "nil")' for '\(zone.zoneName)' "
+          + "(expected \(customZoneType.rawValue))"
       )
     }
     guard !zone.deleted else {

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Tests/PrivateDatabaseTest.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Tests/PrivateDatabaseTest.swift
@@ -45,6 +45,7 @@ internal struct PrivateDatabaseTest: PhasedIntegrationTest {
     ModifyZonesPhase(),
     LookupZonePhase(),
     ZoneRoundtripPhase(),
+    ZonePayloadMetadataPhase(),
     UploadAssetPhase(),
     CreateRecordsPhase(),
     RereferenceAssetPhase(),

--- a/Sources/MistKit/Models/ConversionError.swift
+++ b/Sources/MistKit/Models/ConversionError.swift
@@ -62,6 +62,8 @@ public enum ConversionError: LocalizedError, Sendable, Equatable {
   case zoneMissingID
   /// A zone response was missing its `zoneName`.
   case zoneMissingName
+  /// A zone response carried an unrecognized `zoneType` wire value.
+  case unrecognizedZoneType(String)
   /// A user response was missing its `userRecordName`.
   case userMissingRecordName
   /// A subscription response was missing its `subscriptionID`.
@@ -113,6 +115,8 @@ public enum ConversionError: LocalizedError, Sendable, Equatable {
       return "Zone entry missing zoneID"
     case .zoneMissingName:
       return "Zone entry missing zoneName"
+    case .unrecognizedZoneType(let wireValue):
+      return "Zone entry has unrecognized zoneType '\(wireValue)'"
     case .userMissingRecordName:
       return "UserResponse missing userRecordName"
     case .subscriptionMissingID:

--- a/Sources/MistKit/Models/Sharing/ShareRecordInfo.swift
+++ b/Sources/MistKit/Models/Sharing/ShareRecordInfo.swift
@@ -85,7 +85,11 @@ public struct ShareRecordInfo: Codable, Sendable {
     self.containerIdentifier = schema.containerIdentifier
     self.databaseScope = schema.databaseScope.map(ShareDatabaseScope.init(from:))
     self.environment = schema.environment.map(Environment.init(from:))
-    self.zoneID = schema.zoneID.map(ZoneID.init(from:))
+    if let schemaZoneID = schema.zoneID {
+      self.zoneID = try ZoneID(from: schemaZoneID)
+    } else {
+      self.zoneID = nil
+    }
     self.rootRecordName = schema.rootRecordName
     if let rootRecord = schema.rootRecord {
       self.rootRecord = try RecordInfo(from: rootRecord)

--- a/Sources/MistKit/Models/Subscriptions/SubscriptionInfo+Schema.swift
+++ b/Sources/MistKit/Models/Subscriptions/SubscriptionInfo+Schema.swift
@@ -138,6 +138,6 @@ extension SubscriptionInfo {
     guard let zoneName = payload.zoneName else {
       try ConversionError.zoneMissingName.reportAndThrow()
     }
-    return .zone(ZoneID(zoneName: zoneName, ownerName: payload.ownerName))
+    return .zone(ZoneID(zoneName: zoneName, ownerName: payload.ownerRecordName))
   }
 }

--- a/Sources/MistKit/Models/Zones/ZoneChangeResult.swift
+++ b/Sources/MistKit/Models/Zones/ZoneChangeResult.swift
@@ -45,7 +45,12 @@ extension OperationResult where Success == ZoneInfo, Target == ZoneTarget {
     case .ZoneFetchFailure(let failure):
       self = .failure(try ZoneOperationFailure(from: failure))
     case .DatabaseChangedZone(let zone):
-      self = .success(try ZoneInfo(fromZoneID: zone.zoneID))
+      self = .success(
+        try ZoneInfo(
+          fromZoneID: zone.zoneID,
+          deleted: zone.deleted ?? false
+        )
+      )
     }
   }
 

--- a/Sources/MistKit/Models/Zones/ZoneID.swift
+++ b/Sources/MistKit/Models/Zones/ZoneID.swift
@@ -42,14 +42,20 @@ public struct ZoneID: Codable, Sendable, Equatable, Hashable {
   public let zoneName: String
   /// The owner's record name (optional, nil for current user)
   public let ownerName: String?
+  /// The zone's type (e.g. `REGULAR_CUSTOM_ZONE`, `DEFAULT_ZONE`).
+  ///
+  /// `nil` when the server omits the key.
+  public let zoneType: String?
 
   /// Initialize a zone identifier
   /// - Parameters:
   ///   - zoneName: The zone name
   ///   - ownerName: Optional owner record name (nil = current user)
-  public init(zoneName: String, ownerName: String? = nil) {
+  ///   - zoneType: Optional zone type from the wire payload
+  public init(zoneName: String, ownerName: String? = nil, zoneType: String? = nil) {
     self.zoneName = zoneName
     self.ownerName = ownerName
+    self.zoneType = zoneType
   }
 
   /// Lift a zone identifier from the wire schema.
@@ -59,7 +65,8 @@ public struct ZoneID: Codable, Sendable, Equatable, Hashable {
   internal init(from schema: Components.Schemas.ZoneID) {
     self.init(
       zoneName: schema.zoneName ?? ZoneID.defaultZone.zoneName,
-      ownerName: schema.ownerName
+      ownerName: schema.ownerRecordName,
+      zoneType: schema.zoneType
     )
   }
 }
@@ -69,7 +76,8 @@ extension Components.Schemas.ZoneID {
   internal init(from zoneID: ZoneID) {
     self.init(
       zoneName: zoneID.zoneName,
-      ownerName: zoneID.ownerName
+      ownerRecordName: zoneID.ownerName,
+      zoneType: zoneID.zoneType
     )
   }
 }

--- a/Sources/MistKit/Models/Zones/ZoneID.swift
+++ b/Sources/MistKit/Models/Zones/ZoneID.swift
@@ -42,17 +42,17 @@ public struct ZoneID: Codable, Sendable, Equatable, Hashable {
   public let zoneName: String
   /// The owner's record name (optional, nil for current user)
   public let ownerName: String?
-  /// The zone's type (e.g. `REGULAR_CUSTOM_ZONE`, `DEFAULT_ZONE`).
+  /// The zone's type.
   ///
   /// `nil` when the server omits the key.
-  public let zoneType: String?
+  public let zoneType: ZoneType?
 
   /// Initialize a zone identifier
   /// - Parameters:
   ///   - zoneName: The zone name
   ///   - ownerName: Optional owner record name (nil = current user)
   ///   - zoneType: Optional zone type from the wire payload
-  public init(zoneName: String, ownerName: String? = nil, zoneType: String? = nil) {
+  public init(zoneName: String, ownerName: String? = nil, zoneType: ZoneType? = nil) {
     self.zoneName = zoneName
     self.ownerName = ownerName
     self.zoneType = zoneType
@@ -62,11 +62,11 @@ public struct ZoneID: Codable, Sendable, Equatable, Hashable {
   ///
   /// A missing `zoneName` falls back to ``defaultZone``'s name — share
   /// results may omit it when CloudKit only returns an owner.
-  internal init(from schema: Components.Schemas.ZoneID) {
+  internal init(from schema: Components.Schemas.ZoneID) throws(ConversionError) {
     self.init(
       zoneName: schema.zoneName ?? ZoneID.defaultZone.zoneName,
       ownerName: schema.ownerRecordName,
-      zoneType: schema.zoneType
+      zoneType: try ZoneType.fromWire(schema.zoneType)
     )
   }
 }
@@ -77,7 +77,7 @@ extension Components.Schemas.ZoneID {
     self.init(
       zoneName: zoneID.zoneName,
       ownerRecordName: zoneID.ownerName,
-      zoneType: zoneID.zoneType
+      zoneType: zoneID.zoneType?.rawValue
     )
   }
 }

--- a/Sources/MistKit/Models/Zones/ZoneInfo.swift
+++ b/Sources/MistKit/Models/Zones/ZoneInfo.swift
@@ -39,10 +39,10 @@ public struct ZoneInfo: Codable, Sendable {
   /// Note: always empty — CloudKit Web Services zone responses do not include
   /// capabilities in the current OpenAPI schema.
   public let capabilities: [String]
-  /// The zone's type (e.g. `REGULAR_CUSTOM_ZONE`, `DEFAULT_ZONE`).
+  /// The zone's type.
   ///
   /// `nil` when the server omits the key.
-  public let zoneType: String?
+  public let zoneType: ZoneType?
   /// The current point in the zone's change history.
   ///
   /// Present on zone responses that carry Apple's "Zone Dictionary" payload;
@@ -62,7 +62,7 @@ public struct ZoneInfo: Codable, Sendable {
     zoneName: String,
     ownerRecordName: String?,
     capabilities: [String],
-    zoneType: String? = nil,
+    zoneType: ZoneType? = nil,
     syncToken: String? = nil,
     atomic: Bool? = nil,
     deleted: Bool = false
@@ -105,7 +105,7 @@ public struct ZoneInfo: Codable, Sendable {
       zoneName: zoneName,
       ownerRecordName: zoneID.ownerRecordName,
       capabilities: [],
-      zoneType: zoneID.zoneType,
+      zoneType: try ZoneType.fromWire(zoneID.zoneType),
       syncToken: syncToken,
       atomic: atomic,
       deleted: deleted

--- a/Sources/MistKit/Models/Zones/ZoneInfo.swift
+++ b/Sources/MistKit/Models/Zones/ZoneInfo.swift
@@ -39,6 +39,10 @@ public struct ZoneInfo: Codable, Sendable {
   /// Note: always empty — CloudKit Web Services zone responses do not include
   /// capabilities in the current OpenAPI schema.
   public let capabilities: [String]
+  /// The zone's type (e.g. `REGULAR_CUSTOM_ZONE`, `DEFAULT_ZONE`).
+  ///
+  /// `nil` when the server omits the key.
+  public let zoneType: String?
   /// The current point in the zone's change history.
   ///
   /// Present on zone responses that carry Apple's "Zone Dictionary" payload;
@@ -49,20 +53,27 @@ public struct ZoneInfo: Codable, Sendable {
   /// `nil` when the server omits the key — deliberately *not* defaulted to
   /// `false`, so "absent" stays distinguishable from "explicitly not atomic".
   public let atomic: Bool?
+  /// When `true`, this is a tombstone entry from a zone change feed —
+  /// the zone was deleted and should be removed from local storage.
+  public let deleted: Bool
 
   /// Initialize zone information
   public init(
     zoneName: String,
     ownerRecordName: String?,
     capabilities: [String],
+    zoneType: String? = nil,
     syncToken: String? = nil,
-    atomic: Bool? = nil
+    atomic: Bool? = nil,
+    deleted: Bool = false
   ) {
     self.zoneName = zoneName
     self.ownerRecordName = ownerRecordName
     self.capabilities = capabilities
+    self.zoneType = zoneType
     self.syncToken = syncToken
     self.atomic = atomic
+    self.deleted = deleted
   }
 
   /// Convert a CloudKit zone payload's `zoneID` into a `ZoneInfo`.
@@ -81,7 +92,8 @@ public struct ZoneInfo: Codable, Sendable {
   internal init(
     fromZoneID zoneID: Components.Schemas.ZoneID?,
     syncToken: String? = nil,
-    atomic: Bool? = nil
+    atomic: Bool? = nil,
+    deleted: Bool = false
   ) throws(ConversionError) {
     guard let zoneID else {
       try ConversionError.zoneMissingID.reportAndThrow()
@@ -91,20 +103,23 @@ public struct ZoneInfo: Codable, Sendable {
     }
     self.init(
       zoneName: zoneName,
-      ownerRecordName: zoneID.ownerName,
+      ownerRecordName: zoneID.ownerRecordName,
       capabilities: [],
+      zoneType: zoneID.zoneType,
       syncToken: syncToken,
-      atomic: atomic
+      atomic: atomic,
+      deleted: deleted
     )
   }
 
   /// Convert a CloudKit `Zone` payload into a `ZoneInfo`, carrying the
-  /// zone-level metadata (`syncToken`, `atomic`) alongside the identity.
+  /// zone-level metadata (`syncToken`, `atomic`, `deleted`) alongside the identity.
   internal init(from zone: Components.Schemas.Zone) throws(ConversionError) {
     try self.init(
       fromZoneID: zone.zoneID,
       syncToken: zone.syncToken,
-      atomic: zone.atomic
+      atomic: zone.atomic,
+      deleted: zone.deleted ?? false
     )
   }
 }

--- a/Sources/MistKit/Models/Zones/ZoneType.swift
+++ b/Sources/MistKit/Models/Zones/ZoneType.swift
@@ -1,0 +1,55 @@
+//
+//  ZoneType.swift
+//  MistKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+/// The zone's type as reported on the CloudKit Web Services wire.
+///
+/// Live responses use exactly two values: the database default zone
+/// (``defaultZone``) and every other zone (``regularCustom``). The key is
+/// optional — callers may omit it on requests.
+public enum ZoneType: String, Codable, Sendable, Equatable, Hashable, CaseIterable {
+  /// `_defaultZone` in public or private databases.
+  case defaultZone = "DEFAULT_ZONE"
+  /// User-created custom zones, Core Data mirroring zones, and shared-database zones.
+  case regularCustom = "REGULAR_CUSTOM_ZONE"
+}
+
+// MARK: - Internal Conversion
+extension ZoneType {
+  /// Maps an optional wire string to a domain value.
+  ///
+  /// `nil` stays `nil`. Any other unrecognized string throws
+  /// ``ConversionError/unrecognizedZoneType(_:)``.
+  internal static func fromWire(_ wire: String?) throws(ConversionError) -> ZoneType? {
+    guard let wire else { return nil }
+    guard let value = ZoneType(rawValue: wire) else {
+      throw ConversionError.unrecognizedZoneType(wire)
+    }
+    return value
+  }
+}

--- a/Sources/MistKitOpenAPI/Types.swift
+++ b/Sources/MistKitOpenAPI/Types.swift
@@ -765,23 +765,35 @@ public enum Components {
         public struct ZoneID: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/ZoneID/zoneName`.
             public var zoneName: Swift.String?
-            /// - Remark: Generated from `#/components/schemas/ZoneID/ownerName`.
-            public var ownerName: Swift.String?
+            /// The zone owner's user record name. Use this key to identify a zone owned by another user (e.g. a shared zone).
+            ///
+            ///
+            /// - Remark: Generated from `#/components/schemas/ZoneID/ownerRecordName`.
+            public var ownerRecordName: Swift.String?
+            /// The zone's type. Live responses carry values such as `REGULAR_CUSTOM_ZONE` and `DEFAULT_ZONE`.
+            ///
+            ///
+            /// - Remark: Generated from `#/components/schemas/ZoneID/zoneType`.
+            public var zoneType: Swift.String?
             /// Creates a new `ZoneID`.
             ///
             /// - Parameters:
             ///   - zoneName:
-            ///   - ownerName:
+            ///   - ownerRecordName: The zone owner's user record name. Use this key to identify a zone owned by another user (e.g. a shared zone).
+            ///   - zoneType: The zone's type. Live responses carry values such as `REGULAR_CUSTOM_ZONE` and `DEFAULT_ZONE`.
             public init(
                 zoneName: Swift.String? = nil,
-                ownerName: Swift.String? = nil
+                ownerRecordName: Swift.String? = nil,
+                zoneType: Swift.String? = nil
             ) {
                 self.zoneName = zoneName
-                self.ownerName = ownerName
+                self.ownerRecordName = ownerRecordName
+                self.zoneType = zoneType
             }
             public enum CodingKeys: String, CodingKey {
                 case zoneName
-                case ownerName
+                case ownerRecordName
+                case zoneType
             }
         }
         /// - Remark: Generated from `#/components/schemas/Filter`.
@@ -2254,7 +2266,7 @@ public enum Components {
                 case moreComing
             }
         }
-        /// A record zone as returned by the zone endpoints (`zones/list`, `zones/lookup`, `zones/modify`, `zones/changes`). Matches the "Zone Dictionary" in Apple's archived CloudKit Web Services Reference, which documents exactly three keys: `zoneID`, `syncToken`, and `atomic`. `isEager` is deliberately absent — it appears in no primary Apple source (see issue #386).
+        /// A record zone as returned by the zone endpoints (`zones/list`, `zones/lookup`, `zones/modify`, `zones/changes`). The archived "Zone Dictionary" documents `zoneID`, `syncToken`, and `atomic`; live change feeds also carry `deleted` (issue #444). `isEager` is deliberately absent — it appears in no primary Apple source (see issue #386).
         ///
         ///
         /// - Remark: Generated from `#/components/schemas/Zone`.
@@ -2270,25 +2282,34 @@ public enum Components {
             ///
             /// - Remark: Generated from `#/components/schemas/Zone/atomic`.
             public var atomic: Swift.Bool?
+            /// When `true`, the zone was deleted. Present on change-feed responses (`zones/changes`); absent on list/lookup/modify success payloads.
+            ///
+            ///
+            /// - Remark: Generated from `#/components/schemas/Zone/deleted`.
+            public var deleted: Swift.Bool?
             /// Creates a new `Zone`.
             ///
             /// - Parameters:
             ///   - zoneID:
             ///   - syncToken: The current point in the zone's change history.
             ///   - atomic: A Boolean value indicating whether this zone supports atomic operations.
+            ///   - deleted: When `true`, the zone was deleted. Present on change-feed responses (`zones/changes`); absent on list/lookup/modify success payloads.
             public init(
                 zoneID: Components.Schemas.ZoneID? = nil,
                 syncToken: Swift.String? = nil,
-                atomic: Swift.Bool? = nil
+                atomic: Swift.Bool? = nil,
+                deleted: Swift.Bool? = nil
             ) {
                 self.zoneID = zoneID
                 self.syncToken = syncToken
                 self.atomic = atomic
+                self.deleted = deleted
             }
             public enum CodingKeys: String, CodingKey {
                 case zoneID
                 case syncToken
                 case atomic
+                case deleted
             }
         }
         /// - Remark: Generated from `#/components/schemas/ZonesListResponse`.
@@ -2495,21 +2516,33 @@ public enum Components {
                 case moreComing
             }
         }
-        /// A zone that changed, as returned by `changes/database`.
+        /// A zone that changed, as returned by `changes/database`. Carries the same tombstone shape as `zones/changes` — `deleted: true` when the zone was removed (issue #444).
+        ///
         ///
         /// - Remark: Generated from `#/components/schemas/DatabaseChangedZone`.
         public struct DatabaseChangedZone: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/DatabaseChangedZone/zoneID`.
             public var zoneID: Components.Schemas.ZoneID?
+            /// When `true`, the zone was deleted and should be removed from local storage.
+            ///
+            ///
+            /// - Remark: Generated from `#/components/schemas/DatabaseChangedZone/deleted`.
+            public var deleted: Swift.Bool?
             /// Creates a new `DatabaseChangedZone`.
             ///
             /// - Parameters:
             ///   - zoneID:
-            public init(zoneID: Components.Schemas.ZoneID? = nil) {
+            ///   - deleted: When `true`, the zone was deleted and should be removed from local storage.
+            public init(
+                zoneID: Components.Schemas.ZoneID? = nil,
+                deleted: Swift.Bool? = nil
+            ) {
                 self.zoneID = zoneID
+                self.deleted = deleted
             }
             public enum CodingKeys: String, CodingKey {
                 case zoneID
+                case deleted
             }
         }
         /// Per-zone error returned inline in the `zones` array of a 200 zone

--- a/Tests/MistKitTests/CloudKitService/CreateZone/CloudKitServiceTests.CreateZone+ErrorHandling.swift
+++ b/Tests/MistKitTests/CloudKitService/CreateZone/CloudKitServiceTests.CreateZone+ErrorHandling.swift
@@ -59,7 +59,7 @@ extension CloudKitServiceTests.CreateZone {
       }
       let service = try CloudKitServiceTests.ModifyZones.makeService(zones: [
         [
-          "zoneID": ["zoneName": "Articles", "ownerName": "_defaultOwner"],
+          "zoneID": ["zoneName": "Articles", "ownerRecordName": "_defaultOwner"],
           "serverErrorCode": "EXISTS",
           "reason": "Zone already exists",
         ]

--- a/Tests/MistKitTests/CloudKitService/DeleteZone/CloudKitServiceTests.DeleteZone+ErrorHandling.swift
+++ b/Tests/MistKitTests/CloudKitService/DeleteZone/CloudKitServiceTests.DeleteZone+ErrorHandling.swift
@@ -43,7 +43,7 @@ extension CloudKitServiceTests.DeleteZone {
       }
       let service = try CloudKitServiceTests.ModifyZones.makeService(zones: [
         [
-          "zoneID": ["zoneName": "Missing", "ownerName": "_defaultOwner"],
+          "zoneID": ["zoneName": "Missing", "ownerRecordName": "_defaultOwner"],
           "serverErrorCode": "ZONE_NOT_FOUND",
           "reason": "Zone does not exist",
         ]

--- a/Tests/MistKitTests/CloudKitService/FetchDatabaseChanges/CloudKitServiceTests.FetchDatabaseChanges+Helpers.swift
+++ b/Tests/MistKitTests/CloudKitService/FetchDatabaseChanges/CloudKitServiceTests.FetchDatabaseChanges+Helpers.swift
@@ -115,7 +115,7 @@ extension ResponseConfig {
       [
         "zoneID": [
           "zoneName": "test-zone-\(index)",
-          "ownerName": "_defaultOwner",
+          "ownerRecordName": "_defaultOwner",
         ]
       ]
     }

--- a/Tests/MistKitTests/CloudKitService/FetchDatabaseChanges/CloudKitServiceTests.FetchDatabaseChanges+SuccessCases.swift
+++ b/Tests/MistKitTests/CloudKitService/FetchDatabaseChanges/CloudKitServiceTests.FetchDatabaseChanges+SuccessCases.swift
@@ -106,9 +106,9 @@ extension CloudKitServiceTests.FetchDatabaseChanges {
       let service = try Harness.makeService(
         provider: ResponseProvider(
           defaultResponse: try .databaseChangesResponse(zones: [
-            ["zoneID": ["zoneName": "good-zone", "ownerName": "_defaultOwner"]],
+            ["zoneID": ["zoneName": "good-zone", "ownerRecordName": "_defaultOwner"]],
             [
-              "zoneID": ["zoneName": "bad-zone", "ownerName": "_defaultOwner"],
+              "zoneID": ["zoneName": "bad-zone", "ownerRecordName": "_defaultOwner"],
               "serverErrorCode": "ZONE_NOT_FOUND",
               "reason": "Zone does not exist",
             ],
@@ -137,7 +137,7 @@ extension CloudKitServiceTests.FetchDatabaseChanges {
         provider: ResponseProvider(
           defaultResponse: try .databaseChangesResponse(zones: [
             [
-              "zoneID": ["zoneName": "bad-zone", "ownerName": "_defaultOwner"],
+              "zoneID": ["zoneName": "bad-zone", "ownerRecordName": "_defaultOwner"],
               "serverErrorCode": "ZONE_NOT_FOUND",
             ]
           ])

--- a/Tests/MistKitTests/CloudKitService/FetchRecordZoneChanges/CloudKitServiceTests.FetchRecordZoneChanges+Helpers.swift
+++ b/Tests/MistKitTests/CloudKitService/FetchRecordZoneChanges/CloudKitServiceTests.FetchRecordZoneChanges+Helpers.swift
@@ -66,7 +66,7 @@ extension CloudKitServiceTests.FetchRecordZoneChanges {
       ]
     }
     return [
-      "zoneID": ["zoneName": zoneName, "ownerName": "_defaultOwner"],
+      "zoneID": ["zoneName": zoneName, "ownerRecordName": "_defaultOwner"],
       "records": records,
       "syncToken": syncToken,
       "moreComing": moreComing,
@@ -80,7 +80,7 @@ extension CloudKitServiceTests.FetchRecordZoneChanges {
     reason: String = "Zone does not exist"
   ) -> [String: Any] {
     [
-      "zoneID": ["zoneName": zoneName, "ownerName": "_defaultOwner"],
+      "zoneID": ["zoneName": zoneName, "ownerRecordName": "_defaultOwner"],
       "serverErrorCode": serverErrorCode,
       "reason": reason,
     ]

--- a/Tests/MistKitTests/CloudKitService/FetchZoneChanges/CloudKitServiceTests.FetchZoneChanges+Helpers.swift
+++ b/Tests/MistKitTests/CloudKitService/FetchZoneChanges/CloudKitServiceTests.FetchZoneChanges+Helpers.swift
@@ -95,7 +95,7 @@ extension ResponseConfig {
       zones.append([
         "zoneID": [
           "zoneName": "test-zone-\(index)",
-          "ownerName": "_defaultOwner",
+          "ownerRecordName": "_defaultOwner",
         ]
       ])
     }
@@ -143,7 +143,7 @@ extension ResponseConfig {
           {
             "zoneID": {
               "zoneName": "valid-zone",
-              "ownerName": "_defaultOwner"
+              "ownerRecordName": "_defaultOwner"
             }
           },
           {}

--- a/Tests/MistKitTests/CloudKitService/LookupZones/CloudKitServiceTests.LookupZones+Helpers.swift
+++ b/Tests/MistKitTests/CloudKitService/LookupZones/CloudKitServiceTests.LookupZones+Helpers.swift
@@ -53,8 +53,8 @@ extension CloudKitServiceTests.LookupZones {
     let responseJSON = """
       {
         "zones": [
-          { "zoneID": { "zoneName": "valid-zone", "ownerName": "_defaultOwner" } },
-          { "zoneID": { "ownerName": "_defaultOwner" } }
+          { "zoneID": { "zoneName": "valid-zone", "ownerRecordName": "_defaultOwner" } },
+          { "zoneID": { "ownerRecordName": "_defaultOwner" } }
         ]
       }
       """
@@ -90,7 +90,7 @@ extension ResponseConfig {
       zones.append([
         "zoneID": [
           "zoneName": "test-zone-\(index)",
-          "ownerName": "_defaultOwner",
+          "ownerRecordName": "_defaultOwner",
         ]
       ])
     }

--- a/Tests/MistKitTests/CloudKitService/ModifyZones/CloudKitServiceTests.ModifyZones+ErrorHandling.swift
+++ b/Tests/MistKitTests/CloudKitService/ModifyZones/CloudKitServiceTests.ModifyZones+ErrorHandling.swift
@@ -44,9 +44,9 @@ extension CloudKitServiceTests.ModifyZones {
         return
       }
       let service = try Harness.makeService(zones: [
-        ["zoneID": ["zoneName": "good-zone", "ownerName": "_defaultOwner"]],
+        ["zoneID": ["zoneName": "good-zone", "ownerRecordName": "_defaultOwner"]],
         [
-          "zoneID": ["zoneName": "bad-zone", "ownerName": "_defaultOwner"],
+          "zoneID": ["zoneName": "bad-zone", "ownerRecordName": "_defaultOwner"],
           "serverErrorCode": "ZONE_NOT_FOUND",
           "reason": "Zone does not exist",
         ],
@@ -77,7 +77,7 @@ extension CloudKitServiceTests.ModifyZones {
       }
       let service = try Harness.makeService(zones: [
         [
-          "zoneID": ["zoneName": "bad-zone", "ownerName": "_defaultOwner"],
+          "zoneID": ["zoneName": "bad-zone", "ownerRecordName": "_defaultOwner"],
           "serverErrorCode": "ZONE_NOT_FOUND",
         ]
       ])
@@ -108,7 +108,7 @@ extension CloudKitServiceTests.ModifyZones {
       }
       let service = try Harness.makeService(zones: [
         [
-          "zoneID": ["zoneName": "good-zone", "ownerName": "_defaultOwner"],
+          "zoneID": ["zoneName": "good-zone", "ownerRecordName": "_defaultOwner"],
           "syncToken": "zone-token",
           "atomic": true,
         ]

--- a/Tests/MistKitTests/CloudKitService/ModifyZones/CloudKitServiceTests.ModifyZones+Helpers.swift
+++ b/Tests/MistKitTests/CloudKitService/ModifyZones/CloudKitServiceTests.ModifyZones+Helpers.swift
@@ -81,7 +81,7 @@ extension ResponseConfig {
         [
           "zoneID": [
             "zoneName": "modified-zone-\(index)",
-            "ownerName": "_defaultOwner",
+            "ownerRecordName": "_defaultOwner",
           ]
         ]
       }

--- a/Tests/MistKitTests/CloudKitService/Query/CloudKitServiceTests.Query+ZoneID.swift
+++ b/Tests/MistKitTests/CloudKitService/Query/CloudKitServiceTests.Query+ZoneID.swift
@@ -94,7 +94,7 @@ extension CloudKitServiceTests.Query {
       let body = try await Self.sentBody(for: "queryRecords", from: provider)
       let zoneID = try #require(body["zoneID"] as? [String: Any])
       #expect(zoneID["zoneName"] as? String == "CustomZone")
-      #expect(zoneID["ownerName"] == nil)
+      #expect(zoneID["ownerRecordName"] == nil)
     }
 
     @Test("queryRecords() forwards a shared zone's ownerName")
@@ -111,7 +111,7 @@ extension CloudKitServiceTests.Query {
       let body = try await Self.sentBody(for: "queryRecords", from: provider)
       let zoneID = try #require(body["zoneID"] as? [String: Any])
       #expect(zoneID["zoneName"] as? String == "SharedZone")
-      #expect(zoneID["ownerName"] as? String == "_owner-record-name")
+      #expect(zoneID["ownerRecordName"] as? String == "_owner-record-name")
     }
 
     @Test("queryRecords() forwards ZoneID.defaultZone explicitly when asked")
@@ -156,7 +156,7 @@ extension CloudKitServiceTests.Query {
         let body = try await Self.sentBody(for: "queryRecords", from: provider, at: index)
         let zoneID = try #require(body["zoneID"] as? [String: Any])
         #expect(zoneID["zoneName"] as? String == "CustomZone")
-        #expect(zoneID["ownerName"] as? String == "_owner-record-name")
+        #expect(zoneID["ownerRecordName"] as? String == "_owner-record-name")
       }
     }
 

--- a/Tests/MistKitTests/CloudKitService/Sharing/CloudKitServiceTests.Sharing+Helpers.swift
+++ b/Tests/MistKitTests/CloudKitService/Sharing/CloudKitServiceTests.Sharing+Helpers.swift
@@ -88,7 +88,7 @@ extension CloudKitServiceTests.Sharing {
       "containerIdentifier": TestConstants.serviceContainerIdentifier,
       "databaseScope": "SHARED",
       "environment": "development",
-      "zoneID": ["zoneName": "SharedZone", "ownerName": "_owner"],
+      "zoneID": ["zoneName": "SharedZone", "ownerRecordName": "_owner"],
       "rootRecordName": "root-\(value)",
       "share": shareRecord(for: value),
       "ownerIdentity": [

--- a/Tests/MistKitTests/CloudKitService/Subscriptions/CloudKitServiceTests.Subscriptions+Helpers.swift
+++ b/Tests/MistKitTests/CloudKitService/Subscriptions/CloudKitServiceTests.Subscriptions+Helpers.swift
@@ -47,7 +47,7 @@ extension CloudKitServiceTests.Subscriptions {
         {
           "subscriptionID": "zone-sub",
           "subscriptionType": "zone",
-          "zoneID": { "zoneName": "Photos", "ownerName": "_defaultOwner" },
+          "zoneID": { "zoneName": "Photos", "ownerRecordName": "_defaultOwner" },
           "firesOn": ["create", "update", "delete"]
         }
       ]

--- a/Tests/MistKitTests/CloudKitService/Zones/CloudKitServiceTests.ZoneOwnerWireKey+WireFormat.swift
+++ b/Tests/MistKitTests/CloudKitService/Zones/CloudKitServiceTests.ZoneOwnerWireKey+WireFormat.swift
@@ -1,0 +1,115 @@
+//
+//  CloudKitServiceTests.ZoneOwnerWireKey+WireFormat.swift
+//  MistKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+internal import Foundation
+internal import Testing
+
+@testable import MistKit
+
+extension CloudKitServiceTests.ZoneOwnerWireKey {
+  /// Pins the on-the-wire owner key inside `zoneID` objects (issue #444).
+  ///
+  /// Apple's Zone ID Dictionary and live responses use `ownerRecordName`, not
+  /// the mistaken `ownerName` key MistKit previously emitted.
+  @Suite("ZoneID Wire Format")
+  internal struct WireFormat {
+    private static let database: Database = .private
+
+    private static func makeService(
+      _ provider: ResponseProvider
+    ) throws -> CloudKitService {
+      try CloudKitService(
+        containerIdentifier: TestConstants.serviceContainerIdentifier,
+        credentials: Credentials(
+          apiAuth: APICredentials(
+            apiToken: TestConstants.apiToken,
+            webAuthToken: TestConstants.webAuthToken
+          )
+        ),
+        transport: MockTransport(responseProvider: provider)
+      )
+    }
+
+    private static func sentBody(
+      for operationID: String,
+      from provider: ResponseProvider,
+      at index: Int = 0
+    ) async throws -> [String: Any] {
+      let bodies = await provider.bodies(for: operationID).compactMap { $0 }
+      let data = try #require(bodies.dropFirst(index).first)
+      return try #require(
+        try JSONSerialization.jsonObject(with: data) as? [String: Any]
+      )
+    }
+
+    @Test("queryRecords() encodes ownerRecordName, never ownerName")
+    internal func queryEncodesOwnerRecordName() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let provider = ResponseProvider.successfulQuery()
+      let service = try Self.makeService(provider)
+
+      _ = try await service.queryRecords(
+        MistKit.Query(recordType: "TestRecord"),
+        zoneID: ZoneID(zoneName: "SharedZone", ownerName: "_owner-record-name"),
+        database: Self.database
+      )
+
+      let body = try await Self.sentBody(for: "queryRecords", from: provider)
+      let zoneID = try #require(body["zoneID"] as? [String: Any])
+      #expect(zoneID["ownerRecordName"] as? String == "_owner-record-name")
+      #expect(zoneID["ownerName"] == nil)
+    }
+
+    @Test("modifyZones() encodes ownerRecordName inside each operation's zoneID")
+    internal func modifyZonesEncodesOwnerRecordName() async throws {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let provider = try ResponseProvider.successfulModifyZones(zoneCount: 1)
+      let service = try Self.makeService(provider)
+
+      _ = try await service.modifyZones(
+        [.create(ZoneID(zoneName: "Shared", ownerName: "other-user"))],
+        database: Self.database
+      )
+
+      let body = try await Self.sentBody(for: "modifyZones", from: provider)
+      let operations = try #require(body["operations"] as? [[String: Any]])
+      let operation = try #require(operations.first)
+      let zone = try #require(operation["zone"] as? [String: Any])
+      let zoneID = try #require(zone["zoneID"] as? [String: Any])
+      #expect(zoneID["ownerRecordName"] as? String == "other-user")
+      #expect(zoneID["ownerName"] == nil)
+    }
+  }
+}

--- a/Tests/MistKitTests/CloudKitService/Zones/CloudKitServiceTests.ZoneOwnerWireKey.swift
+++ b/Tests/MistKitTests/CloudKitService/Zones/CloudKitServiceTests.ZoneOwnerWireKey.swift
@@ -1,0 +1,32 @@
+//
+//  CloudKitServiceTests.ZoneOwnerWireKey.swift
+//  MistKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+extension CloudKitServiceTests {
+  internal enum ZoneOwnerWireKey {}
+}

--- a/Tests/MistKitTests/Models/Subscriptions/SubscriptionConversionTests.swift
+++ b/Tests/MistKitTests/Models/Subscriptions/SubscriptionConversionTests.swift
@@ -88,7 +88,7 @@ internal struct SubscriptionConversionTests {
     let schema = info.schema
     #expect(schema.subscriptionType == .zone)
     #expect(schema.zoneID?.zoneName == "Photos")
-    #expect(schema.zoneID?.ownerName == "_owner")
+    #expect(schema.zoneID?.ownerRecordName == "_owner")
     #expect(schema.query == nil)
     // Zone subscriptions don't carry firesOn — only `.query` does.
     #expect(schema.firesOn == nil)
@@ -143,7 +143,7 @@ internal struct SubscriptionConversionTests {
     let payload = Components.Schemas.Subscription(
       subscriptionID: "z",
       subscriptionType: .zone,
-      zoneID: Components.Schemas.ZoneID(ownerName: "_owner")
+      zoneID: Components.Schemas.ZoneID(ownerRecordName: "_owner")
     )
     expectThrow(ConversionError.zoneMissingName) {
       _ = try SubscriptionInfo(from: payload)

--- a/Tests/MistKitTests/Models/Zones/ZoneMetadataTests+Responses.swift
+++ b/Tests/MistKitTests/Models/Zones/ZoneMetadataTests+Responses.swift
@@ -129,7 +129,7 @@ extension ZoneMetadataTests {
           {
             "zones": [
               {
-                "zoneID": { "zoneName": "Articles", "ownerName": "_defaultOwner" },
+                "zoneID": { "zoneName": "Articles", "ownerRecordName": "_defaultOwner" },
                 "syncToken": "lookup-token",
                 "atomic": true
               }

--- a/Tests/MistKitTests/Models/Zones/ZoneMetadataTests+ZoneInfoConversion.swift
+++ b/Tests/MistKitTests/Models/Zones/ZoneMetadataTests+ZoneInfoConversion.swift
@@ -47,7 +47,7 @@ extension ZoneMetadataTests {
       let zone = try Self.decodeZone(
         """
         {
-          "zoneID": { "zoneName": "Articles", "ownerName": "_defaultOwner" },
+          "zoneID": { "zoneName": "Articles", "ownerRecordName": "_defaultOwner" },
           "syncToken": "AQAAAAAAAAAB",
           "atomic": true
         }
@@ -64,7 +64,7 @@ extension ZoneMetadataTests {
       let zone = try Self.decodeZone(
         """
         {
-          "zoneID": { "zoneName": "Articles", "ownerName": "_defaultOwner" },
+          "zoneID": { "zoneName": "Articles", "ownerRecordName": "_defaultOwner" },
           "syncToken": "AQAAAAAAAAAB",
           "atomic": true
         }
@@ -77,6 +77,74 @@ extension ZoneMetadataTests {
       #expect(info.ownerRecordName == "_defaultOwner")
       #expect(info.syncToken == "AQAAAAAAAAAB")
       #expect(info.atomic == true)
+      #expect(info.deleted == false)
+    }
+
+    @Test(
+      "ZoneInfo decodes live-shaped change-feed payload with ownerRecordName, zoneType, and deleted"
+    )
+    internal func zoneInfoDecodesLiveChangeFeedShape() throws {
+      let zone = try Self.decodeZone(
+        """
+        {
+          "zoneID": {
+            "zoneName": "WebChangeTest",
+            "ownerRecordName": "_aca0fa3547ae9f9cd1f7e25fed948a20",
+            "zoneType": "REGULAR_CUSTOM_ZONE"
+          },
+          "deleted": true
+        }
+        """
+      )
+
+      let info = try ZoneInfo(from: zone)
+
+      #expect(info.zoneName == "WebChangeTest")
+      #expect(info.ownerRecordName == "_aca0fa3547ae9f9cd1f7e25fed948a20")
+      #expect(info.zoneType == "REGULAR_CUSTOM_ZONE")
+      #expect(info.deleted == true)
+    }
+
+    @Test("Absent deleted defaults to false rather than collapsing into nil")
+    internal func absentDeletedDefaultsFalse() throws {
+      let zone = try Self.decodeZone(
+        """
+        {
+          "zoneID": { "zoneName": "Articles", "ownerRecordName": "_defaultOwner" }
+        }
+        """
+      )
+
+      let info = try ZoneInfo(from: zone)
+
+      #expect(info.deleted == false)
+    }
+
+    @Test("DatabaseChangedZone tombstone surfaces deleted on ZoneInfo")
+    internal func databaseChangedZoneDeletedSurfaces() throws {
+      let item = try JSONDecoder().decode(
+        Components.Schemas.DatabaseChangesResponse.zonesPayloadPayload.self,
+        from: Data(
+          """
+          {
+            "zoneID": {
+              "zoneName": "WebChangeTest",
+              "ownerRecordName": "_aca0fa3547ae9f9cd1f7e25fed948a20",
+              "zoneType": "REGULAR_CUSTOM_ZONE"
+            },
+            "deleted": true
+          }
+          """.utf8
+        )
+      )
+
+      let result = try ZoneChangeResult(from: item)
+      let zone = try result.get()
+
+      #expect(zone.zoneName == "WebChangeTest")
+      #expect(zone.ownerRecordName == "_aca0fa3547ae9f9cd1f7e25fed948a20")
+      #expect(zone.zoneType == "REGULAR_CUSTOM_ZONE")
+      #expect(zone.deleted == true)
     }
 
     @Test("Absent metadata stays nil rather than defaulting")
@@ -113,7 +181,7 @@ extension ZoneMetadataTests {
     internal func missingZoneNameThrows() throws {
       let zone = try Self.decodeZone(
         """
-        { "zoneID": { "ownerName": "_defaultOwner" }, "atomic": true }
+        { "zoneID": { "ownerRecordName": "_defaultOwner" }, "atomic": true }
         """
       )
 

--- a/Tests/MistKitTests/Models/Zones/ZoneMetadataTests+ZoneInfoConversion.swift
+++ b/Tests/MistKitTests/Models/Zones/ZoneMetadataTests+ZoneInfoConversion.swift
@@ -101,7 +101,7 @@ extension ZoneMetadataTests {
 
       #expect(info.zoneName == "WebChangeTest")
       #expect(info.ownerRecordName == "_aca0fa3547ae9f9cd1f7e25fed948a20")
-      #expect(info.zoneType == "REGULAR_CUSTOM_ZONE")
+      #expect(info.zoneType == .regularCustom)
       #expect(info.deleted == true)
     }
 
@@ -143,8 +143,49 @@ extension ZoneMetadataTests {
 
       #expect(zone.zoneName == "WebChangeTest")
       #expect(zone.ownerRecordName == "_aca0fa3547ae9f9cd1f7e25fed948a20")
-      #expect(zone.zoneType == "REGULAR_CUSTOM_ZONE")
+      #expect(zone.zoneType == .regularCustom)
       #expect(zone.deleted == true)
+    }
+
+    @Test("Unrecognized zoneType throws ConversionError")
+    internal func unrecognizedZoneTypeThrows() throws {
+      let zone = try Self.decodeZone(
+        """
+        {
+          "zoneID": {
+            "zoneName": "Articles",
+            "zoneType": "SHARED_ZONE"
+          }
+        }
+        """
+      )
+
+      ConversionFailureReporter.$assertionHandler.withValue(
+        { _, _, _ in },
+        operation: {
+          #expect(throws: ConversionError.unrecognizedZoneType("SHARED_ZONE")) {
+            _ = try ZoneInfo(from: zone)
+          }
+        }
+      )
+    }
+
+    @Test("DEFAULT_ZONE decodes to ZoneType.defaultZone")
+    internal func defaultZoneTypeDecodes() throws {
+      let zone = try Self.decodeZone(
+        """
+        {
+          "zoneID": {
+            "zoneName": "_defaultZone",
+            "zoneType": "DEFAULT_ZONE"
+          }
+        }
+        """
+      )
+
+      let info = try ZoneInfo(from: zone)
+
+      #expect(info.zoneType == .defaultZone)
     }
 
     @Test("Absent metadata stays nil rather than defaulting")

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1352,8 +1352,16 @@ components:
       properties:
         zoneName:
           type: string
-        ownerName:
+        ownerRecordName:
           type: string
+          description: >
+            The zone owner's user record name. Use this key to identify a zone
+            owned by another user (e.g. a shared zone).
+        zoneType:
+          type: string
+          description: >
+            The zone's type. Live responses carry values such as
+            `REGULAR_CUSTOM_ZONE` and `DEFAULT_ZONE`.
 
     Filter:
       type: object
@@ -1848,11 +1856,11 @@ components:
       type: object
       description: >
         A record zone as returned by the zone endpoints (`zones/list`,
-        `zones/lookup`, `zones/modify`, `zones/changes`). Matches the
-        "Zone Dictionary" in Apple's archived CloudKit Web Services
-        Reference, which documents exactly three keys: `zoneID`,
-        `syncToken`, and `atomic`. `isEager` is deliberately absent — it
-        appears in no primary Apple source (see issue #386).
+        `zones/lookup`, `zones/modify`, `zones/changes`). The archived
+        "Zone Dictionary" documents `zoneID`, `syncToken`, and `atomic`;
+        live change feeds also carry `deleted` (issue #444). `isEager` is
+        deliberately absent — it appears in no primary Apple source (see
+        issue #386).
       properties:
         zoneID:
           $ref: '#/components/schemas/ZoneID'
@@ -1864,6 +1872,12 @@ components:
           description: >
             A Boolean value indicating whether this zone supports atomic
             operations.
+        deleted:
+          type: boolean
+          description: >
+            When `true`, the zone was deleted. Present on change-feed
+            responses (`zones/changes`); absent on list/lookup/modify
+            success payloads.
 
     ZonesListResponse:
       type: object
@@ -1946,10 +1960,18 @@ components:
 
     DatabaseChangedZone:
       type: object
-      description: A zone that changed, as returned by `changes/database`.
+      description: >
+        A zone that changed, as returned by `changes/database`. Carries the
+        same tombstone shape as `zones/changes` — `deleted: true` when the
+        zone was removed (issue #444).
       properties:
         zoneID:
           $ref: '#/components/schemas/ZoneID'
+        deleted:
+          type: boolean
+          description: >
+            When `true`, the zone was deleted and should be removed from
+            local storage.
 
     ZoneFetchFailure:
       type: object


### PR DESCRIPTION
## Summary

Fixes #444. Live zone responses carry `ownerRecordName`, `zoneType`, and (on change feeds) `deleted`, but MistKit was silently dropping them — most critically `ownerRecordName` (the spec used the wrong wire key `ownerName`) and `deleted` (deleted zones were indistinguishable from live ones in change feeds).

- Rename the `ZoneID` wire key to `ownerRecordName` and add optional `zoneType` in `openapi.yaml`; regenerate `MistKitOpenAPI`
- Surface `zoneType` and `deleted` on `ZoneInfo` (`deleted` defaults to `false`, matching `RecordInfo`)
- Thread `deleted` through `DatabaseChangedZone` → `ZoneChangeResult` conversion
- Add unit tests (decode + request wire-format) and a MistDemo `ZonePayloadMetadataPhase` integration phase on the private database pipeline

## Test plan

- [x] `swift build`
- [x] `swift test` (636 tests)
- [x] `mise exec -- swiftlint`
- [x] `cd Examples/MistDemo && swift build`
- [x] `cd Examples/MistDemo && swift run mistdemo test-private` (live container — exercises `ZonePayloadMetadataPhase`)


Made with [Cursor](https://cursor.com)