### PR TITLE
MistDemo web: zoneName/zoneOwner on query panel (#438)

### DIFF
--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/index.html
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/index.html
@@ -64,6 +64,14 @@
                             <label for="query-limit">Limit</label>
                             <input id="query-limit" class="limit-field" type="number" value="20" min="1" max="200">
                         </div>
+                        <div>
+                            <label for="query-zone">Zone</label>
+                            <input id="query-zone" type="text" placeholder="zone name (default: _defaultZone)">
+                        </div>
+                        <div>
+                            <label for="query-zone-owner">Zone owner</label>
+                            <input id="query-zone-owner" type="text" placeholder="owner name (shared zones)">
+                        </div>
                         <div style="flex: 1; display: flex; justify-content: flex-end;">
                             <button id="refresh-btn" type="button">Refresh</button>
                         </div>

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/js/app.js
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/js/app.js
@@ -42,6 +42,8 @@ const deleteBtn = document.getElementById('delete-btn');
 const refreshBtn = document.getElementById('refresh-btn');
 const recordTypeInput = document.getElementById('record-type');
 const queryLimitInput = document.getElementById('query-limit');
+const queryZoneInput = document.getElementById('query-zone');
+const queryZoneOwnerInput = document.getElementById('query-zone-owner');
 const rawResponseEl = document.getElementById('raw-response');
 const formImageGenerateBtn = document.getElementById('form-image-generate');
 const formImageClearBtn = document.getElementById('form-image-clear');
@@ -497,6 +499,10 @@ async function queryNotes() {
     if (queryInFlight) return;
     const recordType = recordTypeInput.value.trim();
     const limit = parseInt(queryLimitInput.value, 10);
+    const zoneName = queryZoneInput.value.trim() || undefined;
+    // The server rejects a zoneOwner without a zoneName, so drop a stray owner
+    // rather than sending a body that is guaranteed to 400.
+    const zoneOwner = zoneName ? (queryZoneOwnerInput.value.trim() || undefined) : undefined;
     queryInFlight = true;
     setQueryControlsDisabled(true);
     const dbLabel = currentDatabase === 'public' ? 'public' : 'private';
@@ -512,6 +518,8 @@ async function queryNotes() {
                 sortBy: currentSort
                     ? [{ field: currentSort.field, ascending: currentSort.ascending }]
                     : undefined,
+                zoneName,
+                zoneOwner,
             });
         } else {
             const query = { recordType };
@@ -520,6 +528,12 @@ async function queryNotes() {
                     fieldName: currentSort.field,
                     ascending: currentSort.ascending,
                 }];
+            }
+            // CloudKit JS names the owner `ownerRecordName` inside zoneID.
+            if (zoneName) {
+                query.zoneID = zoneOwner
+                    ? { zoneName, ownerRecordName: zoneOwner }
+                    : { zoneName };
             }
             payload = await ckJsDatabase().performQuery(query, {
                 resultsLimit: isFinite(limit) ? limit : undefined,
@@ -552,6 +566,7 @@ function setQueryControlsDisabled(disabled) {
         'refresh-btn', 'db-private', 'db-public',
         'mode-mistkit', 'mode-cloudkitjs',
         'save-btn', 'delete-btn',
+        'query-zone', 'query-zone-owner',
     ];
     for (const id of ids) {
         const el = document.getElementById(id);

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+Index.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+Index.swift
@@ -107,5 +107,22 @@
         )
       )
     }
+
+    @Test("Query panel exposes zone name and owner inputs")
+    internal func indexExposesQueryZoneInputs() async throws {
+      let html = try await body(at: "/")
+      #expect(html.contains(#"id="query-zone""#))
+      #expect(html.contains(#"id="query-zone-owner""#))
+
+      let appJs = try await body(at: "/js/app.js")
+      // Both backends read the same two inputs...
+      #expect(appJs.contains("queryZoneInput"))
+      #expect(appJs.contains("queryZoneOwnerInput"))
+      // ...the MistKit path forwards them as-is on the query body,
+      // and the CloudKit JS path maps the owner to `ownerRecordName`.
+      #expect(appJs.contains("ownerRecordName: zoneOwner"))
+      // The inputs join the controls disabled while a query is in flight.
+      #expect(appJs.contains("'query-zone', 'query-zone-owner'"))
+    }
   }
 #endif


### PR DESCRIPTION
## Summary
- Wire optional Zone / Zone owner inputs into the MistDemo web query toolbar and include them on the MistKit `POST /api/records/query` body (and CloudKit JS `query.zoneID`) when set.
- Drop a stray `zoneOwner` without `zoneName` client-side so we never send a request the backend rejects with 400.
- Add `indexExposesQueryZoneInputs` coverage in the served HTML/JS test suite.

Fixes #438.

**Note:** Shared-zone queries (`zoneOwner`) are only fully correct once #444 / PR #451 lands — that renames the wire key to `ownerRecordName`. Zone-name-only queries work on `main` as-is.

## Test plan
- [x] `swift build` / `swift test` in MistDemo (new test passes; 1003 total)
- [x] `swift-format` / `swiftlint` clean on touched Swift
- [ ] CI green
- [ ] Manual: query with blank zone fields (unchanged default-zone behavior)
- [ ] Manual: query with zone name only
- [ ] Manual: shared-zone owner after #444 merges


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Zone and Zone owner fields to the Notes query panel.
  * Supports querying notes from custom zones, including shared zones with an owner.

* **Bug Fixes**
  * Prevents incomplete zone owner details from being submitted.
  * Disables the new fields while queries are in progress.

* **Tests**
  * Added coverage verifying the new fields and query behavior are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->