### PR TITLE
Record why FieldValue.bytes is a base64 String (#467)

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -51,3 +51,4 @@ Project-scoped agent memory for MistKit. This directory **replaces** any native 
 - [Dogfood pins are branch pins, not tags](project_dogfood_pins_are_branch_pins_not_tags.md) — tagging a monorepo package does NOT mean Examples switch to `from:`; they keep `path:` and CI pins both deps to branch HEADs
 - [MistKitConfiguration integration branch](project_mkc_integration_branch.md) — subrepo tracks `mistkit-beta.5`; it is beta.5-line scaffolding and must be DELETED in the `→ main` release PR
 - [Draft-gated CI needs ready_for_review](reference_draft_gated_ci_needs_ready_for_review.md) — an `if: draft == false` job stays `skipped` forever unless `types:` lists `ready_for_review`; re-running replays the stale payload
+- [FieldValue.bytes is a base64 String](project_fieldvalue_bytes_is_base64_string.md) — wire-format mirror, no recorded rationale; #467 specs the move to Data; base64 has no false-positive signal so never infer it

--- a/.claude/memory/project_fieldvalue_bytes_is_base64_string.md
+++ b/.claude/memory/project_fieldvalue_bytes_is_base64_string.md
@@ -1,0 +1,65 @@
+---
+name: project_fieldvalue_bytes_is_base64_string
+description: FieldValue.bytes holds a base64 String (not Data) to mirror the wire format; changing it to Data is specced in #467
+metadata:
+  type: project
+---
+
+`FieldValue.bytes` is `case bytes(String)` — a **base64-encoded string**, not `Data`
+(`Sources/MistKit/Models/FieldValues/FieldValue.swift`).
+
+**There is no recorded rationale for this.** The case arrives fully formed in `d11c6c5`
+("v1.0.0 beta.1", #298), which squashes the entire pre-beta history, and nothing in the
+issue tracker, `ReleaseNotes.md`, or this memory store deliberates it. Don't go looking
+again — this file *is* the answer to "why String?".
+
+The de facto reasons visible in the code:
+
+1. It mirrors the wire 1:1 — `openapi.yaml` defines `BytesValue` as `type: string`
+   ("Base64-encoded string"), and the generated `BytesValue` is `typealias … = Swift.String`.
+2. It keeps the conversion layer total: `.string` and `.bytes` share a `String` payload, so
+   several switch arms collapse into one (`FieldValue+Codable.swift`,
+   `ScalarPayload.text`/`.inferred` in `FieldValue+Components+Scalar.swift`). With `Data`,
+   every decode site gains a fallible `Data(base64Encoded:)` step.
+
+Cost: `bytesValue` returns `String?` and there is **no** `Data` bridge anywhere in
+`Sources/MistKit/` — callers hand-roll the decode.
+
+**Changing it to `Data` is specced in issue #467** (decisions settled there: reuse
+`ConversionError.typeValueMismatch` rather than a new case; untagged base64 keeps
+resolving to `.string`; `dataValue` stays a strict `.bytes`-only match).
+
+## Base64 has no false-positive signal
+
+Load-bearing for #467, and worth knowing generally: base64 carries no header, checksum,
+or self-identifying structure. Validity is only a character-set-and-length check, so **any**
+`[A-Za-z0-9+/]` string whose length is a multiple of 4 decodes successfully:
+
+| Input | `Data(base64Encoded:)` |
+|---|---|
+| `"test"`, `"user"`, `"name"`, `"true"`, `"data"`, `"Chen"` | 3 bytes of garbage |
+| `"hello"` (len 5), `"Mei"` (len 3) | `nil` |
+
+`"Chen"` is from Apple's own example record (`.claude/docs/webservices.md`,
+`"lastName" : {"value" : "Chen"}`) — a four-letter surname is indistinguishable from base64.
+
+**Therefore: never infer `.bytes` by attempting a base64 decode**, neither in the scalar
+decode chain nor as a `dataValue` fallback for `.string`. A non-`nil` result proves only
+that a string *could* be base64, never that it *is*; inference would hand back
+plausible-looking garbage instead of a visible failure.
+
+## Untagged BYTES responses — frequency unmeasured
+
+When a response omits `type`, first-match-wins inference claims a base64 string as
+`.string` (documented in CLAUDE.md as lossy). How often CloudKit actually omits `type` on
+reads is **not established**: our `openapi.yaml` calls it optional, but that wording is
+*ours*, hand-written from Apple's docs — and Apple's authoritative `Record Field Dictionary`
+is referenced at `.claude/docs/webservices.md` without its definition being included in the
+offline copy. Note "optional in the schema" ≠ "sometimes absent in practice". No captured
+live responses exist in the repo; every `"type"` in the tests is a hand-written fixture.
+
+Settle it the way #430 settled `metaSyncToken` — against a live container
+(`swift run mistdemo create` with a bytes field, then a `.debug` query) — before treating
+untagged binary as either real or theoretical.
+
+Related: [[project_release_process]]


### PR DESCRIPTION
Documentation only — one new `.claude/memory/` entry plus its index line. No source, spec, or test changes.

## Why

The question "why is `FieldValue.bytes` a `String` instead of `Data`?" turned out to have **no recorded answer**. The case arrives fully formed in `d11c6c5` ("v1.0.0 beta.1", #298), which squashes the entire pre-beta history, and nothing in the issue tracker, `ReleaseNotes.md`, or `.claude/memory/` deliberates it. Answering it took a full pass over git history, the spec, the docs and the conversion code — this file is so that pass isn't repeated.

## What it records

- **The de facto rationale**: it mirrors the wire 1:1 (`openapi.yaml` defines `BytesValue` as `type: string`; the generated `BytesValue` is `typealias … = Swift.String`), and the shared `String` payload with `.string` keeps the conversion layer total.
- **The cost**: `bytesValue` returns `String?` and there is no `Data` bridge anywhere in `Sources/MistKit/`.
- **A pointer to #467**, which specs the move to `Data` and holds the settled decisions.
- **That base64 has no false-positive signal** — load-bearing for #467 and generally useful. Validity is only a character-set-and-length check, so any `[A-Za-z0-9+/]` string of length % 4 == 0 decodes successfully, including `"Chen"` from Apple's own example record (`.claude/docs/webservices.md:1539`). Hence: never infer `.bytes` by attempting a decode — it yields plausible garbage rather than a visible failure.
- **That untagged-`BYTES` frequency is unmeasured**, with the caveat that our `openapi.yaml`'s "optional" wording is *ours*, hand-written from Apple's docs, and that Apple's authoritative `Record Field Dictionary` is referenced in the offline copy without being included. Flags the #430-style live-container check as the way to settle it.

## Verified before committing

- `typealias BytesValue = Swift.String` — `Sources/MistKitOpenAPI/Types.swift:1566`
- `d11c6c5` is the beta.1 squash
- `"lastName" : {"value" : "Chen"}` — `.claude/docs/webservices.md:1539`
- The base64 decode table was produced by running it, not reasoned about

Base: `v1.0.0-beta.5`. Related: #467.
