### PR TITLE
Add VALIDATE to Reference.Action

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,8 @@
 ## 1.0.0-beta.4
 
+### Field Values
+* Add VALIDATE to `Reference.Action` for CloudKit Web Services reference dictionaries (#464)
+
 ### Change Tracking
 * Add changes/database and changes/zone endpoints; deprecate zones/changes (#401, #47, #46) by @leogdion in https://github.com/brightdigit/MistKit/pull/429
 * modifyZones per-zone failures (#431) + zones/changes metaSyncToken (#430) by @leogdion in https://github.com/brightdigit/MistKit/pull/443

--- a/Sources/MistKit/Models/FieldValues/FieldValue+Components.swift
+++ b/Sources/MistKit/Models/FieldValues/FieldValue+Components.swift
@@ -102,6 +102,8 @@ extension FieldValue {
       action = .deleteSelf
     case .NONE:
       action = Reference.Action.none
+    case .VALIDATE:
+      action = .validate
     case nil:
       action = nil
     }

--- a/Sources/MistKit/Models/FieldValues/Reference.swift
+++ b/Sources/MistKit/Models/FieldValues/Reference.swift
@@ -29,15 +29,19 @@
 
 /// Reference dictionary as defined in CloudKit Web Services
 public struct Reference: Codable, Equatable, Sendable {
-  /// Reference action types supported by CloudKit
+  /// Reference action types supported by CloudKit Web Services.
+  /// Native `CKRecord.ReferenceAction` only has `none` and `deleteSelf`;
+  /// `validate` is a Web Services case that verifies the target record exists
+  /// before creating the reference (create fails if missing).
   public enum Action: String, Codable, Sendable {
     case deleteSelf = "DELETE_SELF"
     case none = "NONE"
+    case validate = "VALIDATE"
   }
 
   /// The record name being referenced
   public let recordName: String
-  /// The action to take (DELETE_SELF, NONE, or nil)
+  /// The action to take (`NONE`, `DELETE_SELF`, `VALIDATE`, or nil)
   public let action: Action?
 
   /// Initialize a reference value

--- a/Sources/MistKit/OpenAPI/Components/Components.Schemas.FieldValueRequest.swift
+++ b/Sources/MistKit/OpenAPI/Components/Components.Schemas.FieldValueRequest.swift
@@ -101,6 +101,8 @@ extension Components.Schemas.FieldValueRequest {
       action = .DELETE_SELF
     case .some(.none):
       action = .NONE
+    case .some(.validate):
+      action = .VALIDATE
     case nil:
       action = nil
     }

--- a/Sources/MistKit/OpenAPI/Components/Components.Schemas.ListValuePayload.swift
+++ b/Sources/MistKit/OpenAPI/Components/Components.Schemas.ListValuePayload.swift
@@ -99,6 +99,8 @@ extension Components.Schemas.ListValuePayload {
       action = .DELETE_SELF
     case .some(.none):
       action = .NONE
+    case .some(.validate):
+      action = .VALIDATE
     case nil:
       action = nil
     }

--- a/Sources/MistKitOpenAPI/Types.swift
+++ b/Sources/MistKitOpenAPI/Types.swift
@@ -1653,14 +1653,17 @@ public enum Components {
             ///
             /// - Remark: Generated from `#/components/schemas/ReferenceValue/recordName`.
             public var recordName: Swift.String
-            /// Action to perform on the referenced record
+            /// Action to perform on the referenced record. NONE performs no action; DELETE_SELF deletes this record when the referenced record is deleted; VALIDATE verifies the target record exists before creating the reference (create fails if missing). VALIDATE is a CloudKit Web Services value; native CKRecord.ReferenceAction has only none and deleteSelf.
+            ///
             ///
             /// - Remark: Generated from `#/components/schemas/ReferenceValue/action`.
             @frozen public enum actionPayload: String, Codable, Hashable, Sendable, CaseIterable {
                 case NONE = "NONE"
                 case DELETE_SELF = "DELETE_SELF"
+                case VALIDATE = "VALIDATE"
             }
-            /// Action to perform on the referenced record
+            /// Action to perform on the referenced record. NONE performs no action; DELETE_SELF deletes this record when the referenced record is deleted; VALIDATE verifies the target record exists before creating the reference (create fails if missing). VALIDATE is a CloudKit Web Services value; native CKRecord.ReferenceAction has only none and deleteSelf.
+            ///
             ///
             /// - Remark: Generated from `#/components/schemas/ReferenceValue/action`.
             public var action: Components.Schemas.ReferenceValue.actionPayload?
@@ -1668,7 +1671,7 @@ public enum Components {
             ///
             /// - Parameters:
             ///   - recordName: The record name being referenced
-            ///   - action: Action to perform on the referenced record
+            ///   - action: Action to perform on the referenced record. NONE performs no action; DELETE_SELF deletes this record when the referenced record is deleted; VALIDATE verifies the target record exists before creating the reference (create fails if missing). VALIDATE is a CloudKit Web Services value; native CKRecord.ReferenceAction has only none and deleteSelf.
             public init(
                 recordName: Swift.String,
                 action: Components.Schemas.ReferenceValue.actionPayload? = nil

--- a/Tests/MistKitTests/Models/FieldValues/FieldValueConversionTests+ComplexTypes.swift
+++ b/Tests/MistKitTests/Models/FieldValues/FieldValueConversionTests+ComplexTypes.swift
@@ -120,6 +120,24 @@ extension FieldValueConversionTests {
       }
     }
 
+    @Test("Convert reference FieldValue with VALIDATE action to Components.FieldValue")
+    internal func convertReferenceWithValidateAction() {
+      guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+        Issue.record("FieldValue is not available on this operating system.")
+        return
+      }
+      let reference = Reference(recordName: "test-record-validate", action: .validate)
+      let fieldValue = FieldValue.reference(reference)
+      let components = Components.Schemas.FieldValueRequest(from: fieldValue)
+
+      if case .ReferenceValue(let value) = components.value {
+        #expect(value.recordName == "test-record-validate")
+        #expect(value.action == .VALIDATE)
+      } else {
+        Issue.record("Expected referenceValue")
+      }
+    }
+
     @Test("Convert asset FieldValue with all fields to Components.FieldValue")
     internal func convertAssetWithAllFields() {
       guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1644,8 +1644,14 @@ components:
           description: The record name being referenced
         action:
           type: string
-          enum: [NONE, DELETE_SELF]
-          description: Action to perform on the referenced record
+          enum: [NONE, DELETE_SELF, VALIDATE]
+          description: >
+            Action to perform on the referenced record. NONE performs no action;
+            DELETE_SELF deletes this record when the referenced record is deleted;
+            VALIDATE verifies the target record exists before creating the
+            reference (create fails if missing). VALIDATE is a CloudKit Web
+            Services value; native CKRecord.ReferenceAction has only none and
+            deleteSelf.
 
     AssetValue:
       type: object


### PR DESCRIPTION
## Summary
- Add `VALIDATE` to CloudKit Web Services `Reference.Action` (openapi + domain enum + conversion switches).
- Regenerated `MistKitOpenAPI` from `openapi.yaml`; conversion tests cover the new case.

Closes #464

## Test plan
- [ ] `swift test --filter FieldValueConversionTests`
- [ ] Confirm `Reference.Action.validate` round-trips to wire `"VALIDATE"`


Made with [Cursor](https://cursor.com)