### PR TITLE
MistDemo web: zoneName/zoneOwner on query panel (#438)

### DIFF
--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/index.html
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/index.html
@@ -64,6 +64,14 @@
                             <label for="query-limit">Limit</label>
                             <input id="query-limit" class="limit-field" type="number" value="20" min="1" max="200">
                         </div>
+                        <div>
+                            <label for="query-zone">Zone</label>
+                            <input id="query-zone" type="text" placeholder="zone name (default: _defaultZone)">
+                        </div>
+                        <div>
+                            <label for="query-zone-owner">Zone owner</label>
+                            <input id="query-zone-owner" type="text" placeholder="owner name (shared zones)">
+                        </div>
                         <div style="flex: 1; display: flex; justify-content: flex-end;">
                             <button id="refresh-btn" type="button">Refresh</button>
                         </div>

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/js/app.js
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/js/app.js
@@ -42,6 +42,8 @@ const deleteBtn = document.getElementById('delete-btn');
 const refreshBtn = document.getElementById('refresh-btn');
 const recordTypeInput = document.getElementById('record-type');
 const queryLimitInput = document.getElementById('query-limit');
+const queryZoneInput = document.getElementById('query-zone');
+const queryZoneOwnerInput = document.getElementById('query-zone-owner');
 const rawResponseEl = document.getElementById('raw-response');
 const formImageGenerateBtn = document.getElementById('form-image-generate');
 const formImageClearBtn = document.getElementById('form-image-clear');
@@ -497,6 +499,10 @@ async function queryNotes() {
     if (queryInFlight) return;
     const recordType = recordTypeInput.value.trim();
     const limit = parseInt(queryLimitInput.value, 10);
+    const zoneName = queryZoneInput.value.trim() || undefined;
+    // The server rejects a zoneOwner without a zoneName, so drop a stray owner
+    // rather than sending a body that is guaranteed to 400.
+    const zoneOwner = zoneName ? (queryZoneOwnerInput.value.trim() || undefined) : undefined;
     queryInFlight = true;
     setQueryControlsDisabled(true);
     const dbLabel = currentDatabase === 'public' ? 'public' : 'private';
@@ -512,6 +518,8 @@ async function queryNotes() {
                 sortBy: currentSort
                     ? [{ field: currentSort.field, ascending: currentSort.ascending }]
                     : undefined,
+                zoneName,
+                zoneOwner,
             });
         } else {
             const query = { recordType };
@@ -520,6 +528,12 @@ async function queryNotes() {
                     fieldName: currentSort.field,
                     ascending: currentSort.ascending,
                 }];
+            }
+            // CloudKit JS names the owner `ownerRecordName` inside zoneID.
+            if (zoneName) {
+                query.zoneID = zoneOwner
+                    ? { zoneName, ownerRecordName: zoneOwner }
+                    : { zoneName };
             }
             payload = await ckJsDatabase().performQuery(query, {
                 resultsLimit: isFinite(limit) ? limit : undefined,
@@ -552,6 +566,7 @@ function setQueryControlsDisabled(disabled) {
         'refresh-btn', 'db-private', 'db-public',
         'mode-mistkit', 'mode-cloudkitjs',
         'save-btn', 'delete-btn',
+        'query-zone', 'query-zone-owner',
     ];
     for (const id of ids) {
         const el = document.getElementById(id);

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/CloudKitService+WebBackend.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/CloudKitService+WebBackend.swift
@@ -35,22 +35,18 @@ extension CloudKitService: WebBackend {
     recordType: String,
     limit: Int?,
     sortBy: [WebRequests.QuerySortField]?,
-    zoneName: String?,
-    zoneOwner: String?,
+    zone: WebRequests.ZoneSelector?,
     database: MistKit.Database
   ) async throws -> [RecordInfo] {
     let querySorts = sortBy?.map { sort in
       QuerySort.sort(sort.field, ascending: sort.ascending)
-    }
-    let zoneID = zoneName.map {
-      ZoneID(zoneName: $0, ownerName: zoneOwner)
     }
     let result = try await queryRecords(
       Query(recordType: recordType, sortBy: querySorts ?? []),
       limit: limit,
       desiredKeys: nil,
       continuationMarker: nil,
-      zoneID: zoneID,
+      zoneID: zone?.zoneID,
       database: database
     )
     return result.records

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebBackend.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebBackend.swift
@@ -43,8 +43,7 @@ internal protocol WebBackend: Sendable {
     recordType: String,
     limit: Int?,
     sortBy: [WebRequests.QuerySortField]?,
-    zoneName: String?,
-    zoneOwner: String?,
+    zone: WebRequests.ZoneSelector?,
     database: MistKit.Database
   ) async throws -> [RecordInfo]
 

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebRequests.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebRequests.swift
@@ -51,7 +51,31 @@ internal enum WebRequests {
     internal let ascending: Bool
   }
 
+  /// Zone target for a web request: default zone is `nil`, own custom zone is
+  /// name-only, shared zone is name + owner. A lone owner is unrepresentable.
+  ///
+  /// Kept separate from MistKit's ``ZoneID`` so request selectors never carry
+  /// response-only fields like `zoneType`.
+  internal struct ZoneSelector: Sendable, Equatable {
+    internal let zoneName: String
+    internal let zoneOwner: String?
+
+    internal init(zoneName: String, zoneOwner: String? = nil) {
+      self.zoneName = zoneName
+      self.zoneOwner = zoneOwner
+    }
+
+    /// MistKit zone identity for `queryRecords` / `modifyRecords`.
+    internal var zoneID: ZoneID {
+      ZoneID(zoneName: zoneName, ownerName: zoneOwner)
+    }
+  }
+
   /// `POST /api/records/query`
+  ///
+  /// Wire format stays flat (`zoneName` / `zoneOwner` at the top level) so
+  /// `app.js` and existing tests keep working; decode folds them into
+  /// ``zone``.
   internal struct Query: Decodable {
     private enum CodingKeys: String, CodingKey {
       case recordType
@@ -66,10 +90,8 @@ internal enum WebRequests {
     internal let limit: Int?
     internal let sortBy: [QuerySortField]?
     internal let database: MistKit.Database
-    /// Optional zone name for custom/shared zone queries.
-    internal let zoneName: String?
-    /// Optional zone owner (ownerName) for shared zones.
-    internal let zoneOwner: String?
+    /// `nil` = default zone; otherwise a custom or shared zone.
+    internal let zone: ZoneSelector?
 
     internal init(from decoder: any Decoder) throws {
       let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -81,18 +103,21 @@ internal enum WebRequests {
       self.database = try WebRequests.decodeDatabase(
         from: container, forKey: .database
       )
-      self.zoneName = try container.decodeIfPresent(
+      let zoneName = try container.decodeIfPresent(
         String.self, forKey: .zoneName
       )
-      self.zoneOwner = try container.decodeIfPresent(
+      let zoneOwner = try container.decodeIfPresent(
         String.self, forKey: .zoneOwner
       )
-      if self.zoneOwner != nil, self.zoneName == nil {
+      if zoneOwner != nil, zoneName == nil {
         throw DecodingError.dataCorruptedError(
           forKey: .zoneOwner,
           in: container,
           debugDescription: "zoneOwner requires zoneName"
         )
+      }
+      self.zone = zoneName.map {
+        ZoneSelector(zoneName: $0, zoneOwner: zoneOwner)
       }
     }
   }

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer+CRUD.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer+CRUD.swift
@@ -51,8 +51,7 @@
             recordType: body.recordType,
             limit: body.limit,
             sortBy: body.sortBy,
-            zoneName: body.zoneName,
-            zoneOwner: body.zoneOwner,
+            zone: body.zone,
             database: body.database
           )
           return try WebJSON.encoder().encode(

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend+Calls.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend+Calls.swift
@@ -39,8 +39,7 @@
       internal let recordType: String
       internal let limit: Int?
       internal let sortBy: [WebRequests.QuerySortField]?
-      internal let zoneName: String?
-      internal let zoneOwner: String?
+      internal let zone: WebRequests.ZoneSelector?
       internal let database: MistKit.Database
     }
 

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend+RecordOperations.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend+RecordOperations.swift
@@ -37,16 +37,14 @@
       recordType: String,
       limit: Int?,
       sortBy: [WebRequests.QuerySortField]?,
-      zoneName: String?,
-      zoneOwner: String?,
+      zone: WebRequests.ZoneSelector?,
       database: MistKit.Database
     ) async throws -> [RecordInfo] {
       lastQuery = QueryCall(
         recordType: recordType,
         limit: limit,
         sortBy: sortBy,
-        zoneName: zoneName,
-        zoneOwner: zoneOwner,
+        zone: zone,
         database: database
       )
       try consumePendingError()

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+Index.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+Index.swift
@@ -107,5 +107,22 @@
         )
       )
     }
+
+    @Test("Query panel exposes zone name and owner inputs")
+    internal func indexExposesQueryZoneInputs() async throws {
+      let html = try await body(at: "/")
+      #expect(html.contains(#"id="query-zone""#))
+      #expect(html.contains(#"id="query-zone-owner""#))
+
+      let appJs = try await body(at: "/js/app.js")
+      // Both backends read the same two inputs...
+      #expect(appJs.contains("queryZoneInput"))
+      #expect(appJs.contains("queryZoneOwnerInput"))
+      // ...the MistKit path forwards them as-is on the query body,
+      // and the CloudKit JS path maps the owner to `ownerRecordName`.
+      #expect(appJs.contains("ownerRecordName: zoneOwner"))
+      // The inputs join the controls disabled while a query is in flight.
+      #expect(appJs.contains("'query-zone', 'query-zone-owner'"))
+    }
   }
 #endif

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+QueryZone.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+QueryZone.swift
@@ -75,8 +75,8 @@
       }
 
       let captured = await fixture.backend.lastQuery
-      #expect(captured?.zoneName == "Articles")
-      #expect(captured?.zoneOwner == "_abc123")
+      #expect(captured?.zone?.zoneName == "Articles")
+      #expect(captured?.zone?.zoneOwner == "_abc123")
     }
   }
 #endif

--- a/Sources/MistKit/CloudKitService/CloudKitService+RecordWriteConvenience.swift
+++ b/Sources/MistKit/CloudKitService/CloudKitService+RecordWriteConvenience.swift
@@ -35,6 +35,8 @@ extension CloudKitService {
   ///   - recordType: The type of record to create
   ///   - recordName: Optional unique record name
   ///   - fields: Dictionary of field names to FieldValue
+  ///   - zoneID: Optional target zone (defaults to the request's zone /
+  ///     `_defaultZone` when omitted)
   ///   - database: The CloudKit database scope to write to (`.public`, `.private`, `.shared`)
   /// - Returns: RecordInfo for the created record
   /// - Throws: CloudKitError if the operation fails
@@ -51,6 +53,7 @@ extension CloudKitService {
     recordType: String,
     recordName: String? = nil,
     fields: [String: FieldValue],
+    zoneID: ZoneID? = nil,
     database: Database
   ) async throws(CloudKitError) -> RecordInfo {
     let operation = RecordOperation.create(
@@ -59,7 +62,9 @@ extension CloudKitService {
       fields: fields
     )
 
-    let results = try await modifyRecords([operation], database: database)
+    let results = try await modifyRecords(
+      [operation], zoneID: zoneID, database: database
+    )
     guard let result = results.first else {
       throw CloudKitError.invalidResponse
     }
@@ -72,6 +77,8 @@ extension CloudKitService {
   ///   - recordName: The unique record name
   ///   - fields: Dictionary of field names to FieldValue
   ///   - recordChangeTag: Optional change tag for optimistic locking
+  ///   - zoneID: Optional target zone (defaults to the request's zone /
+  ///     `_defaultZone` when omitted)
   ///   - database: The CloudKit database scope to write to (`.public`, `.private`, `.shared`)
   /// - Returns: RecordInfo for the updated record
   /// - Throws: CloudKitError if the operation fails
@@ -91,6 +98,7 @@ extension CloudKitService {
     recordName: String,
     fields: [String: FieldValue],
     recordChangeTag: String? = nil,
+    zoneID: ZoneID? = nil,
     database: Database
   ) async throws(CloudKitError) -> RecordInfo {
     let operation = RecordOperation.update(
@@ -100,7 +108,9 @@ extension CloudKitService {
       recordChangeTag: recordChangeTag
     )
 
-    let results = try await modifyRecords([operation], database: database)
+    let results = try await modifyRecords(
+      [operation], zoneID: zoneID, database: database
+    )
     guard let result = results.first else {
       throw CloudKitError.invalidResponse
     }
@@ -112,12 +122,15 @@ extension CloudKitService {
   ///   - recordType: The type of record to delete
   ///   - recordName: The unique record name
   ///   - recordChangeTag: Optional change tag for optimistic locking
+  ///   - zoneID: Optional target zone (defaults to the request's zone /
+  ///     `_defaultZone` when omitted)
   ///   - database: The CloudKit database scope to delete from (`.public`, `.private`, `.shared`)
   /// - Throws: CloudKitError if the operation fails
   public func deleteRecord(
     recordType: String,
     recordName: String,
     recordChangeTag: String? = nil,
+    zoneID: ZoneID? = nil,
     database: Database
   ) async throws(CloudKitError) {
     let operation = RecordOperation.delete(
@@ -126,7 +139,9 @@ extension CloudKitService {
       recordChangeTag: recordChangeTag
     )
 
-    let results = try await modifyRecords([operation], database: database)
+    let results = try await modifyRecords(
+      [operation], zoneID: zoneID, database: database
+    )
     for result in results {
       // `get()` rethrows a per-record failure as `recordOperationFailed`.
       _ = try result.get()

--- a/Tests/MistKitTests/CloudKitService/RecordWrite/CloudKitServiceTests.RecordWriteConvenience.swift
+++ b/Tests/MistKitTests/CloudKitService/RecordWrite/CloudKitServiceTests.RecordWriteConvenience.swift
@@ -146,5 +146,35 @@ extension CloudKitServiceTests {
 
       #expect(await provider.callCount(for: "modifyRecords") == 1)
     }
+
+    @Test("createRecord forwards zoneID into the modifyRecords request body")
+    internal func createForwardsZoneID() async throws {
+      guard #available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let (service, provider) = try Helper.makeServiceWithProvider(responsesByOperation: [
+        "modifyRecords": try Helper.recordsResponse([
+          Helper.noteRecord(recordName: "note-1", changeTag: "tag-1")
+        ])
+      ])
+
+      _ = try await service.createRecord(
+        recordType: "Note",
+        recordName: "note-1",
+        fields: ["title": .string("Hello")],
+        zoneID: ZoneID(zoneName: "Articles", ownerName: "_abc123"),
+        database: Helper.publicDatabase
+      )
+
+      let bodies = await provider.bodies(for: "modifyRecords").compactMap { $0 }
+      let data = try #require(bodies.first)
+      let body = try #require(
+        try JSONSerialization.jsonObject(with: data) as? [String: Any]
+      )
+      let zoneID = try #require(body["zoneID"] as? [String: Any])
+      #expect(zoneID["zoneName"] as? String == "Articles")
+      #expect(zoneID["ownerRecordName"] as? String == "_abc123")
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Rebased onto `v1.0.0-beta.5` after #451 (zone payload fields) merged
- Adds zone name / zone owner inputs to the MistDemo web query panel (#438)

## Test plan
- [ ] Confirm web query panel zone fields round-trip against private DB custom zones
- [ ] CI green on `v1.0.0-beta.5`


Made with [Cursor](https://cursor.com)