### PR TITLE
Zone-aware MistDemo writes and shared-zone live validation (#454)

### DIFF
--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/ShareCreateAndAcceptPhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/ShareCreateAndAcceptPhase.swift
@@ -57,8 +57,22 @@ internal struct ShareCreateAndAcceptPhase: IntegrationPhase {
 
     // Distinct Apple IDs are required: inviting yourself is not a useful
     // create→accept roundtrip. Compare users/caller record names up front.
-    let sharerIdentity = try await context.service.fetchCaller()
-    let shareeIdentity = try await shareeService.fetchCaller()
+    let sharerIdentity: UserInfo
+    do {
+      sharerIdentity = try await context.service.fetchCaller()
+    } catch {
+      throw IntegrationTestError.verificationFailed(
+        "sharer users/caller failed: \(error)"
+      )
+    }
+    let shareeIdentity: UserInfo
+    do {
+      shareeIdentity = try await shareeService.fetchCaller()
+    } catch {
+      throw IntegrationTestError.verificationFailed(
+        "sharee users/caller failed: \(error)"
+      )
+    }
     if sharerIdentity.userRecordName == shareeIdentity.userRecordName {
       throw IntegrationTestError.shareeSameAsSharer(
         userRecordName: sharerIdentity.userRecordName

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/SharedZoneRoundtripPhase.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Phases/SharedZoneRoundtripPhase.swift
@@ -1,0 +1,309 @@
+//
+//  SharedZoneRoundtripPhase.swift
+//  MistDemo
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+internal import Foundation
+internal import MistKit
+
+/// Live shared-zone write round-trip: sharer creates a custom zone and share,
+/// sharee accepts, then sharee update/lookup/zone-changes and zone-scoped asset
+/// upload on the **shared root** (`database: .shared`, `zoneID.ownerName` =
+/// sharer's user record name). CloudKit does not allow sharees to create
+/// arbitrary new top-level records in the zone (ACCESS_DENIED).
+///
+/// Self-cleaning. Requires the same sharee credentials as
+/// ``ShareCreateAndAcceptPhase``.
+internal struct SharedZoneRoundtripPhase: IntegrationPhase {
+  internal typealias Input = NoState
+  internal typealias Output = NoState
+
+  internal static let title = "Shared-zone CRUD and asset round-trip"
+  internal static let emoji = "🔗"
+  internal static let apiName = "shared zone write+uploadAssets"
+
+  internal func run(input: NoState, context: PhaseContext) async throws -> NoState {
+    print("\n\(Self.emoji) \(Self.title)")
+
+    guard let shareeService = context.shareeService,
+      let shareeEmail = context.shareeEmail,
+      !shareeEmail.isEmpty
+    else {
+      throw IntegrationTestError.missingShareeCredentials
+    }
+
+    let sharerIdentity = try await context.service.fetchCaller()
+    let shareeIdentity = try await shareeService.fetchCaller()
+    if sharerIdentity.userRecordName == shareeIdentity.userRecordName {
+      throw IntegrationTestError.shareeSameAsSharer(
+        userRecordName: sharerIdentity.userRecordName
+      )
+    }
+
+    let zoneName = "mistkit-shared-crud-\(UUID().uuidString.lowercased())"
+    let privateZoneID = ZoneID(zoneName: zoneName)
+    let rootRecordName = "mistkit-shared-root-\(UUID().uuidString.lowercased())"
+    let sharedDatabase: MistKit.Database = .shared
+
+    _ = try await context.service.createZone(
+      zoneName: zoneName,
+      database: context.database
+    )
+    if context.verbose {
+      print("   ✅ Created zone: \(zoneName)")
+      print("   Sharer: \(sharerIdentity.userRecordName)")
+      print("   Sharee: \(shareeIdentity.userRecordName)")
+    }
+
+    var shareRecordName: String?
+    do {
+      let created = try await context.service.createShare(
+        rootRecordType: MistDemoConfig.recordType,
+        rootRecordName: rootRecordName,
+        rootFields: [
+          "title": .string("Shared zone root"),
+          "index": .int64(0),
+        ],
+        zoneID: privateZoneID,
+        publicPermission: .none,
+        participants: [
+          ShareParticipant(
+            userIdentity: UserIdentity(
+              lookupInfo: UserIdentityLookupInfo(emailAddress: shareeEmail)
+            ),
+            permission: .readWrite,
+            type: .user,
+            acceptanceStatus: .invited
+          )
+        ],
+        database: context.database
+      )
+      shareRecordName = created.shareRecordName
+      print("✅ Created share \(created.shortGUID)")
+
+      let shortGUID = ShortGUIDDictionary(
+        value: created.shortGUID,
+        shouldFetchRootRecord: true
+      )
+      _ = try await shareeService.resolveShares([shortGUID])
+      let accepted = try await shareeService.acceptShares([shortGUID])
+      guard let acceptInfo = accepted.first else {
+        throw IntegrationTestError.shareAcceptEmpty
+      }
+      if let status = acceptInfo.participantStatus, status == .invited {
+        throw IntegrationTestError.shareStillInvited
+      }
+      print(
+        "✅ Sharee accepted — status: "
+          + "\(acceptInfo.participantStatus?.rawValue ?? "-")"
+      )
+
+      guard let acceptZoneID = acceptInfo.zoneID else {
+        throw IntegrationTestError.verificationFailed(
+          "acceptShares omitted zoneID — cannot address shared DB"
+        )
+      }
+      // Pin owner to the sharer's users/caller name — accept may omit it.
+      let sharedZoneID = ZoneID(
+        zoneName: acceptZoneID.zoneName,
+        ownerName: acceptZoneID.ownerName ?? sharerIdentity.userRecordName
+      )
+      let sharedRootName = acceptInfo.rootRecordName ?? created.rootRecord.recordName
+      if context.verbose {
+        print("   Shared zone: \(sharedZoneID.zoneName) owner \(sharedZoneID.ownerName ?? "-")")
+        print("   Shared root: \(sharedRootName)")
+      }
+
+      guard let sharedRoot = acceptInfo.rootRecord else {
+        throw IntegrationTestError.verificationFailed(
+          "acceptShares omitted rootRecord (shouldFetchRootRecord was true)"
+        )
+      }
+
+      // Sharees can modify records in the share, not create arbitrary new
+      // top-level records in the zone (CloudKit returns ACCESS_DENIED).
+      let updatedRoot = try await shareeService.updateRecord(
+        recordType: MistDemoConfig.recordType,
+        recordName: sharedRootName,
+        fields: [
+          "title": .string("Shared CRUD updated"),
+          "index": .int64(42),
+        ],
+        recordChangeTag: sharedRoot.recordChangeTag,
+        zoneID: sharedZoneID,
+        database: sharedDatabase
+      )
+      if context.verbose {
+        print("   ✅ Sharee updated shared root \(updatedRoot.recordName)")
+      }
+
+      guard updatedRoot.fields["title"] == .string("Shared CRUD updated"),
+        updatedRoot.fields["index"] == .int64(42)
+      else {
+        throw IntegrationTestError.verificationFailed(
+          "shared update did not round-trip title/index on \(sharedRootName)"
+        )
+      }
+      if context.verbose {
+        print("   ✅ Sharee read back updated fields from modify response")
+      }
+
+      let changeResult = try await shareeService.fetchRecordZoneChanges(
+        zones: [ZoneChangesRequest(zoneID: sharedZoneID)],
+        database: sharedDatabase
+      )
+      try ChangeTrackingVerification.requireNoZoneFailures(
+        changeResult.failures,
+        operation: "fetchRecordZoneChanges (shared)"
+      )
+      let changeNames = ChangeTrackingVerification.recordNames(in: changeResult.changes)
+      if !changeNames.contains(sharedRootName) {
+        throw IntegrationTestError.verificationFailed(
+          "shared changes/zone missing root \(sharedRootName); found \(changeNames.sorted())"
+        )
+      }
+
+      // Asset must request an upload URL in the same zone as the update.
+      let png = PNGData.generate(withSizeInKB: min(context.assetSizeKB, 8))
+      let receipt = try await shareeService.uploadAssets(
+        data: png,
+        recordType: MistDemoConfig.recordType,
+        fieldName: "image",
+        recordName: sharedRootName,
+        zoneID: sharedZoneID,
+        database: sharedDatabase
+      )
+      let withAsset = try await shareeService.updateRecord(
+        recordType: MistDemoConfig.recordType,
+        recordName: sharedRootName,
+        fields: [
+          "title": .string("Shared asset"),
+          "index": .int64(43),
+          "image": .asset(receipt.asset),
+        ],
+        recordChangeTag: updatedRoot.recordChangeTag,
+        zoneID: sharedZoneID,
+        database: sharedDatabase
+      )
+      if context.verbose {
+        print("   ✅ Sharee uploaded+attached asset on shared root")
+      }
+
+      _ = withAsset  // used for verification via successful update
+
+      print("✅ Shared-zone CRUD and asset round-trip succeeded")
+
+      try await cleanup(
+        sharer: context.service,
+        database: context.database,
+        zoneID: privateZoneID,
+        rootRecordName: sharedRootName,
+        shareRecordName: created.shareRecordName,
+        extraRecordNames: [],
+        verbose: context.verbose,
+        skipCleanup: context.skipCleanup
+      )
+    } catch {
+      try? await cleanup(
+        sharer: context.service,
+        database: context.database,
+        zoneID: privateZoneID,
+        rootRecordName: rootRecordName,
+        shareRecordName: shareRecordName,
+        extraRecordNames: [],
+        verbose: context.verbose,
+        skipCleanup: context.skipCleanup
+      )
+      throw error
+    }
+
+    return NoState()
+  }
+
+  private func cleanup(
+    sharer: CloudKitService,
+    database: MistKit.Database,
+    zoneID: ZoneID,
+    rootRecordName: String,
+    shareRecordName: String?,
+    extraRecordNames: [String],
+    verbose: Bool,
+    skipCleanup: Bool
+  ) async throws {
+    if skipCleanup {
+      print("   ⏭️  Skipping shared-zone cleanup — inspect zone '\(zoneID.zoneName)'")
+      return
+    }
+
+    var ops = [
+      RecordOperation(
+        operationType: .forceDelete,
+        recordType: MistDemoConfig.recordType,
+        recordName: rootRecordName
+      )
+    ]
+    for name in extraRecordNames {
+      ops.append(
+        RecordOperation(
+          operationType: .forceDelete,
+          recordType: MistDemoConfig.recordType,
+          recordName: name
+        )
+      )
+    }
+    if let shareRecordName {
+      ops.append(
+        RecordOperation(
+          operationType: .forceDelete,
+          recordType: ShareInfo.recordType,
+          recordName: shareRecordName
+        )
+      )
+    }
+    do {
+      _ = try await sharer.modifyRecords(ops, zoneID: zoneID, database: database)
+      if verbose {
+        print("   ✅ Deleted shared-zone records in \(zoneID.zoneName)")
+      }
+    } catch {
+      if verbose {
+        print("   ⚠️  Shared record cleanup failed: \(error)")
+      }
+    }
+
+    do {
+      try await sharer.deleteZone(zoneName: zoneID.zoneName, database: database)
+      if verbose {
+        print("   ✅ Deleted zone: \(zoneID.zoneName)")
+      }
+    } catch {
+      if verbose {
+        print("   ⚠️  Zone cleanup failed: \(error)")
+      }
+    }
+  }
+}

--- a/Examples/MistDemo/Sources/MistDemoKit/Integration/Tests/PrivateDatabaseTest.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Integration/Tests/PrivateDatabaseTest.swift
@@ -67,6 +67,7 @@ internal struct PrivateDatabaseTest: PhasedIntegrationTest {
     TokenRoundtripPhase(),
     NotificationRoundtripPhase(),
     ShareCreateAndAcceptPhase(),
+    SharedZoneRoundtripPhase(),
     CleanupPhase(),
   ]
 }

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/index.html
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/index.html
@@ -66,11 +66,11 @@
                         </div>
                         <div>
                             <label for="query-zone">Zone</label>
-                            <input id="query-zone" type="text" placeholder="zone name (default: _defaultZone)">
+                            <input id="query-zone" type="text" placeholder="zone for query &amp; writes">
                         </div>
                         <div>
                             <label for="query-zone-owner">Zone owner</label>
-                            <input id="query-zone-owner" type="text" placeholder="owner name (shared zones)">
+                            <input id="query-zone-owner" type="text" placeholder="owner (shared zones; used by writes too)">
                         </div>
                         <div style="flex: 1; display: flex; justify-content: flex-end;">
                             <button id="refresh-btn" type="button">Refresh</button>

--- a/Examples/MistDemo/Sources/MistDemoKit/Resources/js/app.js
+++ b/Examples/MistDemo/Sources/MistDemoKit/Resources/js/app.js
@@ -495,14 +495,28 @@ function ckJsFields(fields) {
 
 // ---- Notes CRUD operations ----
 
+/** Selected toolbar zone for query and writes. Drops stray owner without name. */
+function selectedZone() {
+    const zoneName = queryZoneInput.value.trim() || undefined;
+    const zoneOwner = zoneName
+        ? (queryZoneOwnerInput.value.trim() || undefined)
+        : undefined;
+    return { zoneName, zoneOwner };
+}
+
+/** CloudKit JS per-record zoneID shape (unlike query's top-level zoneID). */
+function ckJsRecordZoneID(zoneName, zoneOwner) {
+    if (!zoneName) return undefined;
+    return zoneOwner
+        ? { zoneName, ownerRecordName: zoneOwner }
+        : { zoneName };
+}
+
 async function queryNotes() {
     if (queryInFlight) return;
     const recordType = recordTypeInput.value.trim();
     const limit = parseInt(queryLimitInput.value, 10);
-    const zoneName = queryZoneInput.value.trim() || undefined;
-    // The server rejects a zoneOwner without a zoneName, so drop a stray owner
-    // rather than sending a body that is guaranteed to 400.
-    const zoneOwner = zoneName ? (queryZoneOwnerInput.value.trim() || undefined) : undefined;
+    const { zoneName, zoneOwner } = selectedZone();
     queryInFlight = true;
     setQueryControlsDisabled(true);
     const dbLabel = currentDatabase === 'public' ? 'public' : 'private';
@@ -531,9 +545,7 @@ async function queryNotes() {
             }
             // CloudKit JS names the owner `ownerRecordName` inside zoneID.
             if (zoneName) {
-                query.zoneID = zoneOwner
-                    ? { zoneName, ownerRecordName: zoneOwner }
-                    : { zoneName };
+                query.zoneID = ckJsRecordZoneID(zoneName, zoneOwner);
             }
             payload = await ckJsDatabase().performQuery(query, {
                 resultsLimit: isFinite(limit) ? limit : undefined,
@@ -598,6 +610,7 @@ async function saveNote() {
         // /api/assets/upload, then create/update with the returned descriptor.
         // CloudKit JS handles upload inline through saveRecords by passing a
         // Blob in the field value.
+        const { zoneName, zoneOwner } = selectedZone();
         let uploadedRecordName = null;
         if (hasPendingImage && currentMode === 'mistkit') {
             setStatus(formStatusEl, 'Uploading image…', 'loading');
@@ -607,6 +620,8 @@ async function saveNote() {
                 recordName: isUpdate ? note.recordName : undefined,
                 database: currentDatabase,
                 data: pendingImage.base64,
+                zoneName,
+                zoneOwner,
             });
             uploadedRecordName = receipt.recordName;
             // FieldValue's Asset case decodes the bare Asset shape directly.
@@ -620,6 +635,8 @@ async function saveNote() {
                     recordName: note.recordName,
                     fields,
                     recordChangeTag: note.recordChangeTag,
+                    zoneName,
+                    zoneOwner,
                 });
             } else {
                 payload = await postJSON('/api/records/create', {
@@ -627,6 +644,8 @@ async function saveNote() {
                     database: currentDatabase,
                     recordName: uploadedRecordName || undefined,
                     fields,
+                    zoneName,
+                    zoneOwner,
                 });
             }
         } else {
@@ -641,6 +660,8 @@ async function saveNote() {
                 record.recordName = note.recordName;
                 record.recordChangeTag = note.recordChangeTag;
             }
+            const zoneID = ckJsRecordZoneID(zoneName, zoneOwner);
+            if (zoneID) record.zoneID = zoneID;
             payload = await ckJsDatabase().saveRecords([record]);
             if (payload && payload.hasErrors && payload.errors.length) {
                 throw new Error(payload.errors[0].reason || 'CloudKit JS save failed');
@@ -669,15 +690,21 @@ async function deleteNote(note, statusEl = tableStatusEl) {
     clearStatus(statusEl);
     try {
         let payload;
+        const { zoneName, zoneOwner } = selectedZone();
         if (currentMode === 'mistkit') {
             payload = await postJSON('/api/records/delete', {
                 recordType: note.recordType,
                 database: currentDatabase,
                 recordName: note.recordName,
                 recordChangeTag: note.recordChangeTag,
+                zoneName,
+                zoneOwner,
             });
         } else {
-            payload = await ckJsDatabase().deleteRecords([{ recordName: note.recordName }]);
+            const deleteSpec = { recordName: note.recordName };
+            const zoneID = ckJsRecordZoneID(zoneName, zoneOwner);
+            if (zoneID) deleteSpec.zoneID = zoneID;
+            payload = await ckJsDatabase().deleteRecords([deleteSpec]);
             if (payload && payload.hasErrors && payload.errors.length) {
                 throw new Error(payload.errors[0].reason || 'CloudKit JS delete failed');
             }

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/CloudKitService+WebBackend.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/CloudKitService+WebBackend.swift
@@ -56,12 +56,14 @@ extension CloudKitService: WebBackend {
     recordType: String,
     recordName: String?,
     fields: [String: FieldValue],
+    zone: WebRequests.ZoneSelector?,
     database: MistKit.Database
   ) async throws -> RecordInfo {
     try await createRecord(
       recordType: recordType,
       recordName: recordName,
       fields: fields,
+      zoneID: zone?.zoneID,
       database: database
     )
   }
@@ -71,6 +73,7 @@ extension CloudKitService: WebBackend {
     recordName: String,
     fields: [String: FieldValue],
     recordChangeTag: String?,
+    zone: WebRequests.ZoneSelector?,
     database: MistKit.Database
   ) async throws -> RecordInfo {
     try await updateRecord(
@@ -78,6 +81,7 @@ extension CloudKitService: WebBackend {
       recordName: recordName,
       fields: fields,
       recordChangeTag: recordChangeTag,
+      zoneID: zone?.zoneID,
       database: database
     )
   }
@@ -86,12 +90,14 @@ extension CloudKitService: WebBackend {
     recordType: String,
     recordName: String,
     recordChangeTag: String?,
+    zone: WebRequests.ZoneSelector?,
     database: MistKit.Database
   ) async throws {
     try await deleteRecord(
       recordType: recordType,
       recordName: recordName,
       recordChangeTag: recordChangeTag,
+      zoneID: zone?.zoneID,
       database: database
     )
   }
@@ -183,6 +189,7 @@ extension CloudKitService: WebBackend {
     recordType: String,
     fieldName: String,
     recordName: String?,
+    zone: WebRequests.ZoneSelector?,
     database: MistKit.Database
   ) async throws -> AssetUploadReceipt {
     try await uploadAssets(
@@ -190,6 +197,7 @@ extension CloudKitService: WebBackend {
       recordType: recordType,
       fieldName: fieldName,
       recordName: recordName,
+      zoneID: zone?.zoneID,
       database: database
     )
   }

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebBackend.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebBackend.swift
@@ -51,6 +51,7 @@ internal protocol WebBackend: Sendable {
     recordType: String,
     recordName: String?,
     fields: [String: FieldValue],
+    zone: WebRequests.ZoneSelector?,
     database: MistKit.Database
   ) async throws -> RecordInfo
 
@@ -59,6 +60,7 @@ internal protocol WebBackend: Sendable {
     recordName: String,
     fields: [String: FieldValue],
     recordChangeTag: String?,
+    zone: WebRequests.ZoneSelector?,
     database: MistKit.Database
   ) async throws -> RecordInfo
 
@@ -66,6 +68,7 @@ internal protocol WebBackend: Sendable {
     recordType: String,
     recordName: String,
     recordChangeTag: String?,
+    zone: WebRequests.ZoneSelector?,
     database: MistKit.Database
   ) async throws
 
@@ -153,6 +156,7 @@ internal protocol WebBackend: Sendable {
     recordType: String,
     fieldName: String,
     recordName: String?,
+    zone: WebRequests.ZoneSelector?,
     database: MistKit.Database
   ) async throws -> AssetUploadReceipt
 

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebRequests+Assets.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebRequests+Assets.swift
@@ -49,6 +49,8 @@ extension WebRequests {
       case recordName
       case data
       case database
+      case zoneName
+      case zoneOwner
     }
 
     internal let recordType: String
@@ -56,6 +58,8 @@ extension WebRequests {
     internal let recordName: String?
     internal let data: Data
     internal let database: MistKit.Database
+    /// Must match the zone on the following create/update that attaches the asset.
+    internal let zone: ZoneSelector?
 
     internal init(from decoder: any Decoder) throws {
       let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -68,6 +72,7 @@ extension WebRequests {
       self.database = try WebRequests.decodeDatabase(
         from: container, forKey: .database
       )
+      self.zone = try WebRequests.decodeZoneSelector(from: container)
     }
   }
 

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebRequests.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebRequests.swift
@@ -71,6 +71,12 @@ internal enum WebRequests {
     }
   }
 
+  /// Coding keys shared by request bodies that accept a flat zone selector.
+  internal enum ZoneCodingKeys: String, CodingKey {
+    case zoneName
+    case zoneOwner
+  }
+
   /// `POST /api/records/query`
   ///
   /// Wire format stays flat (`zoneName` / `zoneOwner` at the top level) so
@@ -103,22 +109,7 @@ internal enum WebRequests {
       self.database = try WebRequests.decodeDatabase(
         from: container, forKey: .database
       )
-      let zoneName = try container.decodeIfPresent(
-        String.self, forKey: .zoneName
-      )
-      let zoneOwner = try container.decodeIfPresent(
-        String.self, forKey: .zoneOwner
-      )
-      if zoneOwner != nil, zoneName == nil {
-        throw DecodingError.dataCorruptedError(
-          forKey: .zoneOwner,
-          in: container,
-          debugDescription: "zoneOwner requires zoneName"
-        )
-      }
-      self.zone = zoneName.map {
-        ZoneSelector(zoneName: $0, zoneOwner: zoneOwner)
-      }
+      self.zone = try WebRequests.decodeZoneSelector(from: container)
     }
   }
 
@@ -133,12 +124,16 @@ internal enum WebRequests {
       case recordName
       case fields
       case database
+      case zoneName
+      case zoneOwner
     }
 
     internal let recordType: String
     internal let recordName: String?
     internal let fields: [String: FieldValue]
     internal let database: MistKit.Database
+    /// `nil` = default zone; otherwise a custom or shared zone.
+    internal let zone: ZoneSelector?
 
     internal init(from decoder: any Decoder) throws {
       let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -152,6 +147,7 @@ internal enum WebRequests {
       self.database = try WebRequests.decodeDatabase(
         from: container, forKey: .database
       )
+      self.zone = try WebRequests.decodeZoneSelector(from: container)
     }
   }
 
@@ -167,6 +163,8 @@ internal enum WebRequests {
       case fields
       case recordChangeTag
       case database
+      case zoneName
+      case zoneOwner
     }
 
     internal let recordType: String
@@ -174,6 +172,8 @@ internal enum WebRequests {
     internal let fields: [String: FieldValue]
     internal let recordChangeTag: String?
     internal let database: MistKit.Database
+    /// `nil` = default zone; otherwise a custom or shared zone.
+    internal let zone: ZoneSelector?
 
     internal init(from decoder: any Decoder) throws {
       let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -188,6 +188,7 @@ internal enum WebRequests {
       self.database = try WebRequests.decodeDatabase(
         from: container, forKey: .database
       )
+      self.zone = try WebRequests.decodeZoneSelector(from: container)
     }
   }
 
@@ -202,12 +203,16 @@ internal enum WebRequests {
       case recordName
       case recordChangeTag
       case database
+      case zoneName
+      case zoneOwner
     }
 
     internal let recordType: String
     internal let recordName: String
     internal let recordChangeTag: String?
     internal let database: MistKit.Database
+    /// `nil` = default zone; otherwise a custom or shared zone.
+    internal let zone: ZoneSelector?
 
     internal init(from decoder: any Decoder) throws {
       let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -219,6 +224,7 @@ internal enum WebRequests {
       self.database = try WebRequests.decodeDatabase(
         from: container, forKey: .database
       )
+      self.zone = try WebRequests.decodeZoneSelector(from: container)
     }
   }
 
@@ -247,5 +253,33 @@ internal enum WebRequests {
       )
     }
     return database
+  }
+
+  /// Decode flat `zoneName` / `zoneOwner` into a ``ZoneSelector``.
+  /// Rejects owner-without-name so shared-zone wire mistakes surface as 400.
+  internal static func decodeZoneSelector<Key: CodingKey>(
+    from container: KeyedDecodingContainer<Key>
+  ) throws -> ZoneSelector? {
+    guard let zoneNameKey = Key(stringValue: ZoneCodingKeys.zoneName.rawValue),
+      let zoneOwnerKey = Key(stringValue: ZoneCodingKeys.zoneOwner.rawValue)
+    else {
+      return nil
+    }
+    let zoneName = try container.decodeIfPresent(
+      String.self, forKey: zoneNameKey
+    )
+    let zoneOwner = try container.decodeIfPresent(
+      String.self, forKey: zoneOwnerKey
+    )
+    if zoneOwner != nil, zoneName == nil {
+      throw DecodingError.dataCorruptedError(
+        forKey: zoneOwnerKey,
+        in: container,
+        debugDescription: "zoneOwner requires zoneName"
+      )
+    }
+    return zoneName.map {
+      ZoneSelector(zoneName: $0, zoneOwner: zoneOwner)
+    }
   }
 }

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer+Assets.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer+Assets.swift
@@ -58,6 +58,7 @@
             recordType: body.recordType,
             fieldName: body.fieldName,
             recordName: body.recordName,
+            zone: body.zone,
             database: body.database
           )
           return try WebJSON.encoder().encode(receipt)

--- a/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer+CRUD.swift
+++ b/Examples/MistDemo/Sources/MistDemoKit/Server/WebServer+CRUD.swift
@@ -79,6 +79,7 @@
             recordType: body.recordType,
             recordName: body.recordName,
             fields: body.fields,
+            zone: body.zone,
             database: body.database
           )
           return try WebJSON.encoder().encode(
@@ -107,6 +108,7 @@
             recordName: body.recordName,
             fields: body.fields,
             recordChangeTag: body.recordChangeTag,
+            zone: body.zone,
             database: body.database
           )
           return try WebJSON.encoder().encode(
@@ -134,6 +136,7 @@
             recordType: body.recordType,
             recordName: body.recordName,
             recordChangeTag: body.recordChangeTag,
+            zone: body.zone,
             database: body.database
           )
           return try WebJSON.encoder().encode(

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend+Calls.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend+Calls.swift
@@ -48,6 +48,7 @@
       internal let recordType: String
       internal let recordName: String?
       internal let fields: [String: String]
+      internal let zone: WebRequests.ZoneSelector?
       internal let database: MistKit.Database
     }
 
@@ -57,6 +58,7 @@
       internal let recordName: String
       internal let fields: [String: String]
       internal let recordChangeTag: String?
+      internal let zone: WebRequests.ZoneSelector?
       internal let database: MistKit.Database
     }
 
@@ -65,6 +67,7 @@
       internal let recordType: String
       internal let recordName: String
       internal let recordChangeTag: String?
+      internal let zone: WebRequests.ZoneSelector?
       internal let database: MistKit.Database
     }
 
@@ -160,6 +163,7 @@
       internal let recordType: String
       internal let fieldName: String
       internal let recordName: String?
+      internal let zone: WebRequests.ZoneSelector?
       internal let database: MistKit.Database
     }
 

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend+RecordOperations.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend+RecordOperations.swift
@@ -57,12 +57,14 @@
       recordType: String,
       recordName: String?,
       fields: [String: FieldValue],
+      zone: WebRequests.ZoneSelector?,
       database: MistKit.Database
     ) async throws -> RecordInfo {
       lastCreate = CreateCall(
         recordType: recordType,
         recordName: recordName,
         fields: Self.flatten(fields),
+        zone: zone,
         database: database
       )
       try consumePendingError()
@@ -76,6 +78,7 @@
       recordName: String,
       fields: [String: FieldValue],
       recordChangeTag: String?,
+      zone: WebRequests.ZoneSelector?,
       database: MistKit.Database
     ) async throws -> RecordInfo {
       lastUpdate = UpdateCall(
@@ -83,6 +86,7 @@
         recordName: recordName,
         fields: Self.flatten(fields),
         recordChangeTag: recordChangeTag,
+        zone: zone,
         database: database
       )
       try consumePendingError()
@@ -95,12 +99,14 @@
       recordType: String,
       recordName: String,
       recordChangeTag: String?,
+      zone: WebRequests.ZoneSelector?,
       database: MistKit.Database
     ) async throws {
       lastDelete = DeleteCall(
         recordType: recordType,
         recordName: recordName,
         recordChangeTag: recordChangeTag,
+        zone: zone,
         database: database
       )
       try consumePendingError()

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend+ServiceOperations.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/MockBackend+ServiceOperations.swift
@@ -129,6 +129,7 @@
       recordType: String,
       fieldName: String,
       recordName: String?,
+      zone: WebRequests.ZoneSelector?,
       database: MistKit.Database
     ) async throws -> AssetUploadReceipt {
       lastUploadAsset = UploadAssetCall(
@@ -136,6 +137,7 @@
         recordType: recordType,
         fieldName: fieldName,
         recordName: recordName,
+        zone: zone,
         database: database
       )
       try consumePendingError()

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+Index.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+Index.swift
@@ -113,14 +113,19 @@
       let html = try await body(at: "/")
       #expect(html.contains(#"id="query-zone""#))
       #expect(html.contains(#"id="query-zone-owner""#))
+      #expect(html.contains("zone for query"))
 
       let appJs = try await body(at: "/js/app.js")
-      // Both backends read the same two inputs...
+      // Both backends read the same two inputs for query and writes...
+      #expect(appJs.contains("selectedZone()"))
       #expect(appJs.contains("queryZoneInput"))
       #expect(appJs.contains("queryZoneOwnerInput"))
       // ...the MistKit path forwards them as-is on the query body,
       // and the CloudKit JS path maps the owner to `ownerRecordName`.
       #expect(appJs.contains("ownerRecordName: zoneOwner"))
+      // Writes set per-record zoneID for CloudKit JS save/delete.
+      #expect(appJs.contains("record.zoneID = zoneID"))
+      #expect(appJs.contains("deleteSpec.zoneID = zoneID"))
       // The inputs join the controls disabled while a query is in flight.
       #expect(appJs.contains("'query-zone', 'query-zone-owner'"))
     }

--- a/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+WriteZone.swift
+++ b/Examples/MistDemo/Tests/MistDemoTests/Server/WebServerTests+WriteZone.swift
@@ -1,0 +1,219 @@
+//
+//  WebServerTests+WriteZone.swift
+//  MistDemoTests
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if canImport(Hummingbird)
+  internal import Foundation
+  internal import HTTPTypes
+  internal import Hummingbird
+  internal import HummingbirdTesting
+  internal import MistKit
+  internal import Testing
+
+  @testable import MistDemoKit
+
+  extension WebServerTests {
+    @Test("POST /api/records/create rejects zoneOwner without zoneName")
+    internal func createRejectsZoneOwnerWithoutZoneName() async throws {
+      let fixture = Self.makeFixture(authenticated: true)
+      let app = Application(router: try fixture.server.makeRouter())
+
+      try await app.test(.router) { client in
+        try await client.execute(
+          uri: "/api/records/create",
+          method: .post,
+          headers: [.contentType: "application/json"],
+          body: ByteBuffer(
+            string: #"{"recordType":"Note","fields":{"title":"x"},"zoneOwner":"_abc"}"#
+          )
+        ) { response in
+          #expect(response.status == .badRequest)
+        }
+      }
+    }
+
+    @Test("POST /api/records/create forwards zoneName and zoneOwner to the backend")
+    internal func createForwardsZoneSelection() async throws {
+      let fixture = Self.makeFixture(authenticated: true)
+      let app = Application(router: try fixture.server.makeRouter())
+      let jsonBody = """
+        {"recordType":"Note","fields":{"title":"Hi"},\
+        "zoneName":"Articles","zoneOwner":"_abc123"}
+        """
+
+      try await app.test(.router) { client in
+        try await client.execute(
+          uri: "/api/records/create",
+          method: .post,
+          headers: [.contentType: "application/json"],
+          body: ByteBuffer(string: jsonBody)
+        ) { response in
+          #expect(response.status == .ok)
+        }
+      }
+
+      let captured = await fixture.backend.lastCreate
+      #expect(captured?.zone?.zoneName == "Articles")
+      #expect(captured?.zone?.zoneOwner == "_abc123")
+    }
+
+    @Test("POST /api/records/update rejects zoneOwner without zoneName")
+    internal func updateRejectsZoneOwnerWithoutZoneName() async throws {
+      let fixture = Self.makeFixture(authenticated: true)
+      let app = Application(router: try fixture.server.makeRouter())
+
+      try await app.test(.router) { client in
+        try await client.execute(
+          uri: "/api/records/update",
+          method: .post,
+          headers: [.contentType: "application/json"],
+          body: ByteBuffer(
+            string: #"{"recordType":"Note","recordName":"n1","fields":{},"zoneOwner":"_abc"}"#
+          )
+        ) { response in
+          #expect(response.status == .badRequest)
+        }
+      }
+    }
+
+    @Test("POST /api/records/update forwards zoneName and zoneOwner to the backend")
+    internal func updateForwardsZoneSelection() async throws {
+      let fixture = Self.makeFixture(authenticated: true)
+      let app = Application(router: try fixture.server.makeRouter())
+      let jsonBody = """
+        {"recordType":"Note","recordName":"n1","fields":{"title":"Hi"},\
+        "recordChangeTag":"t1","zoneName":"Articles","zoneOwner":"_abc123"}
+        """
+
+      try await app.test(.router) { client in
+        try await client.execute(
+          uri: "/api/records/update",
+          method: .post,
+          headers: [.contentType: "application/json"],
+          body: ByteBuffer(string: jsonBody)
+        ) { response in
+          #expect(response.status == .ok)
+        }
+      }
+
+      let captured = await fixture.backend.lastUpdate
+      #expect(captured?.zone?.zoneName == "Articles")
+      #expect(captured?.zone?.zoneOwner == "_abc123")
+    }
+
+    @Test("POST /api/records/delete rejects zoneOwner without zoneName")
+    internal func deleteRejectsZoneOwnerWithoutZoneName() async throws {
+      let fixture = Self.makeFixture(authenticated: true)
+      let app = Application(router: try fixture.server.makeRouter())
+
+      try await app.test(.router) { client in
+        try await client.execute(
+          uri: "/api/records/delete",
+          method: .post,
+          headers: [.contentType: "application/json"],
+          body: ByteBuffer(
+            string: #"{"recordType":"Note","recordName":"n1","zoneOwner":"_abc"}"#
+          )
+        ) { response in
+          #expect(response.status == .badRequest)
+        }
+      }
+    }
+
+    @Test("POST /api/records/delete forwards zoneName and zoneOwner to the backend")
+    internal func deleteForwardsZoneSelection() async throws {
+      let fixture = Self.makeFixture(authenticated: true)
+      let app = Application(router: try fixture.server.makeRouter())
+      let jsonBody = """
+        {"recordType":"Note","recordName":"n1","recordChangeTag":"t1",\
+        "zoneName":"Articles","zoneOwner":"_abc123"}
+        """
+
+      try await app.test(.router) { client in
+        try await client.execute(
+          uri: "/api/records/delete",
+          method: .post,
+          headers: [.contentType: "application/json"],
+          body: ByteBuffer(string: jsonBody)
+        ) { response in
+          #expect(response.status == .ok)
+        }
+      }
+
+      let captured = await fixture.backend.lastDelete
+      #expect(captured?.zone?.zoneName == "Articles")
+      #expect(captured?.zone?.zoneOwner == "_abc123")
+    }
+
+    @Test("POST /api/assets/upload rejects zoneOwner without zoneName")
+    internal func uploadRejectsZoneOwnerWithoutZoneName() async throws {
+      let fixture = Self.makeFixture(authenticated: true)
+      let app = Application(router: try fixture.server.makeRouter())
+      // Minimal base64 payload ("AQ==" = one byte).
+      let jsonBody = """
+        {"recordType":"Note","fieldName":"image","data":"AQ==","zoneOwner":"_abc"}
+        """
+
+      try await app.test(.router) { client in
+        try await client.execute(
+          uri: "/api/assets/upload",
+          method: .post,
+          headers: [.contentType: "application/json"],
+          body: ByteBuffer(string: jsonBody)
+        ) { response in
+          #expect(response.status == .badRequest)
+        }
+      }
+    }
+
+    @Test("POST /api/assets/upload forwards zoneName and zoneOwner to the backend")
+    internal func uploadForwardsZoneSelection() async throws {
+      let fixture = Self.makeFixture(authenticated: true)
+      let app = Application(router: try fixture.server.makeRouter())
+      let jsonBody = """
+        {"recordType":"Note","fieldName":"image","data":"AQ==",\
+        "zoneName":"Articles","zoneOwner":"_abc123"}
+        """
+
+      try await app.test(.router) { client in
+        try await client.execute(
+          uri: "/api/assets/upload",
+          method: .post,
+          headers: [.contentType: "application/json"],
+          body: ByteBuffer(string: jsonBody)
+        ) { response in
+          #expect(response.status == .ok)
+        }
+      }
+
+      let captured = await fixture.backend.lastUploadAsset
+      #expect(captured?.zone?.zoneName == "Articles")
+      #expect(captured?.zone?.zoneOwner == "_abc123")
+    }
+  }
+#endif

--- a/Sources/MistKit/CloudKitService/CloudKitService+AssetOperations.swift
+++ b/Sources/MistKit/CloudKitService/CloudKitService+AssetOperations.swift
@@ -54,6 +54,8 @@ extension CloudKitService {
   ///   - recordType: The type of record that will use this asset
   ///   - fieldName: The name of the asset field
   ///   - recordName: Optional unique record name
+  ///   - zoneID: Optional zone ID (defaults to default zone). Must match the
+  ///     zone used on the subsequent create/update that attaches the asset.
   ///   - uploader: Optional custom upload handler
   ///   - database: The CloudKit database scope to upload to (`.public`, `.private`, `.shared`)
   /// - Returns: AssetUploadReceipt containing the upload result
@@ -76,6 +78,7 @@ extension CloudKitService {
     recordType: String,
     fieldName: String,
     recordName: String? = nil,
+    zoneID: ZoneID? = nil,
     using uploader: AssetUploader? = nil,
     database: Database
   ) async throws(CloudKitError) -> AssetUploadReceipt {
@@ -84,6 +87,7 @@ extension CloudKitService {
         recordType: recordType,
         fieldName: fieldName,
         recordName: recordName,
+        zoneID: zoneID,
         database: database
       )
 

--- a/Sources/MistKit/Models/Zones/ZoneType.swift
+++ b/Sources/MistKit/Models/Zones/ZoneType.swift
@@ -46,7 +46,9 @@ extension ZoneType {
   /// `nil` stays `nil`. Any other unrecognized string throws
   /// ``ConversionError/unrecognizedZoneType(_:)``.
   internal static func fromWire(_ wire: String?) throws(ConversionError) -> ZoneType? {
-    guard let wire else { return nil }
+    guard let wire else {
+      return nil
+    }
     guard let value = ZoneType(rawValue: wire) else {
       throw ConversionError.unrecognizedZoneType(wire)
     }

--- a/Tests/MistKitTests/CloudKitService/RecordWrite/CloudKitServiceTests.RecordWriteConvenience+ZoneID.swift
+++ b/Tests/MistKitTests/CloudKitService/RecordWrite/CloudKitServiceTests.RecordWriteConvenience+ZoneID.swift
@@ -1,5 +1,5 @@
 //
-//  CloudKitServiceTests.RecordWriteConvenience.swift
+//  CloudKitServiceTests.RecordWriteConvenience+ZoneID.swift
 //  MistKit
 //
 //  Created by Leo Dion.
@@ -32,101 +32,75 @@ internal import Testing
 
 @testable import MistKit
 
-extension CloudKitServiceTests {
-  /// Covers the single-record write conveniences (`createRecord`,
-  /// `updateRecord`, `deleteRecord`) which delegate to `modifyRecords`.
-  @Suite("Record Write Convenience")
-  internal struct RecordWriteConvenience {
-    /// Reuse the shared mock-transport builders and JSON record fixtures.
+extension CloudKitServiceTests.RecordWriteConvenience {
+  /// Pins zoneID forwarding on the single-record write conveniences (#454).
+  @Suite("Record Write Convenience ZoneID")
+  internal struct ZoneIDForwarding {
     private typealias Helper = CloudKitServiceTests.Rereference
 
-    @Test("createRecord returns the saved record")
-    internal func createReturnsRecord() async throws {
+    @Test("createRecord forwards zoneID into the modifyRecords request body")
+    internal func createForwardsZoneID() async throws {
       guard #available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *) else {
         Issue.record("CloudKitService is not available on this operating system.")
         return
       }
-      let service = try Helper.makeService(responsesByOperation: [
+      let (service, provider) = try Helper.makeServiceWithProvider(responsesByOperation: [
         "modifyRecords": try Helper.recordsResponse([
           Helper.noteRecord(recordName: "note-1", changeTag: "tag-1")
         ])
       ])
 
-      let record = try await service.createRecord(
+      _ = try await service.createRecord(
         recordType: "Note",
         recordName: "note-1",
         fields: ["title": .string("Hello")],
+        zoneID: ZoneID(zoneName: "Articles", ownerName: "_abc123"),
         database: Helper.publicDatabase
       )
 
-      #expect(record.recordName == "note-1")
+      let bodies = await provider.bodies(for: "modifyRecords").compactMap { $0 }
+      let data = try #require(bodies.first)
+      let body = try #require(
+        try JSONSerialization.jsonObject(with: data) as? [String: Any]
+      )
+      let zoneID = try #require(body["zoneID"] as? [String: Any])
+      #expect(zoneID["zoneName"] as? String == "Articles")
+      #expect(zoneID["ownerRecordName"] as? String == "_abc123")
     }
 
-    @Test("createRecord throws invalidResponse when the server returns no records")
-    internal func createThrowsOnEmptyResponse() async throws {
+    @Test("updateRecord forwards zoneID into the modifyRecords request body")
+    internal func updateForwardsZoneID() async throws {
       guard #available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *) else {
         Issue.record("CloudKitService is not available on this operating system.")
         return
       }
-      let service = try Helper.makeService(responsesByOperation: [
-        "modifyRecords": try Helper.recordsResponse([])
-      ])
-
-      await #expect(throws: CloudKitError.self) {
-        _ = try await service.createRecord(
-          recordType: "Note",
-          fields: ["title": .string("Hello")],
-          database: Helper.publicDatabase
-        )
-      }
-    }
-
-    @Test("updateRecord returns the saved record")
-    internal func updateReturnsRecord() async throws {
-      guard #available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *) else {
-        Issue.record("CloudKitService is not available on this operating system.")
-        return
-      }
-      let service = try Helper.makeService(responsesByOperation: [
+      let (service, provider) = try Helper.makeServiceWithProvider(responsesByOperation: [
         "modifyRecords": try Helper.recordsResponse([
           Helper.noteRecord(recordName: "note-1", changeTag: "tag-2")
         ])
       ])
 
-      let record = try await service.updateRecord(
+      _ = try await service.updateRecord(
         recordType: "Note",
         recordName: "note-1",
         fields: ["title": .string("Renamed")],
         recordChangeTag: "tag-1",
+        zoneID: ZoneID(zoneName: "Articles", ownerName: "_abc123"),
         database: Helper.publicDatabase
       )
 
-      #expect(record.recordName == "note-1")
-      #expect(record.recordChangeTag == "tag-2")
+      let bodies = await provider.bodies(for: "modifyRecords").compactMap { $0 }
+      let data = try #require(bodies.first)
+      let body = try #require(
+        try JSONSerialization.jsonObject(with: data) as? [String: Any]
+      )
+      let zoneID = try #require(body["zoneID"] as? [String: Any])
+      #expect(zoneID["zoneName"] as? String == "Articles")
+      #expect(zoneID["ownerRecordName"] as? String == "_abc123")
     }
 
-    @Test("updateRecord throws invalidResponse when the server returns no records")
-    internal func updateThrowsOnEmptyResponse() async throws {
-      guard #available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *) else {
-        Issue.record("CloudKitService is not available on this operating system.")
-        return
-      }
-      let service = try Helper.makeService(responsesByOperation: [
-        "modifyRecords": try Helper.recordsResponse([])
-      ])
-
-      await #expect(throws: CloudKitError.self) {
-        _ = try await service.updateRecord(
-          recordType: "Note",
-          recordName: "note-1",
-          fields: ["title": .string("Renamed")],
-          database: Helper.publicDatabase
-        )
-      }
-    }
-
-    @Test("deleteRecord completes when the server acknowledges the delete")
-    internal func deleteCompletes() async throws {
+    @Test("deleteRecord forwards zoneID into the modifyRecords request body")
+    internal func deleteForwardsZoneID() async throws {
       guard #available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *) else {
         Issue.record("CloudKitService is not available on this operating system.")
         return
@@ -141,10 +115,18 @@ extension CloudKitServiceTests {
         recordType: "Note",
         recordName: "note-1",
         recordChangeTag: "tag-1",
+        zoneID: ZoneID(zoneName: "Articles", ownerName: "_abc123"),
         database: Helper.publicDatabase
       )
 
-      #expect(await provider.callCount(for: "modifyRecords") == 1)
+      let bodies = await provider.bodies(for: "modifyRecords").compactMap { $0 }
+      let data = try #require(bodies.first)
+      let body = try #require(
+        try JSONSerialization.jsonObject(with: data) as? [String: Any]
+      )
+      let zoneID = try #require(body["zoneID"] as? [String: Any])
+      #expect(zoneID["zoneName"] as? String == "Articles")
+      #expect(zoneID["ownerRecordName"] as? String == "_abc123")
     }
   }
 }

--- a/Tests/MistKitTests/CloudKitService/Upload/CloudKitServiceTests.Upload+SuccessCases.swift
+++ b/Tests/MistKitTests/CloudKitService/Upload/CloudKitServiceTests.Upload+SuccessCases.swift
@@ -161,5 +161,40 @@ extension CloudKitServiceTests.Upload {
       let count = await tracker.callCount
       #expect(count == 1, "Custom uploader should have been called exactly once")
     }
+
+    @Test("uploadAssets() forwards zoneID into the uploadAssets request body")
+    internal func uploadAssetsForwardsZoneID() async throws {
+      guard #available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *) else {
+        Issue.record("CloudKitService is not available on this operating system.")
+        return
+      }
+      let responseProvider = ResponseProvider(
+        defaultResponse: .successfulUploadResponse(tokenCount: 1)
+      )
+      let transport = MockTransport(responseProvider: responseProvider)
+      let service = try CloudKitService(
+        containerIdentifier: TestConstants.serviceContainerIdentifier,
+        credentials: Credentials(apiAuth: APICredentials(apiToken: TestConstants.apiToken)),
+        transport: transport
+      )
+
+      _ = try await service.uploadAssets(
+        data: Data(count: 256),
+        recordType: "Note",
+        fieldName: "image",
+        zoneID: ZoneID(zoneName: "Articles", ownerName: "_abc123"),
+        using: CloudKitServiceTests.Upload.makeMockAssetUploader(),
+        database: .public(.prefers(.serverToServer))
+      )
+
+      let bodies = await responseProvider.bodies(for: "uploadAssets").compactMap { $0 }
+      let data = try #require(bodies.first)
+      let body = try #require(
+        try JSONSerialization.jsonObject(with: data) as? [String: Any]
+      )
+      let zoneID = try #require(body["zoneID"] as? [String: Any])
+      #expect(zoneID["zoneName"] as? String == "Articles")
+      #expect(zoneID["ownerRecordName"] as? String == "_abc123")
+    }
   }
 }

--- a/Tests/MistKitTests/Models/Zones/ZoneMetadataTests+ZoneInfoConversion.swift
+++ b/Tests/MistKitTests/Models/Zones/ZoneMetadataTests+ZoneInfoConversion.swift
@@ -204,36 +204,5 @@ extension ZoneMetadataTests {
       #expect(info.atomic == nil)
       #expect(info.zoneName == "Articles")
     }
-
-    @Test("atomic decodes false without collapsing into nil")
-    internal func atomicFalseIsPreserved() throws {
-      let zone = try Self.decodeZone(
-        """
-        { "zoneID": { "zoneName": "Articles" }, "atomic": false }
-        """
-      )
-
-      let info = try ZoneInfo(from: zone)
-
-      #expect(try #require(info.atomic) == false)
-    }
-
-    @Test("ZoneInfo still throws when the zone payload has no zoneName")
-    internal func missingZoneNameThrows() throws {
-      let zone = try Self.decodeZone(
-        """
-        { "zoneID": { "ownerRecordName": "_defaultOwner" }, "atomic": true }
-        """
-      )
-
-      ConversionFailureReporter.$assertionHandler.withValue(
-        { _, _, _ in },
-        operation: {
-          #expect(throws: ConversionError.self) {
-            _ = try ZoneInfo(from: zone)
-          }
-        }
-      )
-    }
   }
 }

--- a/Tests/MistKitTests/Models/Zones/ZoneMetadataTests+ZoneInfoConversionEdgeCases.swift
+++ b/Tests/MistKitTests/Models/Zones/ZoneMetadataTests+ZoneInfoConversionEdgeCases.swift
@@ -1,0 +1,75 @@
+//
+//  ZoneMetadataTests+ZoneInfoConversionEdgeCases.swift
+//  MistKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+internal import Foundation
+internal import Testing
+
+@testable import MistKit
+@testable import MistKitOpenAPI
+
+extension ZoneMetadataTests {
+  /// Edge-case decoding for ``ZoneInfo`` conversion.
+  @Suite("ZoneInfo Conversion Edge Cases")
+  internal struct ZoneInfoConversionEdgeCases {
+    private static func decodeZone(_ json: String) throws -> Components.Schemas.Zone {
+      try JSONDecoder().decode(Components.Schemas.Zone.self, from: Data(json.utf8))
+    }
+
+    @Test("atomic decodes false without collapsing into nil")
+    internal func atomicFalseIsPreserved() throws {
+      let zone = try Self.decodeZone(
+        """
+        { "zoneID": { "zoneName": "Articles" }, "atomic": false }
+        """
+      )
+
+      let info = try ZoneInfo(from: zone)
+
+      #expect(try #require(info.atomic) == false)
+    }
+
+    @Test("ZoneInfo still throws when the zone payload has no zoneName")
+    internal func missingZoneNameThrows() throws {
+      let zone = try Self.decodeZone(
+        """
+        { "zoneID": { "ownerRecordName": "_defaultOwner" }, "atomic": true }
+        """
+      )
+
+      ConversionFailureReporter.$assertionHandler.withValue(
+        { _, _, _ in },
+        operation: {
+          #expect(throws: ConversionError.self) {
+            _ = try ZoneInfo(from: zone)
+          }
+        }
+      )
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Thread `ZoneSelector` through MistDemo web create/update/delete and asset upload, reusing the query toolbar zone for browser writes and CK JS `record.zoneID`.
- Add `zoneID` forwarding on library `uploadAssets` / write conveniences, with unit and WebServer coverage.
- Add `SharedZoneRoundtripPhase` to `test-private`: sharee accepts a share, updates the shared root with zone-scoped writes/assets, and validates zone changes (avoids shared-DB lookup, which cannot address zones without `ownerRecordName`).

## Test plan
- [x] `swift test --filter WebServerTests`
- [x] `swift test --filter RecordWriteConvenience`
- [x] `./Scripts/lint.sh` (SwiftLint clean; periphery requires local install)
- [x] `mistdemo test-private --asset-size 8 --record-count 3` (all 28 phases; requires distinct sharer/sharee tokens)


Made with [Cursor](https://cursor.com)